### PR TITLE
Refactor child-component.js and fix bug

### DIFF
--- a/src/util/child-component.js
+++ b/src/util/child-component.js
@@ -90,8 +90,8 @@ export function createChildComponent (definition={}) {
 			getAllAsProps(parentProps) {
 				let component = this;
 
-				var propsFromProps = component.getOwnProps(parentProps);
-				var propsFromChildren = component.getOwnChildrenAsProps(parentProps.children);
+				const propsFromProps = component.getOwnProps(parentProps);
+				const propsFromChildren = component.getOwnChildrenAsProps(parentProps.children);
 
 				return propsFromProps.concat(propsFromChildren);
 			}

--- a/src/util/child-component.js
+++ b/src/util/child-component.js
@@ -18,68 +18,82 @@ export function createChildComponent (definition={}) {
 			/**
 			 * getOwnChildren
 			 *
-			 * Returns all collective children of elements with this component type
+			 * Returns all elements with this component type
 			 *
-			 * @param {Array} elements - usually `this.props.children` but can be any list of elements which
-			 *	                          might have this type
-			 * @return {Array} All the collective children of elements with this component type
+			 * @param {array} elements - usually `this.props.children` but can be any list of elements which might have this type
+			 * @return {array} elements with this component type
 			 */
 			getOwnChildren(elements) {
 				let component = this;
-				let children = [];
+				let ownElements = [];
 				React.Children.forEach(elements, (element) => {
 					if (element && element.type === component) {
-						children = children.concat(React.Children.map(element.props.children, x => x));
+						ownElements.push(element);
 					}
 				});
-				return children;
+				return ownElements;
 			},
 
 			/**
-			 * getAll
-			 *
-			 * Returns all elements with this component type
-			 *
-			 * @param {Array} elements - usually `this.props.children` but can be any list of elements which
-			 *	                          might have this type
-			 * @return {Array} elements with this component type
-			 */
-			getAll(elements) {
-				let component = this;
-				let elementsOfThisType = [];
-				React.Children.forEach(elements, (element) => {
-					if (element && element.type === component) {
-						elementsOfThisType = elementsOfThisType.concat(element);
-					}
-				});
-				return elementsOfThisType;
-			},
-
-			/**
-			 * getAllProps
+			 * getOwnChildrenAsProps
 			 *
 			 * Returns the `props` object of each element with this component type
 			 *
-			 * @param {Array} elements - usually `this.props.children` but can be any list of elements which
-			 *	                          might have this type
-			 * @return {Array} `props` objects of elements with this component type
+			 * @param {array} elements - usually `this.props.children` but can be any list of elements which might have this type
+			 * @return {array} `props` objects of elements with this component type
 			 */
-			getAllProps(elements) {
+			getOwnChildrenAsProps(elements) {
 				let component = this;
-				return _.map(component.getAll(elements), 'props');
+				return _.map(component.getOwnChildren(elements), 'props');
 			},
 
-			getAllAsProps(props, elements) {
-				let component = this;
-				return _.map(_.flatten([_.get(props, definition.propName, [])]), (childProp) => {
+			/**
+			 * getOwnProps
+			 *
+			 * Given a set of parent props this will return only the props for this
+			 * component type
+			 *
+			 * @param {object} parentProps - usually `this.props` that may contain a prop for the current component type
+			 * @return {array} - an array of normalized props
+			 */
+			getOwnProps(parentProps) {
+				// Extract out the defined `childProps` from the parent class
+				const currentProps = _.chain(parentProps)
+					.get(definition.propName) // grab the prop we care about, e.g. "Child"
+					.thru(x => [x]) // wrap in an array
+					.flatten()
+					.filter(x => x) // remove falsey values
+					.value();
+
+				return _.map(currentProps, (childProp) => {
 					if (_.isPlainObject(childProp)) {
-						return _.assign({}, childProp, {children: childProp.children || childProp.text});
+						return childProp;
 					} else {
 						return {
 							children: childProp
 						};
 					}
-				}).concat(component.getAllProps(elements));
+				});
+			},
+
+			/**
+			 * getAllAsProps
+			 *
+			 * Given a parent props object, this will return a mashup of all the
+			 * children and/or props for the current component type. This is
+			 * particularly useful for providing a flexible component API. It allows
+			 * consumers to either pass stuff through props or children.
+			 *
+			 * @param {object} parentProps - usually `this.props` that may contain a prop for the current component type
+			 * @return {array} - an array of `props`
+			 */
+			getAllAsProps(parentProps) {
+				let component = this;
+
+				var propsFromProps = component.getOwnProps(parentProps);
+				var propsFromChildren = component.getOwnChildrenAsProps(parentProps.children);
+
+				return propsFromProps.concat(propsFromChildren);
 			}
 		}
 	});

--- a/src/util/child-component.js
+++ b/src/util/child-component.js
@@ -16,14 +16,14 @@ export function createChildComponent (definition={}) {
 		statics: {
 
 			/**
-			 * getOwnChildren
+			 * findInChildren
 			 *
 			 * Returns all elements with this component type
 			 *
 			 * @param {array} elements - usually `this.props.children` but can be any list of elements which might have this type
 			 * @return {array} elements with this component type
 			 */
-			getOwnChildren(elements) {
+			findInChildren(elements) {
 				let component = this;
 				let ownElements = [];
 				React.Children.forEach(elements, (element) => {
@@ -35,20 +35,20 @@ export function createChildComponent (definition={}) {
 			},
 
 			/**
-			 * getOwnChildrenAsProps
+			 * findInChildrenAsProps
 			 *
 			 * Returns the `props` object of each element with this component type
 			 *
 			 * @param {array} elements - usually `this.props.children` but can be any list of elements which might have this type
 			 * @return {array} `props` objects of elements with this component type
 			 */
-			getOwnChildrenAsProps(elements) {
+			findInChildrenAsProps(elements) {
 				let component = this;
-				return _.map(component.getOwnChildren(elements), 'props');
+				return _.map(component.findInChildren(elements), 'props');
 			},
 
 			/**
-			 * getOwnProps
+			 * findInProps
 			 *
 			 * Given a set of parent props this will return only the props for this
 			 * component type
@@ -56,7 +56,7 @@ export function createChildComponent (definition={}) {
 			 * @param {object} parentProps - usually `this.props` that may contain a prop for the current component type
 			 * @return {array} - an array of normalized props
 			 */
-			getOwnProps(parentProps) {
+			findInProps(parentProps) {
 				// Extract out the defined `childProps` from the parent class
 				const currentProps = _.chain(parentProps)
 					.get(definition.propName) // grab the prop we care about, e.g. "Child"
@@ -77,7 +77,7 @@ export function createChildComponent (definition={}) {
 			},
 
 			/**
-			 * getAllAsProps
+			 * findInAllAsProps
 			 *
 			 * Given a parent props object, this will return a mashup of all the
 			 * children and/or props for the current component type. This is
@@ -87,11 +87,11 @@ export function createChildComponent (definition={}) {
 			 * @param {object} parentProps - usually `this.props` that may contain a prop for the current component type
 			 * @return {array} - an array of `props`
 			 */
-			getAllAsProps(parentProps) {
+			findInAllAsProps(parentProps) {
 				let component = this;
 
-				const propsFromProps = component.getOwnProps(parentProps);
-				const propsFromChildren = component.getOwnChildrenAsProps(parentProps.children);
+				const propsFromProps = component.findInProps(parentProps);
+				const propsFromChildren = component.findInChildrenAsProps(parentProps.children);
 
 				return propsFromProps.concat(propsFromChildren);
 			}


### PR DESCRIPTION
There was a bug that was caused by not filtering out `null` values in the old version of `getAllAsProps`, this was fixed by `.filter(x => x)`