### PR TITLE
use reaact-router 2.0 browserHistory

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-postcss": "^6.1.0",
     "gulp-tar": "^1.8.0",
     "gulp-zip": "^3.1.0",
+    "history": "^2.0.0",
     "jsdom": "^8.0.1",
     "json-loader": "^0.5.4",
     "less": "^2.3.1",

--- a/src/docs/index.jsx
+++ b/src/docs/index.jsx
@@ -5,16 +5,13 @@ require('../index.less');
 import _ from 'lodash';
 import React from 'react';
 import { render } from 'react-dom';
-import { Router, Route, Link, useRouterHistory } from 'react-router';
-import { createHashHistory } from 'react-router/node_modules/history';
+import { Router, Route, Link} from 'react-router';
+import createHashHistory from 'history/lib/createHashHistory';
 import docgenMapRaw from './docgen.json';
 import hljs from 'hljs';
 import { markdown } from 'markdown';
 
-// Opt out of the ?_k=asdffb in the query string since we don't need to keep
-// state in our router.
-// https://github.com/reactjs/react-router/issues/1967#issuecomment-187730662
-const appHistory = useRouterHistory(createHashHistory)({ queryKey: false });
+const hashHistory = createHashHistory({ queryKey: false });
 
 // This is webpackism for "dynamically load all example files"
 const reqExamples = require.context('../components/', true, /examples.*\.jsx?/i);
@@ -295,7 +292,7 @@ const App = React.createClass({
 });
 
 render((
-	<Router history={appHistory}>
+	<Router history={hashHistory}>
 		<Route path='/' component={App}>
 			<Route path='/components/:componentName' component={Component}/>
 		</Route>


### PR DESCRIPTION
react-router 2.0 uses browserHistory 
https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md

addresses #58

- [x] use hash history