### PR TITLE
expose lucid utils to consumers and clean exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,33 +26,21 @@ import TextField from './components/TextField/TextField'
 import Validation from './components/Validation/Validation';
 import WarningIcon from './components/Icon/WarningIcon/WarningIcon';
 
-export {Badge}
-export {Banner}
-export {Button}
-export {ButtonGroup}
-export {CaretIcon}
-export {CheckIcon}
-export {Checkbox}
-export {ContextMenu}
-export {CrossIcon}
-export {DangerIcon}
-export {EditIcon}
-export {EligibilityIcon}
-export {Icon}
-export {InfoIcon}
-export {MinusIcon}
-export {PlusIcon}
-export {RadioButton}
-export {ResizeIcon}
-export {SearchIcon}
-export {SuccessIcon}
-export {Switch}
-export {Tabs}
-export {TextField}
-export {Validation}
-export {WarningIcon}
+import * as childComponent from './util/child-component';
+import * as componentDefinition from './util/component-definition';
+import * as domHelpers from './util/dom-helpers';
+import * as stateManagement from './util/state-management';
+import * as styleHelpers from './util/style-helpers';
 
-export default {
+export {
+	childComponent,
+	componentDefinition,
+	domHelpers,
+	stateManagement,
+	styleHelpers
+};
+
+export {
 	Badge,
 	Banner,
 	Button,
@@ -79,5 +67,5 @@ export default {
 	Tabs,
 	TextField,
 	Validation,
-	WarningIcon,
+	WarningIcon
 };

--- a/src/util/generic-tests.jsx
+++ b/src/util/generic-tests.jsx
@@ -3,7 +3,7 @@ import { mount, shallow } from 'enzyme';
 import assert from 'assert';
 import describeWithDOM  from './describe-with-dom';
 import _ from 'lodash';
-import lucid from '../index';
+import * as lucid from '../index';
 
 // Common tests for all our components
 export function common(Component, getDefaultProps=_.noop) {


### PR DESCRIPTION
Use named exports only no more default object.

Two reasons for this:
1. ES2015 consumers can use `import * as lucid from 'lucid-ui'` to get the same default object
2. older, non ES2015 consumers will see no difference in their usage: `var lucid = require('lucid-ui');`