### PR TITLE
#122: use window.pageYOffset instead of window.scrollY for compat.

### DIFF
--- a/src/util/dom-helpers.js
+++ b/src/util/dom-helpers.js
@@ -2,10 +2,10 @@ export function getAbsoluteBoundingClientRect(domNode) {
 	let elementRect = domNode.getBoundingClientRect();
 
 	return {
-		bottom: elementRect.bottom + window.scrollY,
-		top: elementRect.top + window.scrollY,
-		left: elementRect.left + window.scrollX,
-		right: elementRect.right + window.scrollX,
+		bottom: elementRect.bottom + window.pageYOffset,
+		top: elementRect.top + window.pageYOffset,
+		left: elementRect.left + window.pageXOffset,
+		right: elementRect.right + window.pageXOffset,
 		height: elementRect.height,
 		width: elementRect.width
 	};


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals

