### PR TITLE
#109 Change height from 19px to #20

### DIFF
--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -18,11 +18,6 @@
 	line-height: @Button-size-lineHeight;
 	padding: 0 @Button-size-padding;
 
-	&[disabled] {
-		cursor: not-allowed;
-	}
-
-
 	// Types
 	&-primary {
 		color: @color-white;
@@ -97,5 +92,10 @@
 		.gradient-reset(linear-gradient(@standardGradient, @featured-color-default-gradientStartColor, @featured-color-default-gradientEndColor));
 		cursor: not-allowed;
 		.opacity();
+	}
+
+	// Also needed in some cases to beat other libraries (e.g. pure.css)
+	&[disabled] {
+		cursor: not-allowed;
 	}
 }

--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -1,6 +1,7 @@
 // button sizes
 @Button-size-padding: 12px;
 @Button-size-lineHeight: 26px;
+@Button-size-shortlineHeight: 20px;
 @Button-size-borderRadius: @size-borderRadius;
 
 .lucid-Button {
@@ -16,6 +17,10 @@
 	letter-spacing: .05em;
 	line-height: @Button-size-lineHeight;
 	padding: 0 @Button-size-padding;
+
+	&[disabled] {
+		cursor: not-allowed;
+	}
 
 
 	// Types
@@ -69,10 +74,10 @@
 
 	// Sizes
 	&-short {
-		line-height: @Button-size-lineHeight/1.5;
+		line-height: @Button-size-shortlineHeight;
 	}
 	&-small {
-		line-height: @Button-size-lineHeight/1.5;
+		line-height: @Button-size-shortlineHeight;
 		padding: 0 @Button-size-padding/1.5;
 	}
 	&-large {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

------

* Change height from 19px to 20px on small and short buttons
* Added new disabled selector to fix display issue after reset.css added