### PR TITLE
Fixes #172 white space in autocomplete

### DIFF
--- a/src/components/Autocomplete/Autocomplete.less
+++ b/src/components/Autocomplete/Autocomplete.less
@@ -80,7 +80,7 @@
 	&-Option-suggestion-match,
 	&-Option-suggestion-post,
 	&-Option-suggestion-pre {
-		white-space: nowrap;
+		white-space: pre;
 	}
 
 	&-Option-suggestion-match {

--- a/src/components/Autocomplete/examples/1.basic.jsx
+++ b/src/components/Autocomplete/examples/1.basic.jsx
@@ -12,10 +12,12 @@ export default React.createClass({
 				placeholder='Enter a word...'
 				suggestions={[
 					'Portland',
-					'portal',
+					'pinky and the brain',
+					'playa please',
 					'porridge',
+					'portal',
+					'potent potables',
 					'potent',
-					'please'
 				]}
 			/>
 		);


### PR DESCRIPTION
We needed `white-space: pre` instead of `white-space: no-wrap` on the suggestion matches to maintain white space correctly.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval

