### PR TITLE
Table cleanup

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -155,15 +155,6 @@ const Tr = React.createClass(createLucidComponentDefinition({
 	}
 }));
 
-const SortedThContent = ({ children, sortDirection }) => (
-	<ul className={boundClassNames('&-is-sorted-container')}>
-		<li className={boundClassNames('&-is-sorted-title')}>{children}</li>
-		<li className={boundClassNames('&-is-sorted-caret')}>
-			<CaretIcon className={boundClassNames('&-sort-icon')} direction={sortDirection} size={6}/>
-		</li>
-	</ul>
-);
-
 /**
  * `Th` renders <th>.
  *
@@ -263,6 +254,15 @@ const Th = React.createClass(createLucidComponentDefinition({
 			passiveWidth
 		} = this.state;
 
+		const cellContent = (isSorted ? (
+			<ul className={boundClassNames('&-is-sorted-container')}>
+				<li className={boundClassNames('&-is-sorted-title')}>{children}</li>
+				<li className={boundClassNames('&-is-sorted-caret')}>
+					<CaretIcon className={boundClassNames('&-sort-icon')} direction={sortDirection} size={6}/>
+				</li>
+			</ul>
+		) : children);
+
 		return (
 			<th
 				{...this.props}
@@ -287,7 +287,7 @@ const Th = React.createClass(createLucidComponentDefinition({
 				{isResizable ? (
 					<div className={boundClassNames('&-is-resizable-container')}>
 						<div className={boundClassNames('&-is-resizable-content')}>
-							{isSorted ? <SortedThContent sortDirection={sortDirection}>{children}</SortedThContent> : children}
+							{cellContent}
 						</div>
 						<DragCaptureZone
 							onDrag={this.handleDragged}
@@ -295,9 +295,7 @@ const Th = React.createClass(createLucidComponentDefinition({
 							onDragStart={this.handleDragStarted}
 						/>
 					</div>
-				) : null}
-				{isSorted && !isResizable ? <SortedThContent sortDirection={sortDirection}>{children}</SortedThContent> : null}
-				{!isSorted && !isResizable ? children : null}
+				) : cellContent}
 			</th>
 		);
 	},

--- a/src/components/Table/Table.spec.jsx
+++ b/src/components/Table/Table.spec.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import assert from 'assert';
 import { common } from '../../util/generic-tests';
 import Table from './Table';
+import CaretIcon from '../Icon/CaretIcon/CaretIcon';
+import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
 
 const { Thead, Tbody, Tr, Th, Td } = Table;
 
@@ -260,21 +262,15 @@ describe('Table', () => {
 					});
 
 					it('should render a container for resizable header content', () => {
-						const wrapper = mount(
-							<Table>
-								<Thead>
-									<Tr>
-										<Th isResizable>foo</Th>
-									</Tr>
-								</Thead>
-							</Table>
+						const wrapper = shallow(
+							<Th isResizable>foo</Th>
 						);
 						const containerWrapper = wrapper.find('div.lucid-Table-is-resizable-container');
 
 						assert.equal(containerWrapper.length, 1, 'must have a container');
 						assert.equal(containerWrapper.find('div.lucid-Table-is-resizable-content').length, 1, 'container must have content');
 						assert.equal(containerWrapper.find('div.lucid-Table-is-resizable-content').text(), 'foo', 'content must match children');
-						assert.equal(containerWrapper.find('div.lucid-DragCaptureZone').length, 1, 'container must have a drag capture zone');
+						assert.equal(containerWrapper.find(DragCaptureZone).length, 1, 'container must have a drag capture zone');
 					});
 				});
 
@@ -288,14 +284,8 @@ describe('Table', () => {
 					});
 
 					it('should render a container for sorted header content', () => {
-						const wrapper = mount(
-							<Table>
-								<Thead>
-									<Tr>
-										<Th isSorted>foo</Th>
-									</Tr>
-								</Thead>
-							</Table>
+						const wrapper = shallow(
+							<Th isSorted>foo</Th>
 						);
 						const containerWrapper = wrapper.find('ul.lucid-Table-is-sorted-container');
 
@@ -303,25 +293,19 @@ describe('Table', () => {
 						assert.equal(containerWrapper.find('li.lucid-Table-is-sorted-title').length, 1, 'container must have a title');
 						assert.equal(containerWrapper.find('li.lucid-Table-is-sorted-title').text(), 'foo', 'title content must match children');
 						assert.equal(containerWrapper.find('li.lucid-Table-is-sorted-caret').length, 1, 'container must have a caret');
-						assert.equal(containerWrapper.find('li.lucid-Table-is-sorted-caret').find('.lucid-CaretIcon').length, 1, 'CaretIcon must be rendered');
-						assert.equal(containerWrapper.find('li.lucid-Table-is-sorted-caret').find('.lucid-CaretIcon.lucid-Table-sort-icon').length, 1, 'CaretIcon must have correct className');
+						assert.equal(containerWrapper.find('li.lucid-Table-is-sorted-caret').find(CaretIcon).length, 1, 'CaretIcon must be rendered');
+						assert(containerWrapper.find('li.lucid-Table-is-sorted-caret').find(CaretIcon).hasClass('lucid-Table-sort-icon'), 'CaretIcon must have correct className');
 					});
 				});
 
 				describe('sortDirection', () => {
 					it('should pass thru to the CaretIcon when `isSorted` is also true', () => {
-						const wrapper = mount(
-							<Table>
-								<Thead>
-									<Tr>
-										<Th isSorted sortDirection='up' />
-									</Tr>
-								</Thead>
-							</Table>
+						const wrapper = shallow(
+							<Th isSorted sortDirection='up' />
 						);
 
 						const containerWrapper = wrapper.find('ul.lucid-Table-is-sorted-container');
-						assert.equal(containerWrapper.find('li.lucid-Table-is-sorted-caret').find('.lucid-CaretIcon-is-up').length, 1, 'CaretIcon direction must match prop');
+						assert(containerWrapper.find('li.lucid-Table-is-sorted-caret').find(CaretIcon).shallow().hasClass('lucid-CaretIcon-is-up'), 'CaretIcon direction must match prop');
 					});
 				});
 			});


### PR DESCRIPTION
Remove one-off SortedThContent component and clean tests to only use shallow rendering.

## PR Checklist

- ~~Manually tested across supported browsers~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~