### PR TITLE
Proposal: redux binding utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "lodash": "^4.11.0",
-    "react-addons-css-transition-group": "^0.14.0"
+    "react-addons-css-transition-group": "^0.14.0",
+    "reselect": "^2.5.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.3",

--- a/src/index.js
+++ b/src/index.js
@@ -48,13 +48,15 @@ import * as componentDefinition from './util/component-definition';
 import * as domHelpers from './util/dom-helpers';
 import * as stateManagement from './util/state-management';
 import * as styleHelpers from './util/style-helpers';
+import * as redux from './util/redux';
 
 export {
 	childComponent,
 	componentDefinition,
 	domHelpers,
+	redux,
 	stateManagement,
-	styleHelpers,
+	styleHelpers
 };
 
 export {
@@ -101,5 +103,5 @@ export {
 	TextField,
 	ValidatedTextField,
 	Validation,
-	WarningIcon,
+	WarningIcon
 };

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -50,7 +50,7 @@ export function getReduxPrimitives({
 	let dispatchTree;
 
 	const reducer = createReduxReducer(reducers, initialState, rootPath);
-	const selector = reduceSelectors(selectors);
+	const selector = selectors ? reduceSelectors(selectors) : identity;
 	const rootPathSelector = state => isEmpty(rootPath) ? state : get(state, rootPath);
 	const mapStateToProps = createSelector(
 		[rootPathSelector],

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -1,0 +1,246 @@
+import {
+	assign,
+	get,
+	identity,
+	isArray,
+	isEmpty,
+	isFunction,
+	isUndefined,
+	merge,
+	reduce,
+	slice
+} from 'lodash';
+import { createSelector } from 'reselect';
+
+/**
+ * thunk
+ *
+ * Marks a function on the reducer tree as a thunk action creator so it doesn't
+ * get incorporated into the redux reducer
+ *
+ * @return {function} with `isThunk` set to `true`
+ */
+export function thunk(fn) {
+	fn.isThunk = true;
+	return fn;
+}
+
+/**
+ * getReduxPrimitives
+ *
+ * Creates a redux reducer and connectors (inputs to redux-react's `connect`)
+ *
+ * @param {Object} param
+ * @param {Object} param.initialState - the initial state object that the reducer will return
+ * @param {Object} param.reducers - a tree of lucid reducers
+ * @param {string[]} param.rootPath - array of strings representing the path to local state in global state
+ * @param {Object} param.selectors - a tree of lucid selectors
+ * @return {Object} redux reducer and connectors
+ */
+
+export function getReduxPrimitives({
+	initialState,
+	reducers,
+	rootPath = [],
+	rootSelector = identity,
+	selectors
+}) {
+
+	// we need this in scope so actionCreators can refer to it
+	let dispatchTree;
+
+	const reducer = createReduxReducer(reducers, initialState, rootPath);
+	const selector = reduceSelectors(selectors);
+	const rootPathSelector = state => isEmpty(rootPath) ? state : get(state, rootPath);
+	const mapStateToProps = createSelector(
+		[rootPathSelector],
+		root => rootSelector(selector(root))
+	);
+	const mapDispatchToProps = dispatch => getDispatchTree(reducers, rootPath, dispatch);
+
+	return {
+		reducer,
+		connectors: [
+			mapStateToProps,
+			mapDispatchToProps,
+			mergeProps
+		]
+	};
+
+	/**
+	 * createActionCreator
+	 *
+	 * @param {function} node - a node in the the reducer tree, either a reducer or a thunk
+	 * @param {string[]} path - the path to the reducer in the reducer tree
+	 * @param {string[]} rootPath - array of strings representing the path to local state in global state
+	 * @return {function} action creator that returns either an action or a thunk
+	 */
+	function createActionCreator(node, path, rootPath) {
+		if (node.isThunk) {
+			return function thunk(...args) {
+				return function thunkInner(dispatch, getState) {
+					const localPath = slice(path, rootPath.length, -1);
+					const localDispatchTree = isEmpty(localPath) ? dispatchTree : get(dispatchTree, localPath);
+					const getLocalState = isEmpty(rootPath) ? getState : () => get(getState(), slice(path, 0, -1));
+					return node(...args)(localDispatchTree, getLocalState, dispatch, getState);
+				};
+			};
+		}
+		return function actionCreator(payload, ...meta) {
+			return {
+				type: path.join('.'),
+				payload,
+				meta
+			};
+		};
+	}
+
+	/**
+	 * createActionCreatorTree
+	 *
+	 * Walks the reducer tree and generates a tree of action creators that correspond to each reducer
+	 * @param {Object} reducers - a tree of lucid reducers
+	 * @param {string[]} rootPath - array of strings representing the path to local state in global state
+	 * @returns {Object} action creator tree
+	 */
+	function createActionCreatorTree(reducers, rootPath) {
+		return (function recur(reducers, path = []) {
+			return reduce(reducers, (memo, node, key) => {
+				const currentPath = path.concat(key);
+				return assign(memo, {
+					[key]: isFunction(node) ?
+						createActionCreator(node, currentPath, rootPath) :
+						recur(node, currentPath)
+				});
+			}, {});
+		})(reducers, rootPath);
+	}
+
+	/**
+	 * getDispatchTree
+	 *
+	 * Walks the reducer tree and generates an action creator tree, then binds dispatch to each node
+	 * @param {Object} reducers - a tree of lucid reducers
+	 * @param {string[]} rootPath - array of strings representing the path to local state in global state
+	 * @param {function} dispatch - the redux store's `dispatch` function
+	 */
+	function getDispatchTree(reducers, rootPath, dispatch) {
+		const actionCreatorTree = createActionCreatorTree(reducers, rootPath);
+		dispatchTree = bindActionCreatorTree(actionCreatorTree, dispatch);
+		return dispatchTree;
+	}
+
+}
+
+/**
+ * createReduxReducerTree
+ *
+ * Walks the reducer tree and generates a tree of redux reducers, converting the
+ * signature from `(state, payload) => state` to `(state, action) => state`
+ * @param {Object} reducers - a tree of lucid reducers
+ * @param {string[]} path - array of strings representing the path to the reducer
+ * @return {Object} redux reducer tree
+ */
+function createReduxReducerTree(reducers, path = []) {
+	return reduce(reducers, (memo, node, key) => {
+		// filter out thunks from the reducer tree
+		if (node.isThunk) {
+			return memo;
+		}
+		const currentPath = path.concat(key);
+		return assign(memo, {
+			[key]: isFunction(node) ?
+				function reduxReducer(state, action) {
+					const { type, payload, meta = [] } = action;
+					if (isUndefined(state) || type !== currentPath.join('.')) {
+						return state;
+					}
+					return node(state, payload, ...meta);
+				} :
+				createReduxReducerTree(node, currentPath)
+		});
+	}, {});
+}
+
+/**
+ * createReducerFromReducerTree
+ *
+ * Returns a function that calls every reducer in the reducer tree with the reducer's local state and action
+ * @param {Object} reduxReducerTree - tree of redux reducers with signature `(state, action) => state`
+ * @param {Object} initialState - the initial state object that the reducer will return
+ * @return {function} the redux reducer
+ */
+function createReducerFromReducerTree(reduxReducerTree, initialState) {
+	return function reduxReducer(state, action) {
+		if (isUndefined(state)) {
+			return initialState;
+		}
+		return reduce(reduxReducerTree, (state, node, key) => {
+			return assign({}, state, isFunction(node) ? node(state, action) : {
+				[key]: createReducerFromReducerTree(node)(state[key], action)
+			});
+		}, state);
+	};
+}
+
+/**
+ * createReduxReducer
+ *
+ * Generates a redux reducer from a tree of lucid reducers
+ * @param {Object} reducers - a tree of lucid reducers
+ * @param {Object} initialState - the initial state object that the reducer will return
+ * @return {function} the redux reducer
+ */
+function createReduxReducer(reducers, initialState, rootPath) {
+	const reducerTree = createReduxReducerTree(reducers, rootPath);
+	return createReducerFromReducerTree(reducerTree, initialState);
+}
+
+/**
+ * bindActionCreatorTree
+ *
+ * Binds redux store.dispatch to actionCreators in a tree
+ * @param {Object} actionCreatorTree - a tree of redux action creator functions
+ * @param {function} dispatch - the redux store's `dispatch` function
+ * @param {string[]} path - array of strings representing the path to the action creator
+ */
+function bindActionCreatorTree(actionCreatorTree, dispatch, path = []) {
+	return reduce(actionCreatorTree, (memo, node, key) => assign(memo, {
+		[key]: isFunction(node) ? function boundActionCreator(...args) {
+			const action = actionCreatorTree[key](...args);
+			return dispatch(action);
+		} : bindActionCreatorTree(node, dispatch, path.concat(key))
+	}), {});
+}
+
+/**
+ * reduceSelectors
+ *
+ * Generates a root selector from a tree of selectors
+ * @param {Object} selectors - a tree of selectors
+ * @returns {function} root selector that when called with state, calls each of
+ * the selectors in the tree with the state local to that selector
+ */
+// @TODO: optimize to create and reuse selectors?
+function reduceSelectors(selectors) {
+	return function rootSelector(state) {
+		return reduce(selectors, (state, selector, key) => assign({}, state, {
+			[key]: isFunction(selector) ?
+				selector(state) :
+				reduceSelectors(selector)(state[key])
+		}), state);
+	};
+}
+
+/**
+ * mergeProps
+ *
+ * Merges state, dispatchTree, and ownProps into a single props object
+ * @param {Object} state
+ * @param {Object} dispatchTree
+ * @param {Object} ownProps
+ * @return {Object}
+ */
+function mergeProps(state, dispatchTree, ownProps) {
+	return merge({}, state, dispatchTree, ownProps, (a, b) => (isArray(a) && isArray(b)) ? b : undefined);
+}

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -242,5 +242,5 @@ function reduceSelectors(selectors) {
  * @return {Object}
  */
 function mergeProps(state, dispatchTree, ownProps) {
-	return merge({}, state, dispatchTree, ownProps, (a, b) => (isArray(a) && isArray(b)) ? b : undefined);
+	return merge({}, state, dispatchTree, ownProps);
 }

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -2,7 +2,6 @@ import {
 	assign,
 	get,
 	identity,
-	isArray,
 	isEmpty,
 	isFunction,
 	isUndefined,
@@ -54,7 +53,7 @@ export function getReduxPrimitives({
 	const rootPathSelector = state => isEmpty(rootPath) ? state : get(state, rootPath);
 	const mapStateToProps = createSelector(
 		[rootPathSelector],
-		root => rootSelector(selector(root))
+		rootState => rootSelector(selector(rootState))
 	);
 	const mapDispatchToProps = dispatch => getDispatchTree(reducers, rootPath, dispatch);
 
@@ -223,7 +222,7 @@ function bindActionCreatorTree(actionCreatorTree, dispatch, path = []) {
  */
 // @TODO: optimize to create and reuse selectors?
 function reduceSelectors(selectors) {
-	return function rootSelector(state) {
+	return function reducedSelector(state) {
 		return reduce(selectors, (state, selector, key) => assign({}, state, {
 			[key]: isFunction(selector) ?
 				selector(state) :

--- a/src/util/redux.spec.js
+++ b/src/util/redux.spec.js
@@ -1,0 +1,197 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import {
+	assign,
+	isFunction,
+	upperCase
+} from 'lodash';
+
+import {
+	thunk,
+	getReduxPrimitives
+} from './redux';
+
+describe('getReduxPrimitives', () => {
+
+	const reducers = {
+		foo: {
+			onChange: (state, payload) => {
+				return ({ value: payload });
+			},
+			bar: {
+				onChange: (state, payload) => ({ value: payload })
+			},
+			asyncOperation: thunk(payload => dispatchTree => Promise.resolve(payload).then(dispatchTree.onChange))
+		}
+	};
+
+	const initialState = {
+		foo: {
+			value: 'foo',
+			bar: {
+				value: null
+			}
+		}
+	};
+
+	describe('reducer', () => {
+
+		const { reducer } = getReduxPrimitives({ reducers, initialState });
+
+		it('should return initialState on unmatched type', () => {
+			const action = { type: 'UNKNOWN' };
+			assert.deepEqual(reducer(initialState, action), initialState);
+		});
+
+		it('should correctly apply state change', () => {
+			const action = { type: 'foo.onChange', payload: 'bar' };
+			const nextState = reducer(initialState, action);
+			assert.equal(nextState.foo.value, 'bar');
+		});
+
+		describe('nested reducer', () => {
+
+			it('should correctly apply state change', () => {
+				const action = { type: 'foo.bar.onChange', payload: 'baz' };
+				const nextState = reducer(initialState, action);
+				assert.equal(nextState.foo.bar.value, 'baz');
+			});
+
+		});
+
+		describe('with rootPath', () => {
+
+			const { reducer: reducerWithRootPath } = getReduxPrimitives({
+				reducers,
+				initialState,
+				rootPath: ['root']
+			});
+
+			it('should correctly apply state change', () => {
+				const action = { type: 'root.foo.onChange', payload: 'bar' };
+				const nextState = reducerWithRootPath(initialState, action);
+				assert.equal(nextState.foo.value, 'bar');
+			});
+
+		});
+
+		describe('thunks', () => {
+			it('should not include thunk paths in reducer', () => {
+				const action = { type: 'root.foo.asyncOperation' };
+				const nextState = reducer(initialState, action);
+				assert.deepEqual(initialState, nextState);
+			});
+		});
+
+	});
+
+	describe('connectors', () => {
+		describe('selector/mapStateToProps', () => {
+
+			const selectors = {
+				foo: {
+					uppercase: ({ value }) => upperCase(value)
+				}
+			};
+
+			const {
+				connectors: [mapStateToProps]
+			} = getReduxPrimitives({
+				reducers,
+				initialState,
+				selectors
+			});
+
+			it('should apply selector', () => {
+				const viewState = mapStateToProps(initialState);
+				assert.equal(viewState.foo.uppercase, 'FOO');
+			});
+
+			describe('rootPath', () => {
+
+				const {
+					connectors: [mapStateToProps]
+				} = getReduxPrimitives({
+					reducers,
+					initialState,
+					selectors,
+					rootPath: ['root']
+				});
+
+				it('should apply selector', () => {
+					const viewState = mapStateToProps({ root: initialState });
+					assert.equal(viewState.foo.uppercase, 'FOO');
+				});
+
+			});
+
+			describe('rootSelector', () => {
+
+				const {
+					connectors: [mapStateToProps]
+				} = getReduxPrimitives({
+					reducers,
+					initialState,
+					selectors,
+					rootSelector: state => assign({}, state, {
+						computed: state.foo.uppercase + state.foo.value
+					})
+				});
+
+				it('should apply rootSelector', () => {
+					const viewState = mapStateToProps(initialState);
+					assert.equal(viewState.computed, 'FOOfoo');
+				});
+
+			});
+		});
+
+		describe('dispatchTree/mapDispatchToProps', () => {
+
+			const {
+				connectors
+			} = getReduxPrimitives({
+				reducers,
+				initialState
+			});
+
+			const mapDispatchToProps = connectors[1];
+			const mockDispatch = sinon.spy(action => isFunction(action) ? action(mockDispatch) : action);
+			const dispatchTree = mapDispatchToProps(mockDispatch);
+
+			beforeEach(() => mockDispatch.reset());
+
+			it('should dispatch the correct action', () => {
+				dispatchTree.foo.onChange('bar', 'baz');
+				const dispatchedAction = mockDispatch.getCall(0).args[0];
+				assert.deepEqual(dispatchedAction, {
+					type: 'foo.onChange',
+					payload: 'bar',
+					meta: ['baz']
+				});
+			});
+
+			describe('thunks', () => {
+
+				beforeEach(() => dispatchTree.foo.asyncOperation('qux'));
+
+				it('should dispatch a thunk', () => {
+					const dispatchedThunk = mockDispatch.getCall(0).args[0];
+					assert(isFunction(dispatchedThunk))
+				});
+
+				it('should dispatch the correct action', () => {
+					const dispatchedAction = mockDispatch.getCall(1).args[0];
+					assert.deepEqual(dispatchedAction, {
+						type: 'foo.onChange',
+						payload: 'qux',
+						meta: []
+					});
+				});
+
+			});
+
+		});
+
+	});
+});


### PR DESCRIPTION
moved https://github.com/appnexus/lucid/pull/211

## PR Checklist

- [ ] finalize names
- ~~Manually tested across supported browsers~~

~~[x] Chrome~~
~~[ ] Firefox~~
~~[ ] Safari~~
~~[ ] IE11 (Win 7)~~
~~[ ] Edge (Win 10)~~

- [x] Unit tests written ~~(`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals

~~[ ] One core team UX approval~~ n/a

+ utility functions for getting react-redux primitives from lucid
	reducers/selectors:
	+ reducer
	+ connectors (mapStateToProps, mapDispatchToProps, mergeProps)

