### PR TITLE
#283 - fix typo in table-Th-align-right

### DIFF
--- a/src/components/Table/Table.less
+++ b/src/components/Table/Table.less
@@ -118,7 +118,7 @@
 			}
 
 			&.lucid-Table-align-right > .lucid-Table-Th-inner .lucid-Table-Th-inner-content {
-				justify-content: flext-end;
+				justify-content: flex-end;
 			}
 		}
 	}


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval

Fixes #283