### PR TITLE
fix Banner icon=true isSmall=true styling

### DIFF
--- a/src/components/Banner/Banner.less
+++ b/src/components/Banner/Banner.less
@@ -1,6 +1,7 @@
 // banner sizes
 @Banner-size-spacing-rightLeft: @size-S;
 @Banner-size-spacing-topBottom: @size-standard;
+@Banner-size-spacing-topBottom-small: @size-XS;
 @Banner-size-borderRadius: @size-borderRadius;
 @Banner-size-iconFontSize: 16px;
 
@@ -87,9 +88,10 @@
 		background-color: @featured-color-danger-backgroundColor;
 	}
 
-	&-small {
-		.lucid-Banner-content {
-			padding: @Banner-size-spacing-topBottom - 5px 0;
-		}
+	&-small &-icon {
+		padding-top: @Banner-size-spacing-topBottom-small - 2px;
+	}
+	&-small &-content {
+		padding: @Banner-size-spacing-topBottom - 6px 0;
 	}
 }

--- a/src/components/Banner/examples/stateless.jsx
+++ b/src/components/Banner/examples/stateless.jsx
@@ -35,6 +35,8 @@ export default React.createClass({
 					<Banner kind='success' isCloseable={false}>Success -- No Close {String.fromCharCode(0x00d7)}</Banner>
 					<Banner kind='success' hasIcon={true}>Success -- has icon</Banner>
 					<Banner kind='success' hasIcon={true} isCloseable={false}>Success -- has icon -- No Close {String.fromCharCode(0x00d7)}</Banner>
+					<Banner kind='success' isSmall={true} hasIcon={true}>Success -- has icon -- small</Banner>
+					<Banner kind='success' isSmall={true} hasIcon={true} isCloseable={false}>Success -- has icon -- No Close {String.fromCharCode(0x00d7)} -- small</Banner>
 					<Banner kind='success' isSmall={true}>Success -- small</Banner>
 					<Banner kind='success' isSmall={true} isCloseable={false}>Success -- small -- No Close {String.fromCharCode(0x00d7)}</Banner>
 					<Banner kind='success' hasIcon={true}>
@@ -54,6 +56,8 @@ export default React.createClass({
 					<Banner kind='warning' hasIcon={true} isCloseable={false}>Warning -- has iconv</Banner>
 					<Banner kind='warning' isSmall={true}>Warning -- small</Banner>
 					<Banner kind='warning' isSmall={true} isCloseable={false}>Warning -- small -- No Close {String.fromCharCode(0x00d7)}</Banner>
+					<Banner kind='warning' hasIcon={true} isSmall={true}>Warning -- has icon -- small</Banner>
+					<Banner kind='warning' hasIcon={true} isSmall={true} isCloseable={false}>Warning -- has icon -- small -- No Close {String.fromCharCode(0x00d7)}</Banner>
 				</div>
 
 				<div>
@@ -63,6 +67,8 @@ export default React.createClass({
 					<Banner kind='danger' hasIcon={true} isCloseable={false}>Danger -- has icon -- No Close {String.fromCharCode(0x00d7)}</Banner>
 					<Banner kind='danger' isSmall={true}>Danger -- small</Banner>
 					<Banner kind='danger' isSmall={true} isCloseable={false}>Danger -- small -- No Close {String.fromCharCode(0x00d7)}</Banner>
+					<Banner kind='danger' hasIcon={true} isSmall={true}>Danger -- has icon -- small</Banner>
+					<Banner kind='danger' hasIcon={true} isSmall={true} isCloseable={false}>Danger -- has icon -- small -- No Close {String.fromCharCode(0x00d7)}</Banner>
 				</div>
 
 				<div>
@@ -72,6 +78,8 @@ export default React.createClass({
 					<Banner kind='info' hasIcon={true} isCloseable={false}>Info -- has icon -- No Close {String.fromCharCode(0x00d7)}</Banner>
 					<Banner kind='info' isSmall={true}>Info -- small</Banner>
 					<Banner kind='info' isSmall={true} isCloseable={false}>Info -- small -- No Close {String.fromCharCode(0x00d7)}</Banner>
+					<Banner kind='info' hasIcon={true} isSmall={true}>Info -- has icon -- small</Banner>
+					<Banner kind='info' hasIcon={true} isSmall={true} isCloseable={false}>Info -- has icon -- small -- No Close {String.fromCharCode(0x00d7)}</Banner>
 				</div>
 
 				<div>


### PR DESCRIPTION
fixes #236

- #315 `patch`: fixed bug with `Banner` with small variants and icons

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~[ ] Unit tests written (`common` at minimum)~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval

http://docspot.devnxs.net/projects/lucid/236-banner-icon-is-small/#/components/Banner