### PR TITLE
Fix white buttons in Safari

### DIFF
--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -18,6 +18,7 @@
 	padding: 0 @Button-size-padding;
 	cursor: pointer;
 	outline: none;
+	color: @color-black;
 
 	// from normalize.css@4.1.1
 	margin: 0; /* 2 */


### PR DESCRIPTION
Fixes #316

- #318 `patch`: fixed small issue with white buttons in Safari

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~