### PR TITLE
Fix D3 imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "classnames": "^2.2.3",
-    "d3-scale": "^0.6.4",
-    "d3-shape": "^0.6.0",
-    "d3-time": "^0.2.5",
-    "d3-time-format": "^0.3.2",
+    "d3-scale": "^0.9.0",
+    "d3-shape": "^0.7.0",
+    "d3-time": "^0.3.0",
+    "d3-time-format": "^0.4.0",
     "lodash": "^4.11.0",
     "reselect": "^2.5.1"
   },

--- a/src/components/Axis/Axis.spec.js
+++ b/src/components/Axis/Axis.spec.js
@@ -1,4 +1,4 @@
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 import { common } from '../../util/generic-tests';
 
 import Axis from './Axis';

--- a/src/components/Axis/examples/2.bottom.jsx
+++ b/src/components/Axis/examples/2.bottom.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 import Axis from '../Axis';
 

--- a/src/components/Axis/examples/3.top.jsx
+++ b/src/components/Axis/examples/3.top.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 import Axis from '../Axis';
 

--- a/src/components/Axis/examples/4.left.jsx
+++ b/src/components/Axis/examples/4.left.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 import Axis from '../Axis';
 

--- a/src/components/Axis/examples/5.right.jsx
+++ b/src/components/Axis/examples/5.right.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 import Axis from '../Axis';
 

--- a/src/components/Axis/examples/6.time.jsx
+++ b/src/components/Axis/examples/6.time.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import d3Scale from 'd3-scale';
-import d3Time from 'd3-time';
+import * as d3Scale from 'd3-scale';
+import * as d3Time from 'd3-time';
 
 import Axis from '../Axis';
 

--- a/src/components/Axis/examples/7.ordinal.jsx
+++ b/src/components/Axis/examples/7.ordinal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 import Axis from '../Axis';
 

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -6,7 +6,7 @@ import {
 	maxByFields,
 	maxByFieldsStacked,
 } from '../../util/chart-helpers';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 import Axis from '../Axis/Axis';
 import AxisLabel from '../AxisLabel/AxisLabel';

--- a/src/components/Bars/Bars.jsx
+++ b/src/components/Bars/Bars.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { lucidClassNames } from '../../util/style-helpers';
 import { groupByFields } from '../../util/chart-helpers';
 import { createClass } from '../../util/component-types';
-import d3Scale from 'd3-scale';
-import d3Shape from 'd3-shape';
+import * as d3Scale from 'd3-scale';
+import * as d3Shape from 'd3-shape';
 
 import Bar from '../Bar/Bar';
 

--- a/src/components/Bars/Bars.spec.js
+++ b/src/components/Bars/Bars.spec.js
@@ -1,4 +1,4 @@
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 import { common } from '../../util/generic-tests';
 
 import Bars from './Bars';

--- a/src/components/Bars/examples/basic.jsx
+++ b/src/components/Bars/examples/basic.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import Bars from '../Bars';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 const width = 1000;
 const height = 400;

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -8,7 +8,7 @@ import {
 	maxByFieldsStacked,
 	formatDate,
 } from '../../util/chart-helpers';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 import Axis from '../Axis/Axis';
 import AxisLabel from '../AxisLabel/AxisLabel';

--- a/src/components/Lines/Lines.jsx
+++ b/src/components/Lines/Lines.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { lucidClassNames } from '../../util/style-helpers';
 import { createClass } from '../../util/component-types';
 import { groupByFields } from '../../util/chart-helpers';
-import d3Shape from 'd3-shape';
+import * as d3Shape from 'd3-shape';
 
 import Line from '../Line/Line';
 

--- a/src/components/Lines/Lines.spec.js
+++ b/src/components/Lines/Lines.spec.js
@@ -1,4 +1,4 @@
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 import { common } from '../../util/generic-tests';
 
 import Lines from './Lines';

--- a/src/components/Lines/examples/stacked.jsx
+++ b/src/components/Lines/examples/stacked.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import Lines from '../Lines';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 const width = 1000;
 const height = 400;

--- a/src/components/Points/Points.jsx
+++ b/src/components/Points/Points.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { lucidClassNames } from '../../util/style-helpers';
 import { createClass } from '../../util/component-types';
 import { groupByFields } from '../../util/chart-helpers';
-import d3Shape from 'd3-shape';
+import * as d3Shape from 'd3-shape';
 
 import Point from '../Point/Point';
 

--- a/src/components/Points/Points.spec.js
+++ b/src/components/Points/Points.spec.js
@@ -1,4 +1,4 @@
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 import { common } from '../../util/generic-tests';
 
 import Points from './Points';

--- a/src/components/Points/examples/basic.jsx
+++ b/src/components/Points/examples/basic.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import Points from '../Points';
-import d3Scale from 'd3-scale';
+import * as d3Scale from 'd3-scale';
 
 const width = 1000;
 const height = 400;

--- a/src/util/chart-helpers.js
+++ b/src/util/chart-helpers.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import d3TimeFormat from 'd3-time-format';
-import d3Time from 'd3-time';
+import * as d3TimeFormat from 'd3-time-format';
+import * as d3Time from 'd3-time';
 
 /**
  * groupByFields


### PR DESCRIPTION
fixes #320 

- #321 `patch`: fixed a critical breaking change introduced by various downstream d3 libraries

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~

