### PR TITLE
Default chart margins improvement

### DIFF
--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -16,9 +16,6 @@ import Legend from '../Legend/Legend';
 
 const cx = lucidClassNames.bind('&-BarChart');
 
-const PADDING = 0.05;
-const PADDING_GROUPED_OR_STACKED = 0.3;
-
 const {
 	arrayOf,
 	func,
@@ -163,11 +160,22 @@ const BarChart = createClass({
 		yAxisTitleColor: number,
 	},
 
+	statics: {
+		PADDING: 0.05,
+		PADDING_GROUPED_OR_STACKED: 0.3,
+		MARGIN: {
+			top: 10,
+			right: 20,
+			bottom: 50,
+			left: 80,
+		},
+	},
+
 	getDefaultProps() {
 		return {
 			height: 400,
 			width: 1000,
-			margin: {
+			margin: { // duplicated because `statics` aren't available during getDefaultProps
 				top: 10,
 				right: 20,
 				bottom: 50,
@@ -197,7 +205,7 @@ const BarChart = createClass({
 			className,
 			height,
 			width,
-			margin,
+			margin: marginOriginal,
 			data,
 			legend,
 			hasToolTips,
@@ -223,6 +231,11 @@ const BarChart = createClass({
 			...passThroughs,
 		} = this.props;
 
+		const margin = {
+			...BarChart.MARGIN,
+			...marginOriginal,
+		};
+
 		// TODO: Consider displaying something specific when there is no data,
 		// perhaps a loading indicator.
 		if (_.isEmpty(data)) {
@@ -241,8 +254,8 @@ const BarChart = createClass({
 
 		// `paddingInner` determines the space between the bars or groups of bars
 		const paddingInner = yAxisFields.length > 1
-			? PADDING_GROUPED_OR_STACKED
-			: PADDING;
+			? BarChart.PADDING_GROUPED_OR_STACKED
+			: BarChart.PADDING;
 
 		const xScale = d3Scale.scaleBand()
 			.domain(_.map(data, xAxisField))

--- a/src/components/BarChart/examples/5.all-the-things.jsx
+++ b/src/components/BarChart/examples/5.all-the-things.jsx
@@ -16,10 +16,7 @@ export default React.createClass({
 			<BarChart
 				data={data}
 				margin={{
-					top: 5,
-					right: 80,
 					bottom: 100,
-					left: 80,
 				}}
 				hasLegend={true}
 				legend={{

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -229,6 +229,15 @@ const LineChart = createClass({
 		y2AxisTitleColor: number,
 	},
 
+	statics: {
+		MARGIN: {
+			top: 10,
+			right: 80,
+			bottom: 65,
+			left: 80,
+		},
+	},
+
 	getDefaultProps() {
 		return {
 			height: 400,
@@ -279,7 +288,7 @@ const LineChart = createClass({
 			className,
 			height,
 			width,
-			margin,
+			margin: marginOriginal,
 			data,
 			legend,
 			hasToolTips,
@@ -325,6 +334,11 @@ const LineChart = createClass({
 			isHovering,
 			mouseX,
 		} = this.state;
+
+		const margin = {
+			...LineChart.MARGIN,
+			...marginOriginal,
+		};
 
 		// TODO: Consider displaying something specific when there is no data,
 		// perhaps a loading indicator.

--- a/src/components/LineChart/examples/3.dual-axis.jsx
+++ b/src/components/LineChart/examples/3.dual-axis.jsx
@@ -14,10 +14,7 @@ export default React.createClass({
 			<LineChart
 				data={data}
 				margin={{
-					top: 10,
 					right: 80,
-					bottom: 50,
-					left: 80,
 				}}
 
 				yAxisFields={['apples']}

--- a/src/components/LineChart/examples/5.all-the-things.jsx
+++ b/src/components/LineChart/examples/5.all-the-things.jsx
@@ -17,10 +17,8 @@ export default React.createClass({
 		return (
 			<LineChart
 				margin={{
-					top: 10,
 					right: 80,
 					bottom: 100,
-					left: 80,
 				}}
 				data={data}
 				hasLegend={true}


### PR DESCRIPTION
Fixes #325 

`minor`: improved `LineChart` and `BarChart` to merge default margins with the `margin` prop so you can still retain defaults if you only want to override some of them

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

