### PR TITLE
add tabIndex to SingleSelect control

### DIFF
--- a/src/components/SingleSelect/SingleSelect.jsx
+++ b/src/components/SingleSelect/SingleSelect.jsx
@@ -179,12 +179,15 @@ const SingleSelect = createClass({
 				flyOutStyle={_.assign({}, flyOutStyle, !_.isNil(maxMenuHeight) ? { maxHeight: maxMenuHeight } : null)}
 			>
 				<DropMenu.Control>
-					<div className={cx('&-Control', {
-						'&-Control-is-highlighted': (!isDisabled && isItemSelected && isSelectionHighlighted) || (isExpanded && isSelectionHighlighted),
-						'&-Control-is-selected': (!isDisabled && isItemSelected && isSelectionHighlighted) || (isExpanded && isSelectionHighlighted),
-						'&-Control-is-expanded': isExpanded,
-						'&-Control-is-disabled': isDisabled,
-					})}>
+					<div
+						tabIndex={0}
+						className={cx('&-Control', {
+							'&-Control-is-highlighted': (!isDisabled && isItemSelected && isSelectionHighlighted) || (isExpanded && isSelectionHighlighted),
+							'&-Control-is-selected': (!isDisabled && isItemSelected && isSelectionHighlighted) || (isExpanded && isSelectionHighlighted),
+							'&-Control-is-expanded': isExpanded,
+							'&-Control-is-disabled': isDisabled,
+						})
+					}>
 						<span
 							{...(!isItemSelected ? placeholderProps : null)}
 							className={cx(


### PR DESCRIPTION
fixes #194 

- `patch`: fixed `SingleSelect` to allow tabbing (i.e. added tabindex)

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~[ ] One core team UX approval~~
