### PR TITLE
#347: Fixed Paginator bug that was causing textfield to revert to the default value onChange

### DIFF
--- a/src/components/Paginator/Paginator.jsx
+++ b/src/components/Paginator/Paginator.jsx
@@ -117,11 +117,8 @@ const Paginator = createClass({
 		const {
 			onPageSelect,
 			selectedPageIndex,
-			totalCount,
-			pageSizeOptions,
-			selectedPageSizeIndex,
+			totalPages,
 		} = this.props;
-		const totalPages = _.ceil(totalCount/pageSizeOptions[selectedPageSizeIndex]);
 		const parsedPageNum = _.parseInt(pageNum);
 		if (_.isNaN(parsedPageNum)) {
 			return onPageSelect(selectedPageIndex, totalPages);
@@ -173,8 +170,8 @@ const Paginator = createClass({
 				<TextField
 					lazyLevel={100}
 					{...textFieldProps}
-					onBlur={_.partialRight(this.handleTextFieldChange, totalPages)}
-					onSubmit={_.partialRight(this.handleTextFieldChange, totalPages)}
+					onBlur={this.handleTextFieldChange}
+					onSubmit={this.handleTextFieldChange}
 					isDisabled={isDisabled}
 					value={selectedPageIndex + 1}
 				/>

--- a/src/components/Paginator/Paginator.jsx
+++ b/src/components/Paginator/Paginator.jsx
@@ -113,11 +113,15 @@ const Paginator = createClass({
 		};
 	},
 
-	handleTextFieldChange(pageNum, totalPages) {
+	handleTextFieldChange(pageNum) {
 		const {
 			onPageSelect,
 			selectedPageIndex,
+			totalCount,
+			pageSizeOptions,
+			selectedPageSizeIndex,
 		} = this.props;
+		const totalPages = _.ceil(totalCount/pageSizeOptions[selectedPageSizeIndex]);
 		const parsedPageNum = _.parseInt(pageNum);
 		if (_.isNaN(parsedPageNum)) {
 			return onPageSelect(selectedPageIndex, totalPages);

--- a/src/components/Paginator/Paginator.jsx
+++ b/src/components/Paginator/Paginator.jsx
@@ -86,7 +86,7 @@ const Paginator = createClass({
 		TextField: shape(TextField.propTypes),
 		/**
 		 * Called when a page is selected.
-		 * Has the signature `(pageIndex, {props, event}) => {}` where pageIndex is a number.
+		 * Has the signature `(pageIndex, totalPages, {props, event}) => {}` where pageIndex is a number.
 		 */
 		onPageSelect: func,
 		/**
@@ -113,7 +113,7 @@ const Paginator = createClass({
 		};
 	},
 
-	handleTextFieldChange(pageNum) {
+	handleTextFieldChange(pageNum, {props, event}) {
 		const {
 			onPageSelect,
 			selectedPageIndex,
@@ -121,9 +121,9 @@ const Paginator = createClass({
 		} = this.props;
 		const parsedPageNum = _.parseInt(pageNum);
 		if (_.isNaN(parsedPageNum)) {
-			return onPageSelect(selectedPageIndex, totalPages);
+			return onPageSelect(selectedPageIndex, totalPages, {props, event});
 		}
-		return onPageSelect(parsedPageNum - 1, totalPages);
+		return onPageSelect(parsedPageNum - 1, totalPages, {props, event});
 	},
 
 	render() {

--- a/src/components/Paginator/Paginator.spec.jsx
+++ b/src/components/Paginator/Paginator.spec.jsx
@@ -247,8 +247,9 @@ describe('Paginator', () => {
 						const onPageSelect = sinon.spy();
 						wrapper = mount(
 							<Paginator
-								selectedPageIndex={1}
-								totalPages={3}
+								selectedPageIndex={10}
+								totalCount={30}
+								selectedPageSizeIndex={0}
 								onPageSelect={onPageSelect}
 								/>
 						);

--- a/src/components/Paginator/Paginator.spec.jsx
+++ b/src/components/Paginator/Paginator.spec.jsx
@@ -248,8 +248,7 @@ describe('Paginator', () => {
 						wrapper = mount(
 							<Paginator
 								selectedPageIndex={1}
-								totalCount={30}
-								selectedPageSizeIndex={0}
+								totalPages={3}
 								onPageSelect={onPageSelect}
 								/>
 						);

--- a/src/components/Paginator/Paginator.spec.jsx
+++ b/src/components/Paginator/Paginator.spec.jsx
@@ -247,7 +247,7 @@ describe('Paginator', () => {
 						const onPageSelect = sinon.spy();
 						wrapper = mount(
 							<Paginator
-								selectedPageIndex={10}
+								selectedPageIndex={1}
 								totalCount={30}
 								selectedPageSizeIndex={0}
 								onPageSelect={onPageSelect}


### PR DESCRIPTION
fixes #347 

## Notes on fix
`Paginator.handleTextFieldChange` expects `(value, totalPages)`. But instead, is receiving the following from `TextField.onSubmit`: `(value, {event, props: this.props })`.

In `Paginator.reducers.onPageSelect`, `selectedPageIndex` always gets set to `0` ->
`selectedPageIndex: _.clamp(pageIndex, 0, totalPages - 1)`, where `totalPages` is an object, not a number.

The fix was to calculate the correct value for `totalPages` in `Paginator.handleTextFieldChange` based on `totalCount` and `selectedPageSizeIndex` and pass that to `Paginator.reducers.onPageSelect`.

Not 100% sure about this. Do we need to pass the event?

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~