### PR TITLE
DON'T MERGE YET: Add fade animation to ToolTip

### DIFF
--- a/src/components/ToolTip/ToolTip.jsx
+++ b/src/components/ToolTip/ToolTip.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
+import { TransitionMotion, spring } from 'react-motion';
 import ContextMenu from '../ContextMenu/ContextMenu';
 import CrossIcon from '../Icon/CrossIcon/CrossIcon';
 import * as reducers from './ToolTip.reducers';
@@ -182,6 +183,10 @@ const ToolTip = createClass({
 		this.props.onClose({ event, props: this.props });
 	},
 
+	willLeave() {
+		return { opacity: spring(0) };
+	},
+
 	render() {
 		const {
 			className,
@@ -190,6 +195,7 @@ const ToolTip = createClass({
 			flyOutMaxWidth,
 			flyOutStyle,
 			isCloseable,
+			isExpanded,
 			kind,
 			...passThroughs,
 		} = this.props;
@@ -210,6 +216,7 @@ const ToolTip = createClass({
 				direction={direction}
 				directonOffset={15}
 				getAlignmentOffset={getAlignmentOffset}
+				isExpanded={true}
 				{...passThroughs}
 				onMouseOver={this.handleMouseOverTarget}
 				onMouseOut={this.handleMouseOutTarget}
@@ -217,20 +224,37 @@ const ToolTip = createClass({
 				<Target {...targetProps} className={cx(_.get(targetProps, 'className'), '&-Target')}>
 					{_.get(targetProps, 'children')}
 				</Target>
-				<FlyOut
-					style={{
-						...flyOutStyle,
-						maxWidth: flyOutMaxWidth || flyOutStyle.maxWidth || 200,
-					}}
-					className={flyOutCx(className, '&', `&-${direction}`, `&-${alignment}`, `&-${kind}`)}
-					onMouseOver={this.handleMouseOverFlyout}
-					onMouseOut={this.handleMouseOutFlyout}
-				>
-					{isCloseable ? <CrossIcon onClick={this.handleClose} className={flyOutCx('&-close')}/> : null}
-					{!_.isNil(title) ?
-						<h2 className={flyOutCx('&-Title')}>{title}</h2>
-					: null}
-					{body}
+				<FlyOut>
+					<TransitionMotion
+						styles={[{
+							style: { opacity: isExpanded ? spring(1) : spring(0) },
+							key: 'tooltip',
+						}]}
+						defaultStyles={[{
+							style: { opacity: 0 },
+							key: 'tooltip',
+						}]}
+						willLeave={this.willLeave}
+					>
+						{([{style}]) => style.opacity > 0 ?
+							<div
+								style={{
+									...style,
+									...flyOutStyle,
+									maxWidth: flyOutMaxWidth || flyOutStyle.maxWidth || 200,
+								}}
+								className={flyOutCx(className, '&', `&-${direction}`, `&-${alignment}`, `&-${kind}`)}
+								onMouseOver={this.handleMouseOverFlyout}
+								onMouseOut={this.handleMouseOutFlyout}
+							>
+								{isCloseable ? <CrossIcon onClick={this.handleClose} className={flyOutCx('&-close')}/> : null}
+								{!_.isNil(title) ?
+									<h2 className={flyOutCx('&-Title')}>{title}</h2>
+								: null}
+								{body}
+							</div> : null
+						}
+					</TransitionMotion>
 				</FlyOut>
 			</ContextMenu>
 		);

--- a/src/components/ToolTip/ToolTip.less
+++ b/src/components/ToolTip/ToolTip.less
@@ -200,6 +200,7 @@
 	&-up:after,
 	&-up:before {
 		top: 100%;
+		margin-top: -1px;
 	}
 
 	&-up:after {
@@ -209,6 +210,7 @@
 	&-down:after,
 	&-down:before {
 		bottom: 100%;
+		margin-bottom: -1px;
 	}
 
 	&-up&-center:after,
@@ -255,11 +257,13 @@
 	&-left:after,
 	&-left:before {
 		left: 100%;
+		margin-left: -1px;
 	}
 
 	&-right:after,
 	&-right:before {
 		right: 100%;
+		margin-right: -1px;
 	}
 
 	&-left&-center:after,


### PR DESCRIPTION
fixes #294 

I ended up throwing out the `ContextMenu` refactor because it was unnecessary for this implementation. The problem with this implementation is that because `ToolTip` is handling `isExpanded` directly instead of passing it down to `ContextMenu`, it doesn't get the perf optimization that `ContextMenu` does on collapsed components (skipping alignment calculation/repositioning render).

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

http://docspot.devnxs.net/projects/lucid/feature-294-toolip-fade-2/#/components/ToolTip