### PR TITLE
313 autocomplete private / 314 remove caret

### DIFF
--- a/src/components/Autocomplete/Autocomplete.jsx
+++ b/src/components/Autocomplete/Autocomplete.jsx
@@ -5,7 +5,6 @@ import { createClass } from '../../util/component-types';
 import * as reducers from './Autocomplete.reducers';
 import * as KEYCODE from '../../constants/key-code';
 import DropMenu from '../DropMenu/DropMenu';
-import CaretIcon from '../Icon/CaretIcon/CaretIcon';
 
 const cx = lucidClassNames.bind('&-Autocomplete');
 
@@ -20,7 +19,7 @@ const {
 
 /**
  *
- * {"categories": ["controls", "text"], "madeFrom": ["CaretIcon", "DropMenu"]}
+ * {"categories": ["controls", "text"], "madeFrom": ["DropMenu"]}
  *
  * A text input with suggested values displayed in an attached menu.
  */
@@ -211,10 +210,7 @@ const Autocomplete = createClass({
 			...passThroughs,
 		} = this.props;
 
-		const {
-			direction,
-			isExpanded,
-		} = dropMenuProps;
+		const { isExpanded } = dropMenuProps;
 
 		const value = this.getInputValue();
 		const valuePattern = new RegExp(_.escapeRegExp(value), 'i');
@@ -241,7 +237,6 @@ const Autocomplete = createClass({
 							onKeyDown={this.handleInputKeydown}
 							disabled={isDisabled}
 						/>
-						<CaretIcon direction={isExpanded ? direction : 'down'} />
 					</div>
 				</DropMenu.Control>
 				{value ? _.map(suggestions, (suggestion) => (

--- a/src/components/Autocomplete/Autocomplete.jsx
+++ b/src/components/Autocomplete/Autocomplete.jsx
@@ -28,6 +28,8 @@ const {
 const Autocomplete = createClass({
 	displayName: 'Autocomplete',
 
+	_lucidIsPrivate: true,
+
 	reducers,
 
 	propTypes: {


### PR DESCRIPTION
fixes #313
fixes #314 

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - ~~[ ] Firefox~~
  - ~~[ ] Safari~~
  - ~~[ ] IE11 (Win 7)~~
  - ~~[ ] Edge (Win 10)~~
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

http://docspot.devnxs.net/projects/lucid/313-autocomplete-private/#/components/Autocomplete