### PR TITLE
default Button type='button' - to avoid accidental trigger onEnter elsewhere

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -71,6 +71,10 @@ const Button = createClass({
 		 * Signature: `({ event, props }) => {}`
 		 */
 		onClick: func,
+		/**
+		 * form element type variations of button. Defaults to 'button' to avoid being triggered by 'Enter' anywhere on the page. Passed through to DOM button.
+		 */
+		type: string,
 	},
 
 	getDefaultProps() {
@@ -78,6 +82,7 @@ const Button = createClass({
 			isDisabled: false,
 			isActive: false,
 			onClick: _.noop,
+			type: 'button',
 		};
 	},
 
@@ -103,6 +108,7 @@ const Button = createClass({
 			size,
 			className,
 			children,
+			type,
 			...passThroughs,
 		} = this.props;
 
@@ -125,6 +131,7 @@ const Button = createClass({
 				onClick={this.handleClick}
 				disabled={isDisabled}
 				ref='button'
+				type={type}
 			>
 				<span className={cx('&-content')}>
 					{children}

--- a/src/components/Button/Button.spec.jsx
+++ b/src/components/Button/Button.spec.jsx
@@ -50,6 +50,18 @@ describe('Button', () => {
 			assert(_.includes(classNames, 'lucid-Button-is-active'), `'${classNames}' should include 'lucid-Button-is-active'`);
 		});
 	});
+
+	describe('type', () => {
+		it('should be a button type by default', () => {
+			const wrapper = shallow(<Button />);
+			assert.equal(wrapper.find('button').prop('type'), 'button');
+		});
+
+		it('should passthrough button type property', () => {
+			const wrapper = shallow(<Button type='submit' />);
+			assert.equal(wrapper.find('button').prop('type'), 'submit');
+		});
+	});
 });
 
 describeWithDOM('Button', () => {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

…ing Enter key on the page