### PR TITLE
Fixes #374 - remove maxWidth on chart tooltips

### DIFF
--- a/src/components/Bars/Bars.jsx
+++ b/src/components/Bars/Bars.jsx
@@ -237,7 +237,12 @@ const Bars = createClass({
 						))}
 
 						{hasToolTips ?
-							<ToolTip isExpanded={isHovering && hoveringSeriesIndex === seriesIndex}>
+							<ToolTip
+								isExpanded={isHovering && hoveringSeriesIndex === seriesIndex}
+								flyOutStyle={{
+									maxWidth: 'none',
+								}}
+							>
 								<ToolTip.Target elementType='g'>
 									<rect
 										className={cx('&-tooltip-hover-zone')}

--- a/src/components/Legend/Legend.less
+++ b/src/components/Legend/Legend.less
@@ -39,6 +39,7 @@
 	}
 
 	&-Item-indicator {
+		flex: 1 0 auto;
 		margin-right: @size-XS;
 	}
 }

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -458,7 +458,12 @@ const LineChart = createClass({
 				{/* tooltips */}
 				<g transform={`translate(${margin.left}, ${margin.top})`}>
 					{hasToolTips && isHovering && !_.isNil(mouseX) ?
-						<ToolTip isExpanded={true}>
+						<ToolTip
+							isExpanded={true}
+							flyOutStyle={{
+								maxWidth: 'none',
+							}}
+						>
 							<ToolTip.Target elementType='g'>
 								<path
 									className={cx('&-tooltip-line')}


### PR DESCRIPTION
`patch`: fixed an issue with tooltips and long field names on `BarChart` and `LineChart` by removing the max-width property on the underlying `ToolTip`

Fixes #374 

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~Unit tests written (`common` at minimum)~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

