### PR TITLE
Check tests for .only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+before_install: bash ./scripts/validate-tests.sh
 after_success: bash ./scripts/docs-upload-gh.sh
 branches:
   only:

--- a/scripts/validate-tests.sh
+++ b/scripts/validate-tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# exit with nonzero exit code if anything fails
+set -e
+
+! grep -r --include "*.spec.*" "\.only" src


### PR DESCRIPTION
This adds a check in travis for `.spec.` files that contain `.only` in them. It should fail the build before even installing any npm packages.

Fixes #415 