### PR TITLE
fix wrapping of Button contents

### DIFF
--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -27,6 +27,8 @@
 	-webkit-appearance: button; /* 2 */
 	// end normalize
 
+	white-space: nowrap;
+
 	// don't show Firefox's focus ring: https://github.com/appnexus/lucid/issues/292
 	&::-moz-focus-inner {
 		border: 0;


### PR DESCRIPTION
fixes #324 

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

http://docspot.devnxs.net/projects/lucid/324-button-wrapping/#/components/Button