### PR TITLE
Switch ChevronIcon to fill

### DIFF
--- a/src/components/Expander/Expander.less
+++ b/src/components/Expander/Expander.less
@@ -26,7 +26,7 @@
 				outline: none;
 
 				.lucid-ChevronIcon {
-					stroke: @color-darkGray;
+					fill: @color-darkGray;
 				}
 			}
 

--- a/src/components/ExpanderPanel/ExpanderPanel.less
+++ b/src/components/ExpanderPanel/ExpanderPanel.less
@@ -26,7 +26,7 @@
 				outline: none;
 
 				.lucid-ChevronIcon {
-					stroke: @color-darkGray;
+					fill: @color-darkGray;
 				}
 			}
 		}

--- a/src/components/Icon/ChevronIcon/ChevronIcon.jsx
+++ b/src/components/Icon/ChevronIcon/ChevronIcon.jsx
@@ -57,7 +57,7 @@ const ChevronIcon = createClass({
 				}, className)}
 				size={size}
 			>
-				<path d='M3,6 L8,11 L13,6' strokeWidth='2' strokeLinejoin='round' />
+				<path d='M12.293,5.293 L13.707,6.707 L8.707,11.707 C8.317,12.098 7.683,12.098 7.293,11.707 L2.293,6.707 L3.707,5.293 L8,9.586 L12.293,5.293 z' />
 			</Icon>
 		);
 	},

--- a/src/components/Icon/ChevronIcon/ChevronIcon.less
+++ b/src/components/Icon/ChevronIcon/ChevronIcon.less
@@ -1,6 +1,5 @@
 .lucid-ChevronIcon {
-	fill: none;
-	stroke: @color-primary;
+	fill: @color-primary;
 
 	&-is-down { transform: rotate(0deg) }
 	&-is-up { transform: rotate(180deg) }
@@ -8,6 +7,6 @@
 	&-is-right { transform: rotate(270deg) }
 
 	&.lucid-Icon-is-badge {
-		stroke: @color-white;
+		fill: @color-white;
 	}
 }

--- a/src/components/Sidebar/Sidebar.less
+++ b/src/components/Sidebar/Sidebar.less
@@ -90,7 +90,7 @@
 					}
 
 					.lucid-ChevronIcon {
-						stroke: @color-darkGray;
+						fill: @color-darkGray;
 					}
 				}
 			}

--- a/src/components/VerticalListMenu/VerticalListMenu.less
+++ b/src/components/VerticalListMenu/VerticalListMenu.less
@@ -83,7 +83,7 @@
 					outline: none;
 
 					.lucid-ChevronIcon {
-						stroke: @color-darkGray;
+						fill: @color-darkGray;
 					}
 				}
 			}


### PR DESCRIPTION
- Fixes #399 
- Fixed all the usages of ChevronIcon to work with `fill` instead of `stroke`
- The bottom of the ChevronIcon wasn't properly rounded, I fixed that too

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~

