### PR TITLE
Add `onResizing` event handler to SplitVertical and Sidebar.

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -70,6 +70,12 @@ const Sidebar = createClass({
 		 */
 		Title: any,
 		/**
+		 * Called when the user is currently resizing the Sidebar.
+		 *
+		 * Signature: `(width, { event, props }) => {}`
+		 */
+		onResizing: func,
+		/**
 		 * Called when the user resizes the Sidebar.
 		 *
 		 * Signature: `(width, { event, props }) => {}`
@@ -132,6 +138,7 @@ const Sidebar = createClass({
 			width: 250,
 			position: 'left',
 			isResizeDisabled: false,
+			onResizing: _.noop,
 			onResize: _.noop,
 			onToggle: _.noop,
 		};
@@ -143,6 +150,14 @@ const Sidebar = createClass({
 		} = this.props;
 
 		onToggle({ props: this.props, event });
+	},
+
+	handleResizing(width, { event }) {
+		const {
+			onResizing,
+		} = this.props;
+
+		onResizing(width, { props: this.props, event });
 	},
 
 	handleResize(width, { event }) {
@@ -193,6 +208,7 @@ const Sidebar = createClass({
 				isAnimated={isAnimated}
 				isExpanded={isExpanded}
 				collapseShift={33} // leave 33px of sidebar to stick out when collapsed
+				onResizing={this.handleResizing}
 				onResize={this.handleResize}
 			>
 				<BarPane {...omitProps(barProps, Sidebar.Bar)} className={cx('&-Bar', barProps.className)} width={width}>

--- a/src/components/Sidebar/Sidebar.spec.jsx
+++ b/src/components/Sidebar/Sidebar.spec.jsx
@@ -209,6 +209,27 @@ describe('Sidebar', () => {
 			});
 		});
 
+		describe('onResizing', () => {
+			it('should be called when onResizing event handler is called on SplitVertical', () => {
+				const onResizing = sinon.spy();
+				const wrapper = shallow(
+					<Sidebar onResizing={onResizing} />
+				);
+				const splitVertical = wrapper.find(SplitVertical);
+				const splitVerticalOnResize = splitVertical.prop('onResizing');
+				const lastArg = {
+					event: {},
+					props: wrapper.props(),
+				};
+
+				splitVerticalOnResize(123, lastArg);
+
+				assert(onResizing.called, 'must be called');
+				assert.equal(123, onResizing.lastCall.args[0], 'must pass the new width in the first arg');
+				assert.equal(lastArg.event, onResizing.lastCall.args[1].event, 'must pass event in the last arg');
+			});
+		});
+
 		describe('onResize', () => {
 			it('should be called when onResize event handler is called on SplitVertical', () => {
 				const onResize = sinon.spy();

--- a/src/components/Sidebar/examples/8.handle-toggle-and-resize.jsx
+++ b/src/components/Sidebar/examples/8.handle-toggle-and-resize.jsx
@@ -13,6 +13,10 @@ export default React.createClass({
 		this.setState({ isExpanded: !this.state.isExpanded });
 	},
 
+	handleResizing(width) {
+		this.setState({ resizeWidth: width });
+	},
+
 	handleResize(width) {
 		this.setState({ resizeWidth: width });
 	},
@@ -23,7 +27,7 @@ export default React.createClass({
 				<p>isExpanded: {`${this.state.isExpanded}`}</p>
 				<p>resizeWidth: {`${this.state.resizeWidth}`}</p>
 
-				<Sidebar onResize={this.handleResize} onToggle={this.handleToggle}>
+				<Sidebar onResizing={this.handleResizing} onResize={this.handleResize} onToggle={this.handleToggle}>
 					<Sidebar.Bar>
 						Non cliche minim normcore ullamco, iPhone etsy banh mi farm-to-table mumblecore stumptown asymmetrical wolf pour-over odio.
 					</Sidebar.Bar>

--- a/src/components/SplitVertical/SplitVertical.jsx
+++ b/src/components/SplitVertical/SplitVertical.jsx
@@ -46,6 +46,12 @@ const SplitVertical = createClass({
 		 */
 		isAnimated: bool,
 		/**
+		 * Called when the user is currently resizing the split with the Divider.
+		 *
+		 * Signature: `(width, { event, props }) => {}`
+		 */
+		onResizing: func,
+		/**
 		 * Called when the user resizes the split with the Divider.
 		 *
 		 * Signature: `(width, { event, props }) => {}`
@@ -129,6 +135,7 @@ const SplitVertical = createClass({
 			isExpanded: true,
 			isAnimated: false,
 			collapseShift: 0,
+			onResizing: _.noop,
 			onResize: _.noop,
 		};
 	},
@@ -231,10 +238,11 @@ const SplitVertical = createClass({
 		this.disableAnimation(this.refs.inner, secondaryRef, primaryRef);
 	},
 
-	handleDrag({ dX }) {
+	handleDrag({ dX }, { event }) {
 		const {
 			isExpanded,
 			collapseShift,
+			onResizing,
 		} = this.props;
 
 		const {
@@ -244,7 +252,10 @@ const SplitVertical = createClass({
 			primaryRef,
 		} = this.panes;
 
-		this.applyDeltaToSecondaryWidth(dX, isExpanded, this.secondaryStartRect, secondaryRef, secondary, right, this.refs.inner, primaryRef, collapseShift);
+		onResizing(
+			this.applyDeltaToSecondaryWidth(dX, isExpanded, this.secondaryStartRect, secondaryRef, secondary, right, this.refs.inner, primaryRef, collapseShift),
+			{ props: this.props, event }
+		)
 	},
 
 	handleDragEnd({ dX }, { event }) {

--- a/src/components/SplitVertical/SplitVertical.spec.jsx
+++ b/src/components/SplitVertical/SplitVertical.spec.jsx
@@ -154,6 +154,51 @@ describe('SplitVertical', () => {
 
 		});
 
+		describeWithDOM('onResizing', () => {
+			let wrapper;
+			let mountTestDiv;
+
+			beforeEach(() => {
+				mountTestDiv = document.createElement('div');
+				document.body.appendChild(mountTestDiv);
+			});
+
+			afterEach(() => {
+				if (wrapper) {
+					wrapper.unmount();
+				}
+
+				if (mountTestDiv) {
+					mountTestDiv.parentNode.removeChild(mountTestDiv);
+				}
+			});
+
+			it('should be called when the DragCaptureZone calls the onDrag event handler', () => {
+				const onResizing = sinon.spy();
+
+				wrapper = mount(
+					<SplitVertical isExpanded={true} onResizing={onResizing} />
+				, { attachTo: mountTestDiv });
+
+				const {
+					onDragStart,
+					onDrag,
+					onDragEnd,
+				} = wrapper.find(DragCaptureZone).props();
+
+				const lastArg = { event: {} };
+
+				onDragStart(lastArg);
+				onDrag({dX: 122}, lastArg);
+				onDragEnd({dX: 123}, lastArg);
+
+				assert(onResizing.called, 'must be called');
+				assert.equal(onResizing.lastCall.args[0], 122, 'must pass the new width of the pane');
+				assert.equal(onResizing.lastCall.args[1].props, wrapper.props(), 'must pass component props in the last arg');
+				assert.equal(onResizing.lastCall.args[1].event, lastArg.event, 'must pass event reference in the last arg');
+			});
+		});
+
 		describeWithDOM('onResize', () => {
 			let wrapper;
 			let mountTestDiv;
@@ -189,7 +234,7 @@ describe('SplitVertical', () => {
 				const lastArg = { event: {} };
 
 				onDragStart(lastArg);
-				onDrag({dX: 123}, lastArg);
+				onDrag({dX: 122}, lastArg);
 				onDragEnd({dX: 123}, lastArg);
 
 				assert(onResize.called, 'must be called');


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

Fixes #422