### PR TITLE
Remove button icon content offset when the icon is the only child

### DIFF
--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -45,6 +45,9 @@
 		> .lucid-Icon {
 			margin-left: -1em/2;
 			transition: color 0.1s, fill 0.1s;
+			&:only-child {
+				margin-left: 0;
+			}
 		}
 		> span {
 			transition: color 0.1s, fill 0.1s;

--- a/src/components/Button/examples/basic.jsx
+++ b/src/components/Button/examples/basic.jsx
@@ -7,7 +7,8 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button>Default</Button>
-					<Button><CheckIcon /> has icon</Button>
+					<Button><CheckIcon /></Button>
+					<Button><CheckIcon /> has icon and text</Button>
 					<Button isDisabled={true}>is disabled</Button>
 					<Button isActive={true}>is active</Button>
 				</article>


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

