### PR TITLE
Button icons fix

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -28,26 +28,31 @@ const Button = createClass({
 	propName: 'Button',
 	propTypes: {
 		/**
-		 * disables the button by greying it out
+		 * Disables the Button by greying it out
 		 */
 		isDisabled: bool,
 		/**
-		 * activates the button by giving it a "pressed down" look
+		 * Activates the Button by giving it a "pressed down" look
 		 */
 		isActive: bool,
 		/**
-		 * class names that are appended to the defaults
+		 * Class names that are appended to the defaults
 		 */
 		className: string,
 		/**
-		 * any valid React children
+		 * Set this to `true` if you want the Button to only contain
+		 * an icon.
+		 */
+		hasOnlyIcon: bool,
+		/**
+		 * Any valid React children
 		 */
 		children: oneOfType([
 			node,
 			arrayOf(node),
 		]),
 		/**
-		 * style variations of the button
+		 * Style variations of the Button
 		 */
 		kind: oneOf([
 			'primary',
@@ -58,7 +63,7 @@ const Button = createClass({
 			'info',
 		]),
 		/**
-		 * size variations of the button
+		 * Size variations of the Button
 		 */
 		size: oneOf([
 			'short',
@@ -72,7 +77,9 @@ const Button = createClass({
 		 */
 		onClick: func,
 		/**
-		 * form element type variations of button. Defaults to 'button' to avoid being triggered by 'Enter' anywhere on the page. Passed through to DOM button.
+		 * Form element type variations of Button. Defaults to 'button' to avoid
+		 * being triggered by 'Enter' anywhere on the page. Passed through to DOM
+		 * Button.
 		 */
 		type: string,
 	},
@@ -83,6 +90,7 @@ const Button = createClass({
 			isActive: false,
 			onClick: _.noop,
 			type: 'button',
+			hasOnlyIcon: false,
 		};
 	},
 
@@ -104,6 +112,7 @@ const Button = createClass({
 		const {
 			isDisabled,
 			isActive,
+			hasOnlyIcon,
 			kind,
 			size,
 			className,
@@ -127,6 +136,7 @@ const Button = createClass({
 					'&-short': size === 'short',
 					'&-small': size === 'small',
 					'&-large': size === 'large',
+					'&-has-only-icon': hasOnlyIcon,
 				}, className)}
 				onClick={this.handleClick}
 				disabled={isDisabled}

--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -124,6 +124,12 @@
 			}
 		}
 	}
+	&&-link&-has-only-icon {
+		// Clear the right margin, only need it if the has text with it
+		.lucid-Icon {
+			margin-right: 0;
+		}
+	}
 
 	// Sizes
 	&&-short {

--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -36,6 +36,10 @@
 
 	&:before {border-radius: @Button-size-borderRadius;}
 
+	&&-has-only-icon {
+		padding: 0 5px;
+	}
+
 	& &-content {
 		display: flex;
 		justify-content: center;
@@ -44,14 +48,6 @@
 
 		> .lucid-Icon {
 			transition: color @timing-animation-hover, fill @timing-animation-hover;
-
-			// Bascially a hack to get the buttons to be square when there's only an
-			// icon in them. Went with this approach since it's css only. Obviously
-			// the negative margin and the hard coded value is pretty bad, but it
-			// should suffice unless we make large changes to our buttons.
-			&:only-child {
-				margin: 0 -7px;
-			}
 		}
 		> span {
 			transition: color @timing-animation-hover, fill @timing-animation-hover;
@@ -137,6 +133,9 @@
 		height: @Button-size-height-small;
 		padding: 0 @Button-size-padding/1.5;
 	}
+	&&-small&-has-only-icon {
+		padding: 0 1px;
+	}
 	&&-large {
 		height: @Button-size-height-large;
 		padding: 0 @Button-size-padding*1.5;
@@ -146,14 +145,9 @@
 			width: 1.2em;
 			height: 1.2em;
 		}
-
-		// Basically a hack to get the buttons to be square when there's only an
-		// icon in them. Went with this approach since it's css only. Obviously the
-		// negative margin and the hard coded value is pretty bad, but it should
-		// suffice unless we make large changes to our buttons.
-		> .lucid-Button-content > .lucid-Icon:only-child {
-			margin: 0 -10px;
-		}
+	}
+	&&-large&-has-only-icon {
+		padding: 0 8px;
 	}
 
 	// States

--- a/src/components/Button/Button.spec.jsx
+++ b/src/components/Button/Button.spec.jsx
@@ -49,6 +49,11 @@ describe('Button', () => {
 			let classNames = wrapper.find('button').prop('className').split(' ');
 			assert(_.includes(classNames, 'lucid-Button-is-active'), `'${classNames}' should include 'lucid-Button-is-active'`);
 		});
+
+		it('should have a button with the "has-only-icon" class when hasOnlyIcon is true', () => {
+			const wrapper = shallow(<Button hasOnlyIcon={true} />);
+			assert(wrapper.hasClass('lucid-Button-has-only-icon'));
+		});
 	});
 
 	describe('type', () => {

--- a/src/components/Button/examples/basic.jsx
+++ b/src/components/Button/examples/basic.jsx
@@ -8,21 +8,28 @@ export default React.createClass({
 				<article>
 					<Button>Default</Button>
 					<Button><CheckIcon /> has icon</Button>
+					<Button hasOnlyIcon={true}><CheckIcon /></Button>
 					<Button isDisabled={true}>is disabled</Button>
 					<Button isActive={true}>is active</Button>
 				</article>
 				<article>
 					<Button size='short'>short</Button>
+					<Button size='short'><CheckIcon /> has icon</Button>
+					<Button size='short' hasOnlyIcon={true}><CheckIcon /></Button>
 					<Button size='short' isDisabled={true}>short is disabled</Button>
 					<Button size='short' isActive={true}>short is active</Button>
 				</article>
 				<article>
 					<Button size='small'>small</Button>
+					<Button size='small'><CheckIcon /> has icon</Button>
+					<Button size='small' hasOnlyIcon={true}><CheckIcon /></Button>
 					<Button size='small' isDisabled={true}>small is disabled</Button>
 					<Button size='small' isActive={true}>small is active</Button>
 				</article>
 				<article>
 					<Button size='large'>large</Button>
+					<Button size='large'><CheckIcon /> has icon</Button>
+					<Button size='large' hasOnlyIcon={true}><CheckIcon /></Button>
 					<Button size='large'><CheckIcon /> large has icon</Button>
 					<Button size='large' isDisabled={true}>large is disabled</Button>
 					<Button size='large' isActive={true}>large is active</Button>

--- a/src/components/Button/examples/basic.jsx
+++ b/src/components/Button/examples/basic.jsx
@@ -7,32 +7,31 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button>Default</Button>
-					<Button><CheckIcon /> has icon</Button>
+					<Button><CheckIcon />Default</Button>
 					<Button hasOnlyIcon={true}><CheckIcon /></Button>
-					<Button isDisabled={true}>is disabled</Button>
-					<Button isActive={true}>is active</Button>
+					<Button isDisabled={true}>Default disabled</Button>
+					<Button isActive={true}>Default active</Button>
 				</article>
 				<article>
-					<Button size='short'>short</Button>
-					<Button size='short'><CheckIcon /> has icon</Button>
+					<Button size='short'>Short</Button>
+					<Button size='short'><CheckIcon />Short</Button>
 					<Button size='short' hasOnlyIcon={true}><CheckIcon /></Button>
-					<Button size='short' isDisabled={true}>short is disabled</Button>
-					<Button size='short' isActive={true}>short is active</Button>
+					<Button size='short' isDisabled={true}>Short disabled</Button>
+					<Button size='short' isActive={true}>Short active</Button>
 				</article>
 				<article>
-					<Button size='small'>small</Button>
-					<Button size='small'><CheckIcon /> has icon</Button>
+					<Button size='small'>Small</Button>
+					<Button size='small'><CheckIcon />Small</Button>
 					<Button size='small' hasOnlyIcon={true}><CheckIcon /></Button>
-					<Button size='small' isDisabled={true}>small is disabled</Button>
-					<Button size='small' isActive={true}>small is active</Button>
+					<Button size='small' isDisabled={true}>Small disabled</Button>
+					<Button size='small' isActive={true}>Small active</Button>
 				</article>
 				<article>
-					<Button size='large'>large</Button>
-					<Button size='large'><CheckIcon /> has icon</Button>
+					<Button size='large'>Large</Button>
+					<Button size='large'><CheckIcon />Large</Button>
 					<Button size='large' hasOnlyIcon={true}><CheckIcon /></Button>
-					<Button size='large'><CheckIcon /> large has icon</Button>
-					<Button size='large' isDisabled={true}>large is disabled</Button>
-					<Button size='large' isActive={true}>large is active</Button>
+					<Button size='large' isDisabled={true}>Large disabled</Button>
+					<Button size='large' isActive={true}>Large active</Button>
 				</article>
 			</section>
 		);

--- a/src/components/Button/examples/danger.jsx
+++ b/src/components/Button/examples/danger.jsx
@@ -7,19 +7,19 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button kind='danger'>Danger</Button>
-					<Button kind='danger' isDisabled={true}>is disabled</Button>
+					<Button kind='danger' isDisabled={true}>Disabled</Button>
 				</article>
 				<article>
-					<Button kind='danger' size='short'>short</Button>
-					<Button kind='danger' size='short' isDisabled={true}>short is disabled</Button>
+					<Button kind='danger' size='short'>Short</Button>
+					<Button kind='danger' size='short' isDisabled={true}>Short disabled</Button>
 				</article>
 				<article>
-					<Button kind='danger' size='small'>small</Button>
-					<Button kind='danger' size='small' isDisabled={true}>small is disabled</Button>
+					<Button kind='danger' size='small'>Small</Button>
+					<Button kind='danger' size='small' isDisabled={true}>Small disabled</Button>
 				</article>
 				<article>
-					<Button kind='danger' size='large'>large</Button>
-					<Button kind='danger' size='large' isDisabled={true}>large is disabled</Button>
+					<Button kind='danger' size='large'>Large</Button>
+					<Button kind='danger' size='large' isDisabled={true}>Large disabled</Button>
 				</article>
 			</section>
 		);

--- a/src/components/Button/examples/info.jsx
+++ b/src/components/Button/examples/info.jsx
@@ -7,19 +7,19 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button kind='info'>Info</Button>
-					<Button kind='info' isDisabled={true}>is disabled</Button>
+					<Button kind='info' isDisabled={true}>Disabled</Button>
 				</article>
 				<article>
-					<Button kind='info' size='short'>short</Button>
-					<Button kind='info' size='short' isDisabled={true}>short is disabled</Button>
+					<Button kind='info' size='short'>Short</Button>
+					<Button kind='info' size='short' isDisabled={true}>Short disabled</Button>
 				</article>
 				<article>
-					<Button kind='info' size='small'>small</Button>
-					<Button kind='info' size='small' isDisabled={true}>small is disabled</Button>
+					<Button kind='info' size='small'>Small</Button>
+					<Button kind='info' size='small' isDisabled={true}>Small disabled</Button>
 				</article>
 				<article>
-					<Button kind='info' size='large'>large</Button>
-					<Button kind='info' size='large' isDisabled={true}>large is disabled</Button>
+					<Button kind='info' size='large'>Large</Button>
+					<Button kind='info' size='large' isDisabled={true}>Large disabled</Button>
 				</article>
 			</section>
 		);

--- a/src/components/Button/examples/link.jsx
+++ b/src/components/Button/examples/link.jsx
@@ -7,8 +7,9 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button kind='link'>Link</Button>
-					<Button kind='link' isDisabled={true}>Link is disabled</Button>
-					<Button kind='link'><PlusIcon />Link has icon</Button>
+					<Button kind='link' isDisabled={true}>Link disabled</Button>
+					<Button kind='link'><PlusIcon />Link</Button>
+					<Button kind='link' hasOnlyIcon ><PlusIcon /></Button>
 				</article>
 			</section>
 		);

--- a/src/components/Button/examples/primary.jsx
+++ b/src/components/Button/examples/primary.jsx
@@ -7,19 +7,19 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button kind='primary'>Primary</Button>
-					<Button kind='primary' isDisabled={true}>is disabled</Button>
+					<Button kind='primary' isDisabled={true}>Disabled</Button>
 				</article>
 				<article>
-					<Button kind='primary' size='short'>short</Button>
-					<Button kind='primary' size='short' isDisabled={true}>short is disabled</Button>
+					<Button kind='primary' size='short'>Short</Button>
+					<Button kind='primary' size='short' isDisabled={true}>Short disabled</Button>
 				</article>
 				<article>
-					<Button kind='primary' size='small'>small</Button>
-					<Button kind='primary' size='small' isDisabled={true}>small is disabled</Button>
+					<Button kind='primary' size='small'>Small</Button>
+					<Button kind='primary' size='small' isDisabled={true}>Small disabled</Button>
 				</article>
 				<article>
-					<Button kind='primary' size='large'>large</Button>
-					<Button kind='primary' size='large' isDisabled={true}>large is disabled</Button>
+					<Button kind='primary' size='large'>Large</Button>
+					<Button kind='primary' size='large' isDisabled={true}>Large disabled</Button>
 				</article>
 			</section>
 		);

--- a/src/components/Button/examples/success.jsx
+++ b/src/components/Button/examples/success.jsx
@@ -7,19 +7,19 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button kind='success'>Success</Button>
-					<Button kind='success' isDisabled={true}>is disabled</Button>
+					<Button kind='success' isDisabled={true}>Disabled</Button>
 				</article>
 				<article>
-					<Button kind='success' size='short'>short</Button>
-					<Button kind='success' size='short' isDisabled={true}>short is disabled</Button>
+					<Button kind='success' size='short'>Short</Button>
+					<Button kind='success' size='short' isDisabled={true}>Short disabled</Button>
 				</article>
 				<article>
-					<Button kind='success' size='small'>small</Button>
-					<Button kind='success' size='small' isDisabled={true}>small is disabled</Button>
+					<Button kind='success' size='small'>Small</Button>
+					<Button kind='success' size='small' isDisabled={true}>Small disabled</Button>
 				</article>
 				<article>
-					<Button kind='success' size='large'>large</Button>
-					<Button kind='success' size='large' isDisabled={true}>large is disabled</Button>
+					<Button kind='success' size='large'>Large</Button>
+					<Button kind='success' size='large' isDisabled={true}>Large disabled</Button>
 				</article>
 			</section>
 		);

--- a/src/components/Button/examples/warning.jsx
+++ b/src/components/Button/examples/warning.jsx
@@ -7,19 +7,19 @@ export default React.createClass({
 			<section>
 				<article>
 					<Button kind='warning'>Warning</Button>
-					<Button kind='warning' isDisabled={true}>is disabled</Button>
+					<Button kind='warning' isDisabled={true}>Disabled</Button>
 				</article>
 				<article>
-					<Button kind='warning' size='short'>short</Button>
-					<Button kind='warning' size='short' isDisabled={true}>short is disabled</Button>
+					<Button kind='warning' size='short'>Short</Button>
+					<Button kind='warning' size='short' isDisabled={true}>Short disabled</Button>
 				</article>
 				<article>
-					<Button kind='warning' size='small'>small</Button>
-					<Button kind='warning' size='small' isDisabled={true}>small is disabled</Button>
+					<Button kind='warning' size='small'>Small</Button>
+					<Button kind='warning' size='small' isDisabled={true}>Small disabled</Button>
 				</article>
 				<article>
-					<Button kind='warning' size='large'>large</Button>
-					<Button kind='warning' size='large' isDisabled={true}>large is disabled</Button>
+					<Button kind='warning' size='large'>Large</Button>
+					<Button kind='warning' size='large' isDisabled={true}>Large disabled</Button>
 				</article>
 			</section>
 		);

--- a/src/components/Paginator/Paginator.jsx
+++ b/src/components/Paginator/Paginator.jsx
@@ -164,6 +164,7 @@ const Paginator = createClass({
 				<Button
 					onClick={_.partial(onPageSelect, selectedPageIndex - 1, totalPages)}
 					isDisabled={isDisabled || selectedPageIndex === 0}
+					hasOnlyIcon
 				>
 					<ArrowIcon direction='left'/>
 				</Button>
@@ -179,6 +180,7 @@ const Paginator = createClass({
 				<Button
 					onClick={_.partial(onPageSelect, selectedPageIndex + 1, totalPages)}
 					isDisabled={isDisabled || selectedPageIndex === totalPages - 1}
+					hasOnlyIcon
 				>
 					<ArrowIcon direction='right'/>
 				</Button>

--- a/src/components/Paginator/Paginator.less
+++ b/src/components/Paginator/Paginator.less
@@ -30,7 +30,6 @@
 	.lucid-Button {
 		.lucid-Button-content {
 			&> .lucid-Icon {
-				margin-right: -.5em;
 				fill: @color-textColor;
 			}
 		}

--- a/src/docs/containers/icons.jsx
+++ b/src/docs/containers/icons.jsx
@@ -67,16 +67,16 @@ const Icons = React.createClass({
 					<section className={cx('&-buttons')}>
 						{_.map(icons, ([name, Icon]) => (
 							<div className={cx('&-buttons-section')} key={name}>
-								<Button size='short'><Icon /></Button>
-								<Button size='small'><Icon /></Button>
-								<Button ><Icon /></Button>
-								<Button isActive ><Icon /></Button>
-								<Button size='large'><Icon /></Button>
-								<Button kind='primary' size='short'><Icon /></Button>
-								<Button kind='primary' size='small'><Icon /></Button>
-								<Button kind='primary' ><Icon /></Button>
-								<Button kind='primary' isActive ><Icon /></Button>
-								<Button kind='primary' size='large'><Icon /></Button>
+								<Button hasOnlyIcon size='short'><Icon /></Button>
+								<Button hasOnlyIcon size='small'><Icon /></Button>
+								<Button hasOnlyIcon ><Icon /></Button>
+								<Button hasOnlyIcon isActive ><Icon /></Button>
+								<Button hasOnlyIcon size='large'><Icon /></Button>
+								<Button hasOnlyIcon kind='primary' size='short'><Icon /></Button>
+								<Button hasOnlyIcon kind='primary' size='small'><Icon /></Button>
+								<Button hasOnlyIcon kind='primary' ><Icon /></Button>
+								<Button hasOnlyIcon kind='primary' isActive ><Icon /></Button>
+								<Button hasOnlyIcon kind='primary' size='large'><Icon /></Button>
 							</div>
 						))}
 					</section>


### PR DESCRIPTION
`patch`: fixed issue with buttons that had an icon and text nodes as siblings that were incorrectly styled with react 15. Added a new prop to `Button` called `hasOnlyIcon` that can be flipped on for buttons that should only contain a single icon.

Fixes #441

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~
