### PR TITLE
 bugfix/456: add whitespace 'nowrap' for SingleSelect

### DIFF
--- a/src/components/SingleSelect/SingleSelect.less
+++ b/src/components/SingleSelect/SingleSelect.less
@@ -18,6 +18,7 @@
 		line-height: @size-standard-height;
 		padding: 0 @size-standard;
 		align-items: center;
+		white-space: nowrap;
 
 		&-content {
 			display: flex;

--- a/src/components/SingleSelect/examples/07.max-menu-height.jsx
+++ b/src/components/SingleSelect/examples/07.max-menu-height.jsx
@@ -94,7 +94,7 @@ export default React.createClass({
 					<Option>Linen</Option>
 					<Option>Magenta</Option>
 					<Option>Maroon</Option>
-					<Option>Mediumaquamarine</Option>
+					<Option>Medium aquamarine</Option>
 					<Option>Mediumblue</Option>
 					<Option>Mediumorchid</Option>
 					<Option>Mediumpurple</Option>


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~

