### PR TITLE
Pass thru className from Accordian.Item to the rendered item element.

### DIFF
--- a/src/components/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion.jsx
@@ -97,7 +97,7 @@ const Accordion = createClass({
 					return <ExpanderPanel
 							key={index}
 							{...itemChildProp}
-							className={cx('&-Item')}
+							className={cx('&-Item', itemChildProp.className)}
 							onToggle={(isExpanded, { event }) => this.handleToggle(isExpanded, index, event)}
 							isExpanded={!itemChildProp.isDisabled && selectedIndex === index}/>;
 				})}

--- a/src/components/Accordion/Accordion.spec.jsx
+++ b/src/components/Accordion/Accordion.spec.jsx
@@ -97,6 +97,19 @@ describe('Accordion', () => {
 				assert(_.has(rootProps, 'foo'), 'props missing "foo" prop');
 				assert(_.has(rootProps, 'bar'), 'props missing "bar" prop');
 			});
+
+			it('passes through Item className to the rendered item element', () => {
+				const wrapper = shallow(
+					<Accordion>
+						<Accordion.Item className='TestOne'>One</Accordion.Item>
+						<Accordion.Item className='TestTwo'>Two</Accordion.Item>
+					</Accordion>
+				);
+				const itemsWrapper = wrapper.find('.lucid-Accordion-Item');
+
+				assert.equal(itemsWrapper.find('.TestOne').length, 1, 'must find one item with className `TestOne`');
+				assert.equal(itemsWrapper.find('.TestTwo').length, 1, 'must find one item with className `TestTwo`');
+			});
 		});
 	});
 });


### PR DESCRIPTION
Fixes: #471 
## PR Checklist

- Manually tested across supported browsers
  - [ ] ~~Chrome~~
  - [ ] ~~Firefox~~
  - [ ] ~~Safari~~
  - [ ] ~~IE11 (Win 7)~~
  - [ ] ~~Edge (Win 10)~~
- [ ] ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] ~~One core team UX approval~~

