### PR TITLE
strip synthetic events from action creator args in dev mode

### DIFF
--- a/src/components/ContextMenu/ContextMenu.jsx
+++ b/src/components/ContextMenu/ContextMenu.jsx
@@ -65,7 +65,7 @@ const ContextMenu = createClass({
 		 */
 		isExpanded: bool,
 		/**
-		 * Called when a click event happenens outside of the ContextMenu.
+		 * Called when a click event happenens outside of the ContextMenu, with the signature `({ props, event }) => { ... }`
 		 */
 		onClickOut: func,
 		/**
@@ -145,7 +145,7 @@ const ContextMenu = createClass({
 			if (this.props.onClickOut && this.refs.flyOutPortal) {
 				const flyOutEl = this.refs.flyOutPortal.portalElement.firstChild;
 				if (!(flyOutEl.contains(event.target) || this.refs.target.contains(event.target))) {
-					this.props.onClickOut(event);
+					this.props.onClickOut({ props: this.props, event });
 				}
 			}
 		});

--- a/src/components/DropMenu/DropMenu.jsx
+++ b/src/components/DropMenu/DropMenu.jsx
@@ -122,10 +122,12 @@ const DropMenu = createClass({
 		flyOutStyle: object,
 		/**
 		 * Called when collapsed and the control is clicked, or when the control has focus and the Down Arrow is pressed.
+		 * Has the signature `({ props, event }) => {}`
 		 */
 		onExpand: func,
 		/**
-		 * Called when expanded and the user clicks the control or outside of the menu, or when the control has focus and the Escape key is pressed.
+		 * Called when expanded and the user clicks the control or outside of the menu, or when the control has focus and the Escape key is pressed
+		 * Has the signature `({ props, event }) => {}`
 		 */
 		onCollapse: func,
 		/**
@@ -135,10 +137,12 @@ const DropMenu = createClass({
 		onSelect: func,
 		/**
 		 * Called when expanded and the the Down Arrow key is pressed. Not called when focus is on the last option.
+		 * Has the signature `({ props, event }) => {}`
 		 */
 		onFocusNext: func,
 		/**
 		 * Called when expanded and the the Up Arrow key is pressed. Not called when focus is on the first option.
+		 * Has the signature `({ props, event }) => {}`
 		 */
 		onFocusPrev: func,
 		/**
@@ -249,16 +253,19 @@ const DropMenu = createClass({
 		return DropMenu.preprocessOptionData(props, DropMenu);
 	},
 
-	handleKeydown(e) {
+	handleKeydown(event) {
 		const {
-			isExpanded,
-			focusedIndex,
-			onExpand,
-			onCollapse,
-			onSelect,
-			onFocusPrev,
-			onFocusNext,
-		} = this.props;
+			props,
+			props: {
+				isExpanded,
+				focusedIndex,
+				onExpand,
+				onCollapse,
+				onSelect,
+				onFocusPrev,
+				onFocusNext,
+			},
+		} = this;
 
 		const {
 			flattenedOptionsData,
@@ -270,71 +277,74 @@ const DropMenu = createClass({
 		});
 
 		if (isExpanded) {
-			if (e.keyCode === KEYCODE.Enter) {
-				e.preventDefault();
+			if (event.keyCode === KEYCODE.Enter) {
+				event.preventDefault();
 				const focusedOptionData = _.get(flattenedOptionsData, focusedIndex, null);
 				const focusedOptionProps = _.get(focusedOptionData, 'optionProps', {});
 				if (focusedOptionData && !focusedOptionProps.isDisabled) {
-					onSelect(focusedIndex, {props: focusedOptionProps, event: e});
+					onSelect(focusedIndex, {props: focusedOptionProps, event});
 				} else if (_.isNull(focusedIndex)) {
-					onSelect(null, {props: _.first(nullOptions), event: e});
+					onSelect(null, {props: _.first(nullOptions), event});
 				}
 			}
-			if (e.keyCode === KEYCODE.Escape) {
-				e.preventDefault();
-				onCollapse(e);
+			if (event.keyCode === KEYCODE.Escape) {
+				event.preventDefault();
+				onCollapse({ props, event });
 			}
-			if (e.keyCode === KEYCODE.ArrowUp) {
+			if (event.keyCode === KEYCODE.ArrowUp) {
 				if (_.isNumber(focusedIndex) || _.isNull(focusedIndex)) {
 					if (focusedIndex === 0) {
 						if (!_.isEmpty(nullOptions)) {
-							e.preventDefault();
-							onFocusPrev(e);
+							event.preventDefault();
+							onFocusPrev({ props, event });
 						}
 					}
 					if (focusedIndex > 0) {
-						e.preventDefault();
-						onFocusPrev(e);
+						event.preventDefault();
+						onFocusPrev({ props, event });
 					}
 				} else {
-					e.preventDefault();
-					onFocusPrev(e);
+					event.preventDefault();
+					onFocusPrev({ props, event });
 				}
 			}
-			if (e.keyCode === KEYCODE.ArrowDown) {
+			if (event.keyCode === KEYCODE.ArrowDown) {
 				if (_.isNumber(focusedIndex)) {
 					if (focusedIndex < _.size(flattenedOptionsData) - 1) {
-						e.preventDefault();
-						onFocusNext(e);
+						event.preventDefault();
+						onFocusNext({ props, event });
 					}
 				} else {
-					e.preventDefault();
-					onFocusNext(e);
+					event.preventDefault();
+					onFocusNext({ props, event });
 				}
 			}
 		} else {
-			if (e.keyCode === KEYCODE.ArrowDown) {
-				e.preventDefault();
-				onExpand(e);
+			if (event.keyCode === KEYCODE.ArrowDown) {
+				event.preventDefault();
+				onExpand({ props, event });
 			}
 		}
 	},
 
-	handleClick(e) {
+	handleClick(event) {
 		const {
-			isExpanded,
-			onExpand,
-			onCollapse,
-		} = this.props;
+			props,
+			props: {
+				isExpanded,
+				onExpand,
+				onCollapse,
+			},
+		} = this;
 
 		if (isExpanded) {
-			onCollapse(e);
+			onCollapse({ props, event });
 		} else {
-			onExpand(e);
+			onExpand({ props, event });
 		}
 	},
 
-	handleMouseFocusOption(optionIndex, optionProps) {
+	handleMouseFocusOption(optionIndex, optionProps, event) {
 		const {
 			focusedIndex,
 			onFocusOption,
@@ -345,7 +355,7 @@ const DropMenu = createClass({
 		});
 
 		if (!optionProps.isDisabled && focusedIndex !== optionIndex) {
-			onFocusOption(optionIndex);
+			onFocusOption(optionIndex, { props: optionProps, event });
 		}
 	},
 
@@ -355,7 +365,7 @@ const DropMenu = createClass({
 		} = this.props;
 
 		if (!optionProps.isDisabled) {
-			onSelect(optionIndex, { props: optionProps, event: event });
+			onSelect(optionIndex, { props: optionProps, event });
 		}
 	},
 
@@ -379,7 +389,7 @@ const DropMenu = createClass({
 		return (
 			<div
 				key={'DropMenuOption' + optionIndex}
-				onMouseMove={() => this.handleMouseFocusOption(optionIndex, optionProps)}
+				onMouseMove={(event) => this.handleMouseFocusOption(optionIndex, optionProps, event)}
 				onClick={(event) => this.handleSelectOption(optionIndex, optionProps, event)}
 				{...omitProps(optionProps, DropMenu.Option)}
 				className={cx(

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -83,7 +83,7 @@ const TextField = createClass({
 		/**
 		 * Fires an event on every keydown
 		 *
-		 * Signature: `(event) => {}`
+		 * Signature: `({ event, props }) => {}`
 		 */
 		onKeyDown: func,
 
@@ -209,14 +209,17 @@ const TextField = createClass({
 
 	handleKeyDown(event) {
 		const {
-			onSubmit,
-			onKeyDown,
-		} = this.props;
+			props,
+			props: {
+				onSubmit,
+				onKeyDown,
+			},
+		} = this;
 		const value = _.get(event, 'target.value', '');
 
 		// If the consumer passed an onKeyDown, we call it
 		if (onKeyDown) {
-			onKeyDown(event);
+			onKeyDown({ event, props });
 		}
 
 		if (event.keyCode === KEYCODE.Enter) {

--- a/src/components/ToolTip/ToolTip.jsx
+++ b/src/components/ToolTip/ToolTip.jsx
@@ -94,10 +94,12 @@ const ToolTip = createClass({
 		isExpanded: bool,
 		/**
 		 * Called when cursor moves over the target
+		 * Signature: `({ props, event }) => {}`
 		 */
 		onMouseOver: func,
 		/**
 		 * Called when cursor leaves the target and the ToolTip
+		 * Signature: `({ props, event }) => {}`
 		 */
 		onMouseOut: func,
 		/**
@@ -149,9 +151,10 @@ const ToolTip = createClass({
 		};
 	},
 
-	handleMouseOut() {
+	handleMouseOut(event) {
 		setTimeout(() => {
 			const {
+				props,
 				state: {
 					isMouseOverFlyout,
 					isMouseOverTarget,
@@ -161,7 +164,7 @@ const ToolTip = createClass({
 				},
 			} = this;
 			if (!isMouseOverFlyout && !isMouseOverTarget) {
-				onMouseOut();
+				onMouseOut({ props, event });
 			}
 		}, 100);
 	},
@@ -175,9 +178,9 @@ const ToolTip = createClass({
 		this.handleMouseOut();
 	},
 
-	handleMouseOverTarget() {
+	handleMouseOverTarget(event) {
 		this.setState({ isMouseOverTarget: true });
-		this.props.onMouseOver();
+		this.props.onMouseOver({ props: this.props, event });
 	},
 
 	handleMouseOutTarget() {

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -227,7 +227,7 @@ function mergeProps(state, dispatchTree, ownProps) {
 	return _.merge({}, state, dispatchTree, ownProps);
 }
 
-function cleanArgs(args) {
+export function cleanArgs(args) {
 	return _.chain(args).last().has('event').value()
 		? _.dropRight(args)
 		: args;

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { reduceSelectors } from './state-management.js';
+import { isDevMode } from './logger.js';
 
 /**
  * thunk
@@ -78,7 +79,10 @@ export function getReduxPrimitives({
 				};
 			};
 		}
-		return function actionCreator(payload, ...meta) {
+		return function actionCreator(...args) {
+
+			const [payload, ...meta] = isDevMode ? cleanArgs(args) : args;
+
 			return {
 				type: path.join('.'),
 				payload,
@@ -221,4 +225,21 @@ function bindActionCreatorTree(actionCreatorTree, dispatch, path = []) {
  */
 function mergeProps(state, dispatchTree, ownProps) {
 	return _.merge({}, state, dispatchTree, ownProps);
+}
+
+function cleanArgs(args) {
+	return hasEvent(_.last(args))
+		? _.dropRight(args)
+		: args;
+}
+
+function hasEvent(obj) {
+	return obj && obj.event
+		? isEvent(obj.event)
+		: isEvent(obj);
+}
+
+function isEvent(obj) {
+	const proto = Object.getPrototypeOf(Object.getPrototypeOf(obj));
+	return proto && proto.constructor && proto.constructor.name === 'SyntheticUIEvent';
 }

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -228,18 +228,7 @@ function mergeProps(state, dispatchTree, ownProps) {
 }
 
 function cleanArgs(args) {
-	return hasEvent(_.last(args))
+	return _.chain(args).last().has('event').value()
 		? _.dropRight(args)
 		: args;
-}
-
-function hasEvent(obj) {
-	return obj && obj.event
-		? isEvent(obj.event)
-		: isEvent(obj);
-}
-
-function isEvent(obj) {
-	const proto = Object.getPrototypeOf(Object.getPrototypeOf(obj));
-	return proto && proto.constructor && proto.constructor.name === 'SyntheticUIEvent';
 }

--- a/src/util/redux.spec.js
+++ b/src/util/redux.spec.js
@@ -6,11 +6,23 @@ import {
 } from 'lodash';
 
 import {
+	cleanArgs,
 	thunk,
 	getReduxPrimitives,
 } from './redux';
 
 describe('redux utils', () => {
+
+	describe('#cleanArgs', () => {
+		it('it should remove the last element if it has an `event` property', () => {
+			assert.deepEqual(cleanArgs(['foo', 'bar', { event: 'event' }]), ['foo', 'bar']);
+			assert.deepEqual(cleanArgs(['foo', 'bar', { event: null }]), ['foo', 'bar']);
+		});
+
+		it('it should not remove the last element if it has no `event` property', () => {
+			assert.deepEqual(cleanArgs(['foo', 'bar']), ['foo', 'bar']);
+		});
+	});
 
 	describe('#thunk', () => {
 		it('should set `isThunk` property on the input function to `true`', () => {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - ~~[ ] Chrome~~
  - ~~[ ] Firefox~~
  - ~~[ ] Safari~~
  - ~~[ ] IE11 (Win 7)~~
  - ~~[ ] Edge (Win 10)~~
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Our pattern of passing the underlying event as the last argument of
event handlers was causing generated action creators to get called with
the event, which at some point gets traversed, and the property access
throws a warning synthetic event pooling warning.

The events are never actually used by any of the reducers, so the
warning is benign afaict, so I'm only stripping them in dev mode.

~~The code is a little uglier than it could be because we're not
completely consistent about where the event goes (sometimes the last arg
is an object `{ props, event }`, sometimes the event itself).~~ fixed all the consistency issues