### PR TITLE
Make small style tweaks to fully hide the divider

### DIFF
--- a/src/components/Sidebar/Sidebar.less
+++ b/src/components/Sidebar/Sidebar.less
@@ -1,4 +1,4 @@
-@Sidebar-Divider-width: @size-XS - 1px;
+@Sidebar-Divider-width: @size-XS;
 @Sidebar-transition-duration: @timing-animation-fade;
 @Sidebar-transition-half-duration: @Sidebar-transition-duration / 2;
 @Sidebar-transition-third-duration: @Sidebar-transition-duration / 3;

--- a/src/components/Submarine/Submarine.less
+++ b/src/components/Submarine/Submarine.less
@@ -1,4 +1,4 @@
-@Submarine-Divider-height: @size-XS - 1px;
+@Submarine-Divider-height: @size-XS;
 @Submarine-Bar-header-height: 33px;
 @Submarine-transition-duration: @timing-animation-fade;
 @Submarine-transition-half-duration: @Submarine-transition-duration / 2;


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

of Sidebar and Submarine on collapse.