### PR TITLE
Chart tweaks

### DIFF
--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -85,13 +85,9 @@ const BarChart = createClass({
 		 */
 		legend: object,
 		/**
-		 * Show tooltips on hover.
+		 * Show tool tips on hover.
 		 */
 		hasToolTips: bool,
-		/**
-		 * Controls the visibility of series' titles within the tooltips.
-		 */
-		hasToolTipTitles: bool,
 		/**
 		 * Show a legend at the bottom of the chart.
 		 */
@@ -203,6 +199,14 @@ const BarChart = createClass({
 		 * `number` is supported only for backwards compatability.
 		 */
 		yAxisTitleColor: oneOfType([number, string]),
+		/**
+		 * An optional function used to format your y axis titles and data in the
+		 * tooltips. The first value is the name of your y field, the second value
+		 * is your post-formatted y value.
+		 *
+		 * Signature: `(yField, yValueFormatted) => {}`
+		 */
+		yAxisTooltipFormatter: func,
 	},
 
 	statics: {
@@ -229,7 +233,6 @@ const BarChart = createClass({
 			},
 			palette: chartConstants.PALETTE_6,
 			hasToolTips: true,
-			hasToolTipTitles: true,
 			hasLegend: false,
 
 			xAxisField: 'x',
@@ -244,6 +247,7 @@ const BarChart = createClass({
 			yAxisMin: 0,
 			yAxisTitle: null,
 			yAxisTitleColor: '#000',
+			yAxisTooltipFormatter: (yField, yValueFormatted) => `${yField}: ${yValueFormatted}`,
 		};
 	},
 
@@ -256,7 +260,6 @@ const BarChart = createClass({
 			data,
 			legend,
 			hasToolTips,
-			hasToolTipTitles,
 			hasLegend,
 			palette,
 			colorMap,
@@ -274,6 +277,7 @@ const BarChart = createClass({
 			yAxisIsStacked,
 			yAxisTickCount,
 			yAxisMin,
+			yAxisTooltipFormatter,
 			yAxisMax = yAxisIsStacked
 				? maxByFieldsStacked(data, yAxisFields)
 				: maxByFields(data, yAxisFields),
@@ -424,8 +428,8 @@ const BarChart = createClass({
 						yStackedMax={yAxisMax}
 						data={data}
 						isStacked={yAxisIsStacked}
+						yTooltipFormatter={yAxisTooltipFormatter}
 						hasToolTips={hasToolTips}
-						hasToolTipTitles={hasToolTipTitles}
 						legend={legend}
 						palette={palette}
 						colorMap={colorMap}

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -85,9 +85,13 @@ const BarChart = createClass({
 		 */
 		legend: object,
 		/**
-		 * Show tool tips on hover.
+		 * Show tooltips on hover.
 		 */
 		hasToolTips: bool,
+		/**
+		 * Controls the visibility of series' titles within the tooltips.
+		 */
+		hasToolTipTitles: bool,
 		/**
 		 * Show a legend at the bottom of the chart.
 		 */
@@ -225,6 +229,7 @@ const BarChart = createClass({
 			},
 			palette: chartConstants.PALETTE_6,
 			hasToolTips: true,
+			hasToolTipTitles: true,
 			hasLegend: false,
 
 			xAxisField: 'x',
@@ -251,6 +256,7 @@ const BarChart = createClass({
 			data,
 			legend,
 			hasToolTips,
+			hasToolTipTitles,
 			hasLegend,
 			palette,
 			colorMap,
@@ -419,6 +425,7 @@ const BarChart = createClass({
 						data={data}
 						isStacked={yAxisIsStacked}
 						hasToolTips={hasToolTips}
+						hasToolTipTitles={hasToolTipTitles}
 						legend={legend}
 						palette={palette}
 						colorMap={colorMap}

--- a/src/components/BarChart/BarChart.spec.jsx
+++ b/src/components/BarChart/BarChart.spec.jsx
@@ -23,6 +23,7 @@ describe('BarChart', () => {
 		exemptFunctionProps: [
 			'xAxisFormatter',
 			'yAxisFormatter',
+			'yAxisTooltipFormatter',
 		],
 		getDefaultProps: () => ({
 			data: [

--- a/src/components/Bars/Bars.jsx
+++ b/src/components/Bars/Bars.jsx
@@ -70,6 +70,10 @@ const Bars = createClass({
 		 */
 		hasToolTips: bool,
 		/**
+		 * Controls the visibility of series' titles within the tooltips.
+		 */
+		hasToolTipTitles: bool,
+		/**
 		 * Takes one of the palettes exported from `lucid.chartConstants`.
 		 * Available palettes:
 		 *
@@ -150,6 +154,7 @@ const Bars = createClass({
 	getDefaultProps() {
 		return {
 			hasToolTips: true,
+			hasToolTipTitles: true,
 			xField: 'x',
 			xFormatter: _.identity,
 			yFields: ['y'],
@@ -172,6 +177,7 @@ const Bars = createClass({
 			data,
 			legend,
 			hasToolTips,
+			hasToolTipTitles,
 			palette,
 			colorMap,
 			colorOffset,
@@ -276,7 +282,11 @@ const Bars = createClass({
 												pointKind={1}
 												color={_.get(colorMap, field, palette[(fieldIndex + colorOffset ) % palette.length])}
 											>
-												{`${_.get(legend, field, field)}: ${yFormatter(data[seriesIndex][field])}`}
+												{hasToolTipTitles ?
+													<span>{`${_.get(legend, field, field)}:\u00a0`}</span>
+												: null}
+												<span></span>
+												{`${yFormatter(data[seriesIndex][field])}`}
 											</Legend.Item>
 										))}
 									</Legend>

--- a/src/components/Bars/Bars.jsx
+++ b/src/components/Bars/Bars.jsx
@@ -70,10 +70,6 @@ const Bars = createClass({
 		 */
 		hasToolTips: bool,
 		/**
-		 * Controls the visibility of series' titles within the tooltips.
-		 */
-		hasToolTipTitles: bool,
-		/**
 		 * Takes one of the palettes exported from `lucid.chartConstants`.
 		 * Available palettes:
 		 *
@@ -136,6 +132,14 @@ const Bars = createClass({
 		 * stacking, pass it in here.
 		 */
 		yStackedMax: number,
+		/**
+		 * An optional function used to format your y axis titles and data in the
+		 * tooltips. The first value is the name of your y field, the second value
+		 * is your post-formatted y value.
+		 *
+		 * Signature: `(yField, yValueFormatted) => {}`
+		 */
+		yTooltipFormatter: func,
 
 		/**
 		 * This will stack the data instead of grouping it. In order to stack the
@@ -154,11 +158,11 @@ const Bars = createClass({
 	getDefaultProps() {
 		return {
 			hasToolTips: true,
-			hasToolTipTitles: true,
 			xField: 'x',
 			xFormatter: _.identity,
 			yFields: ['y'],
 			yFormatter: _.identity,
+			yTooltipFormatter: (yField, yValueFormatted) => `${yField}: ${yValueFormatted}`,
 			isStacked: false,
 			colorOffset: 0,
 			palette: chartConstants.PALETTE_6,
@@ -177,7 +181,6 @@ const Bars = createClass({
 			data,
 			legend,
 			hasToolTips,
-			hasToolTipTitles,
 			palette,
 			colorMap,
 			colorOffset,
@@ -188,6 +191,7 @@ const Bars = createClass({
 			yFields,
 			yFormatter,
 			yStackedMax,
+			yTooltipFormatter,
 			isStacked,
 			...passThroughs,
 		} = this.props;
@@ -282,11 +286,7 @@ const Bars = createClass({
 												pointKind={1}
 												color={_.get(colorMap, field, palette[(fieldIndex + colorOffset ) % palette.length])}
 											>
-												{hasToolTipTitles ?
-													<span>{`${_.get(legend, field, field)}:\u00a0`}</span>
-												: null}
-												<span></span>
-												{`${yFormatter(data[seriesIndex][field])}`}
+												{yTooltipFormatter(_.get(legend, field, field), yFormatter(data[seriesIndex][field]))}
 											</Legend.Item>
 										))}
 									</Legend>

--- a/src/components/Bars/Bars.jsx
+++ b/src/components/Bars/Bars.jsx
@@ -278,7 +278,7 @@ const Bars = createClass({
 								</ToolTip.Title>
 
 								<ToolTip.Body>
-									<Legend hasBorders={false}>
+									<Legend hasBorders={false} isReversed={isStacked}>
 										{_.map(yFields, (field, fieldIndex) => (
 											<Legend.Item
 												key={fieldIndex}

--- a/src/components/Bars/Bars.spec.jsx
+++ b/src/components/Bars/Bars.spec.jsx
@@ -30,6 +30,7 @@ describe('Bars', () => {
 			'yScale',
 			'xFormatter',
 			'yFormatter',
+			'yTooltipFormatter',
 		],
 		getDefaultProps: () => ({
 			data: defaultData,

--- a/src/components/Legend/Legend.jsx
+++ b/src/components/Legend/Legend.jsx
@@ -50,12 +50,17 @@ const Legend = createClass({
 		 * a `ToolTip` for example.
 		 */
 		hasBorders: bool,
+		/**
+		 * Reverse the order of items in the legend.
+		 */
+		isReversed: bool,
 	},
 
 	getDefaultProps() {
 		return {
 			orient: 'vertical',
 			hasBorders: true,
+			isReversed: false,
 		};
 	},
 
@@ -97,6 +102,7 @@ const Legend = createClass({
 			orient,
 			className,
 			hasBorders,
+			isReversed,
 			...passThroughs,
 		} = this.props;
 
@@ -112,6 +118,7 @@ const Legend = createClass({
 					'&-is-horizontal': isHorizontal,
 					'&-is-vertical': isVertical,
 					'&-has-borders': hasBorders,
+					'&-is-reversed': isReversed,
 				})}
 			>
 				{_.map(itemProps, ({

--- a/src/components/Legend/Legend.less
+++ b/src/components/Legend/Legend.less
@@ -10,17 +10,23 @@
 	&-is-horizontal {
 		flex-direction: row;
 		height: @size-standard-height;
-		padding: 0 @size-S;
+		padding: 0 (@size-S / 2);
+	}
+	&-is-horizontal&-is-reversed {
+		flex-direction: row-reverse;
 	}
 	&-is-vertical {
 		flex-direction: column;
+	}
+	&-is-vertical&-is-reversed {
+		flex-direction: column-reverse;
 	}
 	&-has-borders {
 		border: @border-lightBorder;
 		border-radius: @size-borderRadius;
 	}
 	&-is-vertical&-has-borders {
-		padding: @size-S;
+		padding: (@size-S / 2) @size-S;
 	}
 
 	&-Item {
@@ -28,14 +34,12 @@
 		align-items: center;
 	}
 	&-is-vertical &-Item {
-		padding-top: @size-S;
+		margin-top: @size-S / 2;
+		margin-bottom: @size-S / 2;
 	}
 	&-is-horizontal &-Item {
-		padding-left: @size-L;
-	}
-	&-Item:first-of-type {
-		padding-left: 0;
-		padding-top: 0;
+		margin-left: @size-L / 2;
+		margin-right: @size-L / 2;
 	}
 
 	&-Item-indicator {

--- a/src/components/Legend/examples/basic.jsx
+++ b/src/components/Legend/examples/basic.jsx
@@ -69,12 +69,39 @@ export default React.createClass({
 
 				<br />
 
+				<Legend isReversed >
+					{_.map(chartConstants.PALETTE_6, (color, i) => (
+						<Item
+							key={color}
+							hasPoint
+							hasLine
+							pointKind={i}
+							color={color}
+						>
+							{`Partner ${i}`}
+						</Item>
+					))}
+				</Legend>
+
+				<br />
+
 				<Legend orient='horizontal'>
 					<Item hasLine color={chartConstants.COLOR_GOOD}>Revenue</Item>
 					<Item hasLine color={chartConstants.COLOR_BAD}>Loss</Item>
 					<Item hasPoint color={chartConstants.COLOR_0}>Partner 0</Item>
 					<Item hasPoint color={chartConstants.COLOR_1}>Partner 1</Item>
 				</Legend>
+
+				<br />
+
+				<Legend orient='horizontal' isReversed >
+					<Item hasLine color={chartConstants.COLOR_GOOD}>Revenue</Item>
+					<Item hasLine color={chartConstants.COLOR_BAD}>Loss</Item>
+					<Item hasPoint color={chartConstants.COLOR_0}>Partner 0</Item>
+					<Item hasPoint color={chartConstants.COLOR_1}>Partner 1</Item>
+				</Legend>
+
+				<br />
 
 				<Legend>
 					<Item hasLine color={chartConstants.COLOR_GOOD}>Revenue</Item>

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -497,7 +497,7 @@ const LineChart = createClass({
 								{xAxisTooltipFormatter(_.get(xPointMap, `${mouseX}.x`))}
 							</ToolTip.Title>
 							<ToolTip.Body>
-								<Legend hasBorders={false}>
+								<Legend hasBorders={false} isReversed={yAxisIsStacked}>
 									{_.map(yAxisFields, (field, index) => (
 										_.get(xPointMap, mouseX + '.y.' + field) ?
 											<Legend.Item

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -444,6 +444,13 @@ const LineChart = createClass({
 				? y2Scale.tickFormat()
 				: _.identity;
 
+		// This logic is getting a bit complicated
+		const yAxisHasPointsFinal = yAxisHasPoints || yAxisIsStacked;
+		const yAxisHasLinesFinal = !(yAxisIsStacked && !yAxisHasPoints);
+
+		const y2AxisHasPointsFinal = y2AxisHasPoints || y2AxisIsStacked;
+		const y2AxisHasLinesFinal = !(y2AxisIsStacked && !y2AxisHasPoints);
+
 		// This is used to map x mouse values back to data points.
 		const xPointMap = _.reduce(data, (acc, d) => {
 			// `floor` to avoid rounding errors, it doesn't need to be super precise
@@ -495,10 +502,10 @@ const LineChart = createClass({
 										_.get(xPointMap, mouseX + '.y.' + field) ?
 											<Legend.Item
 												key={index}
-												hasPoint={yAxisHasPoints}
-												hasLine={true}
+												hasPoint={yAxisHasPointsFinal}
+												hasLine={yAxisHasLinesFinal}
 												color={_.get(colorMap, field, palette[index % palette.length])}
-												pointKind={index}
+												pointKind={yAxisHasPoints ? index : 1}
 											>
 												{yAxisTooltipFormatter(_.get(legend, field, field), yFinalFormatter(_.get(xPointMap, mouseX + '.y.' + field)))}
 											</Legend.Item>
@@ -508,10 +515,10 @@ const LineChart = createClass({
 										_.get(xPointMap, mouseX + '.y.' + field) ?
 											<Legend.Item
 												key={index}
-												hasPoint={y2AxisHasPoints}
-												hasLine={true}
+												hasPoint={y2AxisHasPointsFinal}
+												hasLine={y2AxisHasLinesFinal}
 												color={_.get(colorMap, field, palette[index + yAxisFields.length % palette.length])}
-												pointKind={index + yAxisFields.length}
+												pointKind={y2AxisHasPoints ? index + yAxisFields.length : 1}
 											>
 												{yAxisTooltipFormatter(_.get(legend, field, field), y2FinalFormatter(_.get(xPointMap, mouseX + '.y.' + field)))}
 											</Legend.Item>
@@ -553,10 +560,10 @@ const LineChart = createClass({
 									{_.map(yAxisFields, (field, index) => (
 										<Legend.Item
 											key={index}
-											hasPoint={yAxisHasPoints}
-											hasLine={true}
+											hasPoint={yAxisHasPointsFinal}
+											hasLine={yAxisHasLinesFinal}
 											color={_.get(colorMap, field, palette[index % palette.length])}
-											pointKind={index}
+											pointKind={yAxisHasPoints ? index : 1}
 										>
 											{_.get(legend, field, field)}
 										</Legend.Item>
@@ -564,10 +571,10 @@ const LineChart = createClass({
 									{_.map(y2AxisFields, (field, index) => (
 										<Legend.Item
 											key={index}
-											hasPoint={y2AxisHasPoints}
-											hasLine={true}
+											hasPoint={y2AxisHasPointsFinal}
+											hasLine={y2AxisHasLinesFinal}
 											color={_.get(colorMap, field, palette[index + yAxisFields.length % palette.length])}
-											pointKind={index + yAxisFields.length}
+											pointKind={y2AxisHasPoints ? index + yAxisFields.length : 1}
 										>
 											{_.get(legend, field, field)}
 										</Legend.Item>

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -92,13 +92,9 @@ const LineChart = createClass({
 		 */
 		legend: object,
 		/**
-		 * Show tooltips on hover.
+		 * Show tool tips on hover.
 		 */
 		hasToolTips: bool,
-		/**
-		 * Controls the visibility of series' titles within the tooltips.
-		 */
-		hasToolTipTitles: bool,
 		/**
 		 * Show a legend at the bottom of the chart.
 		 */
@@ -227,6 +223,14 @@ const LineChart = createClass({
 		 * `number` is supported only for backwards compatability.
 		 */
 		yAxisTitleColor: oneOfType([number, string]),
+		/**
+		 * An optional function used to format your y axis titles and data in the
+		 * tooltips. The first value is the name of your y field, the second value
+		 * is your post-formatted y value.
+		 *
+		 * Signature: `(yField, yValueFormatted) => {}`
+		 */
+		yAxisTooltipFormatter: func,
 
 
 		/**
@@ -302,7 +306,6 @@ const LineChart = createClass({
 			},
 			palette: chartConstants.PALETTE_6,
 			hasToolTips: true,
-			hasToolTipTitles: true,
 			hasLegend: false,
 
 			xAxisField: 'x',
@@ -319,6 +322,7 @@ const LineChart = createClass({
 			yAxisTickCount: null,
 			yAxisTitle: null,
 			yAxisTitleColor: '#000',
+			yAxisTooltipFormatter: (yField, yValueFormatted) => `${yField}: ${yValueFormatted}`,
 
 			y2AxisFields: null,
 			y2AxisIsStacked: false,
@@ -345,7 +349,6 @@ const LineChart = createClass({
 			data,
 			legend,
 			hasToolTips,
-			hasToolTipTitles,
 			hasLegend,
 			palette,
 			colorMap,
@@ -367,6 +370,7 @@ const LineChart = createClass({
 			yAxisTitle,
 			yAxisTitleColor,
 			yAxisMin,
+			yAxisTooltipFormatter,
 			yAxisMax = yAxisIsStacked
 				? maxByFieldsStacked(data, yAxisFields)
 				: maxByFields(data, yAxisFields),
@@ -496,10 +500,7 @@ const LineChart = createClass({
 												color={_.get(colorMap, field, palette[index % palette.length])}
 												pointKind={index}
 											>
-												{hasToolTipTitles ?
-													<span>{`${_.get(legend, field, field)}:\u00a0`}</span>
-												: null}
-												<span>{`${yFinalFormatter(_.get(xPointMap, mouseX + '.y.' + field))}`}</span>
+												{yAxisTooltipFormatter(_.get(legend, field, field), yFinalFormatter(_.get(xPointMap, mouseX + '.y.' + field)))}
 											</Legend.Item>
 										: null
 									))}
@@ -512,10 +513,7 @@ const LineChart = createClass({
 												color={_.get(colorMap, field, palette[index + yAxisFields.length % palette.length])}
 												pointKind={index + yAxisFields.length}
 											>
-												{hasToolTipTitles ?
-													<span>{`${_.get(legend, field, field)}:\u00a0`}</span>
-												: null}
-												<span>{`${y2FinalFormatter(_.get(xPointMap, mouseX + '.y.' + field))}`}</span>
+												{yAxisTooltipFormatter(_.get(legend, field, field), y2FinalFormatter(_.get(xPointMap, mouseX + '.y.' + field)))}
 											</Legend.Item>
 										: null
 									))}

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -92,9 +92,13 @@ const LineChart = createClass({
 		 */
 		legend: object,
 		/**
-		 * Show tool tips on hover.
+		 * Show tooltips on hover.
 		 */
 		hasToolTips: bool,
+		/**
+		 * Controls the visibility of series' titles within the tooltips.
+		 */
+		hasToolTipTitles: bool,
 		/**
 		 * Show a legend at the bottom of the chart.
 		 */
@@ -298,6 +302,7 @@ const LineChart = createClass({
 			},
 			palette: chartConstants.PALETTE_6,
 			hasToolTips: true,
+			hasToolTipTitles: true,
 			hasLegend: false,
 
 			xAxisField: 'x',
@@ -340,6 +345,7 @@ const LineChart = createClass({
 			data,
 			legend,
 			hasToolTips,
+			hasToolTipTitles,
 			hasLegend,
 			palette,
 			colorMap,
@@ -490,7 +496,10 @@ const LineChart = createClass({
 												color={_.get(colorMap, field, palette[index % palette.length])}
 												pointKind={index}
 											>
-												{`${_.get(legend, field, field)}: ${yFinalFormatter(_.get(xPointMap, mouseX + '.y.' + field))}`}
+												{hasToolTipTitles ?
+													<span>{`${_.get(legend, field, field)}:\u00a0`}</span>
+												: null}
+												<span>{`${yFinalFormatter(_.get(xPointMap, mouseX + '.y.' + field))}`}</span>
 											</Legend.Item>
 										: null
 									))}
@@ -503,7 +512,10 @@ const LineChart = createClass({
 												color={_.get(colorMap, field, palette[index + yAxisFields.length % palette.length])}
 												pointKind={index + yAxisFields.length}
 											>
-												{`${_.get(legend, field, field)}: ${y2FinalFormatter(_.get(xPointMap, mouseX + '.y.' + field))}`}
+												{hasToolTipTitles ?
+													<span>{`${_.get(legend, field, field)}:\u00a0`}</span>
+												: null}
+												<span>{`${y2FinalFormatter(_.get(xPointMap, mouseX + '.y.' + field))}`}</span>
 											</Legend.Item>
 										: null
 									))}

--- a/src/components/LineChart/LineChart.spec.jsx
+++ b/src/components/LineChart/LineChart.spec.jsx
@@ -23,6 +23,7 @@ describe('LineChart', () => {
 		exemptFunctionProps: [
 			'xAxisFormatter',
 			'xAxisTooltipFormatter',
+			'yAxisTooltipFormatter',
 			'yAxisFormatter',
 			'y2AxisFormatter',
 		],

--- a/src/components/LineChart/examples/4.multi-with-legend.jsx
+++ b/src/components/LineChart/examples/4.multi-with-legend.jsx
@@ -33,6 +33,7 @@ export default React.createClass({
 							hasPoint
 							hasLine
 							color={palette[i % palette.length]}
+							pointKind={i}
 						>
 							{field}
 						</Legend.Item>

--- a/src/components/LineChart/examples/8.stacked-single-series-with-formatters.jsx
+++ b/src/components/LineChart/examples/8.stacked-single-series-with-formatters.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { LineChart } from '../../../index';
+
+const data = [
+	{ x: new Date('2015-01-01T00:00:00-08:00'), y: 1.55 },
+	{ x: new Date('2015-01-02T00:00:00-08:00'), y: 2.67 },
+	{ x: new Date('2015-01-03T00:00:00-08:00'), y: 3.31 },
+	{ x: new Date('2015-01-04T00:00:00-08:00'), y: 5.99 },
+];
+
+export default React.createClass({
+	render() {
+		return (
+			<LineChart
+				yAxisIsStacked
+				yAxisFormatter={yValue => `$ ${yValue}`}
+				yAxisTooltipFormatter={(yField, yValueFormatted) => yValueFormatted}
+				data={data}
+			/>
+		);
+	},
+});

--- a/src/components/LineChart/examples/9.stacked-monochrome-no-shapes.jsx
+++ b/src/components/LineChart/examples/9.stacked-monochrome-no-shapes.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { LineChart, chartConstants } from '../../../index';
+
+const data = [
+	{ x: new Date('2015-01-01T00:00:00-08:00'), apples: 2, oranges: 3, pears: 1, bananas: 7, kiwis: 5 },
+	{ x: new Date('2015-01-02T00:00:00-08:00'), apples: 2, oranges: 5, pears: 6, bananas: 7, kiwis: 5 },
+	{ x: new Date('2015-01-03T00:00:00-08:00'), apples: 3, oranges: 2, pears: 4, bananas: 7, kiwis: 5 },
+	{ x: new Date('2015-01-04T00:00:00-08:00'), apples: 5, oranges: 6, pears: 1, bananas: 7, kiwis: 5 },
+	{ x: new Date('2015-01-05T00:00:00-08:00'), apples: 4, oranges: 3, pears: 2, bananas: 7, kiwis: 5 },
+	{ x: new Date('2015-01-06T00:00:00-08:00'), apples: 3, oranges: 4, pears: 4, bananas: 7, kiwis: 5 },
+];
+
+export default React.createClass({
+	render() {
+		return (
+			<LineChart
+				data={data}
+				yAxisFields={['apples', 'oranges', 'pears', 'bananas', 'kiwis']}
+				yAxisIsStacked={true}
+				yAxisHasPoints={false}
+				yAxisTitle='Fruit Count'
+				palette={chartConstants.PALETTE_MONOCHROME_0_5}
+			/>
+		);
+	},
+});

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -83,6 +83,10 @@ const PieChart = createClass({
 		 */
 		hasToolTips: bool,
 		/**
+		 * Determines if the pie slices have a stroke around them.
+		 */
+		hasStroke: bool,
+		/**
 		 * Takes one of the palettes exported from `lucid.chartConstants`.
 		 * Available palettes:
 		 *
@@ -187,6 +191,7 @@ const PieChart = createClass({
 			},
 			palette: chartConstants.PALETTE_6,
 			hasToolTips: true,
+			hasStroke: true,
 			isDonut: false,
 			donutWidth: DONUT_WIDTH,
 			ToolTip: ToolTip.getDefaultProps(),
@@ -227,6 +232,7 @@ const PieChart = createClass({
 			margin: marginOriginal,
 			data,
 			hasToolTips,
+			hasStroke,
 			palette,
 			colorMap,
 			isDonut,
@@ -310,7 +316,9 @@ const PieChart = createClass({
 									>
 										<Line
 											key={index}
-											className={cx('&-slice')}
+											className={cx('&-slice', {
+												'&-slice-has-stroke': hasStroke,
+											})}
 											d={arc(pieDatum)}
 											color={_.get(colorMap, data[index][xAxisField], palette[index % palette.length])}
 											transform={`scale(${isHovering && hoveringIndex === index ? HOVER_SCALE : 1})`}

--- a/src/components/PieChart/PieChart.less
+++ b/src/components/PieChart/PieChart.less
@@ -1,8 +1,11 @@
 .lucid-PieChart {
 	// Increase specificity by 1 to beat .lucid-Line
 	&-slice&-slice {
-		stroke: @color-white;
+		stroke: none;
 		transition: transform @timing-animation-hover;
+	}
+	&-slice-has-stroke&-slice-has-stroke {
+		stroke: @color-white;
 	}
 
 	&-slice-group-is-hovering &-slice {

--- a/src/components/PieChart/PieChart.spec.jsx
+++ b/src/components/PieChart/PieChart.spec.jsx
@@ -134,6 +134,30 @@ describe('PieChart', () => {
 			});
 		});
 
+		describe('hasStroke', () => {
+			it('should add the correct class', () => {
+				const wrapper = shallow(
+					<PieChart
+						data={sampleData}
+						hasStroke={true}
+					/>
+				);
+
+				assert.equal(wrapper.find('.lucid-PieChart-slice-has-stroke').length, 3);
+			});
+
+			it('should not add the class when false', () => {
+				const wrapper = shallow(
+					<PieChart
+						data={sampleData}
+						hasStroke={false}
+					/>
+				);
+
+				assert.equal(wrapper.find('.lucid-PieChart-slice-has-stroke').length, 0);
+			});
+		});
+
 		describe('isHovering and hoveringIndex', () => {
 			it('should put the right class on the right slice', () => {
 				const wrapper = shallow(

--- a/src/components/PieChart/examples/6.small-with-no-stroke-or-hover.jsx
+++ b/src/components/PieChart/examples/6.small-with-no-stroke-or-hover.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { PieChart } from '../../../index';
+
+const data = [
+	{ x: 'Leslie' , y: 60 } ,
+	{ x: 'Ron'    , y: 40 } ,
+	{ x: 'Tom'    , y: 30 } ,
+	{ x: 'Gary'   , y: 20 } ,
+	{ x: 'Ben'    , y: 15 } ,
+];
+
+export default React.createClass({
+	render() {
+		return (
+			<PieChart
+				margin={{
+					top: 0,
+					right: 0,
+					bottom: 0,
+					left: 0,
+				}}
+				width={25}
+				height={25}
+				data={data}
+				hasStroke={false}
+				isHovering={false}
+			/>
+		);
+	},
+});


### PR DESCRIPTION
Fixes #478 added hasStroke to PieChart
Fixes #481 by adding a `hasToolTipTitles` to bar, line, and bars
Fixes #498 by tweaking the tooltip/legend logic on line charts

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval
