### PR TITLE
SingleSelect - add border-radius style to :before control

### DIFF
--- a/src/components/SingleSelect/SingleSelect.less
+++ b/src/components/SingleSelect/SingleSelect.less
@@ -20,6 +20,10 @@
 		align-items: center;
 		white-space: nowrap;
 
+		&:before {
+			border-radius: @size-borderRadius;
+		}
+
 		&-content {
 			display: flex;
 			align-items: center;


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

Fixes #484