### PR TITLE
Make LoadingIndicator use Light variant by default

### DIFF
--- a/src/components/LoadingIndicator/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.jsx
@@ -55,7 +55,7 @@ const LoadingIndicator = createClass({
 		return {
 			hasOverlay: true,
 			isLoading: false,
-			overlayKind: 'dark',
+			overlayKind: 'light',
 		};
 	},
 


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - ~~Chrome~~
  - ~~Firefox~~
  - ~~Safari~~
  - ~~IE11 (Win 7)~~
  - ~~Edge (Win 10)~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

Fixes #511 