### PR TITLE
Add browser build of lucid

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,20 +8,21 @@
     "url": "https://github.com/appnexus/lucid.git"
   },
   "scripts": {
+    "build-bundle": "scripts/build-bundle.sh",
     "dev": "gulp docs-generate && webpack-dev-server --inline --content-base src/docs/",
-    "docs-upload-gh": "./scripts/docs-upload-gh.sh",
+    "docs-upload-gh": "scripts/docs-upload-gh.sh",
     "docs-upload": "gulp docs-upload",
-    "preversion": "rm -rf dist && gulp lint && npm run test && gulp preversion",
+    "preversion": "rm -rf dist && gulp lint && npm run test && gulp preversion && npm run build-bundle",
     "postversion": "gulp docs-upload",
     "start": "npm run dev",
     "test": "npm run test-browserstack && npm run test-acceptance",
-    "test-browserstack": "./scripts/env-check.sh && karma start karma.conf.js --singleRun --auto-watch=false --browsers=bs_chrome,bs_firefox,bs_safari,bs_ie,bs_edge --reporters failed",
+    "test-browserstack": "scripts/env-check.sh && karma start karma.conf.js --singleRun --auto-watch=false --browsers=bs_chrome,bs_firefox,bs_safari,bs_ie,bs_edge --reporters failed",
     "test-local": "karma start karma.conf.js --singleRun --auto-watch=false",
     "test-tdd": "karma start karma.conf.js",
-    "test-acceptance": "./scripts/env-check.sh && ./scripts/local.runner.js -c nightwatch/nightwatch.conf.js --skiptags setup,screenshots -e bs_chrome,bs_firefox,bs_safari,bs_ie,bs_edge",
-    "test-screenshots": "./scripts/env-check.sh && ./scripts/local.runner.js -c nightwatch/nightwatch.conf.js -a screenshots -e bs_chrome,bs_firefox,bs_safari,bs_edge --retries=2",
+    "test-acceptance": "scripts/env-check.sh && scripts/local.runner.js -c nightwatch/nightwatch.conf.js --skiptags setup,screenshots -e bs_chrome,bs_firefox,bs_safari,bs_ie,bs_edge",
+    "test-screenshots": "scripts/env-check.sh && scripts/local.runner.js -c nightwatch/nightwatch.conf.js -a screenshots -e bs_chrome,bs_firefox,bs_safari,bs_edge --retries=2",
     "test-acceptance-local": "nightwatch -c nightwatch/nightwatch.local.conf.js --skiptags setup,screenshots",
-    "test-screenshot-setup": "./scripts/env-check.sh && ./scripts/local.runner.js -c nightwatch/nightwatch.conf.js -a setup -e bs_chrome,bs_firefox,bs_safari,bs_edge"
+    "test-screenshot-setup": "scripts/env-check.sh && scripts/local.runner.js -c nightwatch/nightwatch.conf.js -a setup -e bs_chrome,bs_firefox,bs_safari,bs_edge"
   },
   "keywords": [
     "component",

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+node_modules/.bin/webpack --config webpack.config.bundle.js &
+node_modules/.bin/webpack --config webpack.config.bundle.js --minify &
+wait

--- a/webpack.config.bundle.js
+++ b/webpack.config.bundle.js
@@ -1,0 +1,55 @@
+// This webpack config builds lucid for the use in a <script> tag that already
+// has React and ReactDOM available as globals
+
+var path = require('path');
+var webpack = require('webpack');
+var isMinified = process.argv.indexOf('--minify') !== -1;
+
+module.exports = {
+	context: __dirname,
+	entry: [
+		'./src/index.js',
+	],
+	output: {
+		path: path.join(__dirname, '/dist'),
+		filename: isMinified ? 'lucid.min.js' : 'lucid.js',
+		libraryTarget: 'var',
+		library: 'Lucid',
+	},
+	externals: {
+		'react': 'React',
+		'react-dom': 'ReactDOM',
+
+		// to avoid duplicate import of React with react-addons-css-transition-group
+		'./React': 'React',
+		'./ReactDOM': 'ReactDOM',
+	},
+	module: {
+		loaders: [
+			{
+				test: /\.jsx?$/,
+				loader: 'babel',
+				exclude: /(node_modules)/,
+			},
+			{
+				test: /\.json/,
+				loader: 'json',
+			},
+		],
+	},
+	resolve: {
+		extensions: ['', '.js', '.jsx'],
+	},
+	plugins: [
+		isMinified ? new webpack.DefinePlugin({
+			'process.env': {
+				'NODE_ENV': '"production"',
+			},
+		}) : function() {},
+		isMinified ? new webpack.optimize.UglifyJsPlugin({
+			compress: {
+				warnings: false,
+			},
+		}) : function() {},
+	],
+};


### PR DESCRIPTION
Fixes #525 by adding a bundled build of lucid to the `npm run preversion` command.

## PR Checklist

- ~~Manually tested across supported browsers~~
- ~~Unit tests written (`common` at minimum)~~
- ~~PR has one of the `semver-` labels~~
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~

