### PR TITLE
Updates label alignment for long labels.

### DIFF
--- a/src/components/CheckboxLabeled/CheckboxLabeled.jsx
+++ b/src/components/CheckboxLabeled/CheckboxLabeled.jsx
@@ -94,11 +94,10 @@ const CheckboxLabeled = createClass({
 						onSelect={onSelect}
 						{...omitProps(passThroughs, CheckboxLabeled)}
 				/>
-				{
-					labelChildProps
-							? labelChildProps.children || labelChildProps
-							: null
-				}
+				<div
+					{...labelChildProps}
+					className={cx('&-label')}
+				/>
 			</label>
 		);
 	},

--- a/src/components/CheckboxLabeled/CheckboxLabeled.less
+++ b/src/components/CheckboxLabeled/CheckboxLabeled.less
@@ -12,7 +12,7 @@
 	}
 
 	&-label {
-		align-self: center;
+		padding-top: @size-XXS;
 	}
 
 	&&-is-disabled {

--- a/src/components/CheckboxLabeled/CheckboxLabeled.less
+++ b/src/components/CheckboxLabeled/CheckboxLabeled.less
@@ -1,5 +1,5 @@
 .lucid-CheckboxLabeled {
-	align-items: center;
+	align-items: flex-start;
 	color: @color-darkGray;
 	cursor: pointer;
 	display: flex;
@@ -9,6 +9,10 @@
 	> .lucid-Checkbox {
 		flex: 0 0 @Checkbox-size;
 		margin-right: @size-XXS;
+	}
+
+	&-label {
+		align-self: center;
 	}
 
 	&&-is-disabled {

--- a/src/components/CheckboxLabeled/examples/interactive.jsx
+++ b/src/components/CheckboxLabeled/examples/interactive.jsx
@@ -45,6 +45,22 @@ export default React.createClass({
 		});
 	},
 
+	handleSelectedHipsum2(isSelected) {
+		this.setState({
+			flavors: isSelected
+				? _.concat(this.state.flavors, 'hipsum2')
+				: _.without(this.state.flavors, 'hipsum2'),
+		});
+	},
+
+	handleSelectedHipsum3(isSelected) {
+		this.setState({
+			flavors: isSelected
+				? _.concat(this.state.flavors, 'hipsum3')
+				: _.without(this.state.flavors, 'hipsum3'),
+		});
+	},
+
 	render() {
 		return (
 			<section>
@@ -80,6 +96,22 @@ export default React.createClass({
 							style={style}
 					>
 						<CheckboxLabeled.Label>Polaroid four dollar toast bespoke succulents. Kickstarter truffaut PBR&B fashion axe, lyft actually viral everyday carry iPhone tote bag mumblecore umami. Skateboard you probably haven't heard of them before they sold out, edison bulb paleo poutine jianbing blue bottle mixtape. Normcore farm-to-table coloring book cliche before they sold out. Roof party authentic hoodie paleo next level, bicycle rights selvage you probably haven't heard of them leggings venmo etsy cronut williamsburg. Dreamcatcher vice gastropub austin fam. Actually subway tile kickstarter, messenger bag shabby chic activated charcoal lomo.</CheckboxLabeled.Label>
+					</CheckboxLabeled>
+					<CheckboxLabeled
+							isSelected={_.includes(this.state.flavors, 'hipsum2')}
+							name='interactive-checkboxes'
+							onSelect={this.handleSelectedHipsum2}
+							style={style}
+					>
+						<CheckboxLabeled.Label>Unicorn helvetica glossier pop-up letterpress snackwave raw denim. Lomo blog tattooed helvetica seitan DIY. Tbh kombucha shabby chic cornhole, microdosing seitan snackwave gastropub celiac. Biodiesel 90's fixie drinking vinegar literally unicorn readymade fap, vape wolf direct trade kickstarter pickled disrupt fashion axe. Heirloom subway tile hell of, austin portland meditation PBR&B tacos raclette. Prism fanny pack banh mi trust fund unicorn, thundercats chicharrones salvia pour-over VHS. Distillery organic pork belly squid.</CheckboxLabeled.Label>
+					</CheckboxLabeled>
+					<CheckboxLabeled
+							isSelected={_.includes(this.state.flavors, 'hipsum3')}
+							name='interactive-checkboxes'
+							onSelect={this.handleSelectedHipsum3}
+							style={style}
+					>
+						<CheckboxLabeled.Label>Heirloom keffiyeh schlitz cray. Keytar tumblr dreamcatcher art party polaroid, sriracha etsy pinterest typewriter. IPhone ugh williamsburg man bun waistcoat literally paleo direct trade. Taxidermy cold-pressed pabst green juice, freegan tumblr post-ironic everyday carry disrupt distillery. Hell of lumbersexual cliche, whatever tilde raclette pop-up blue bottle skateboard butcher meditation four dollar toast tattooed health goth pinterest. Poutine polaroid YOLO, biodiesel chambray gentrify microdosing kickstarter bushwick humblebrag yr cred intelligentsia you probably haven't heard of them. Blog meditation locavore tousled, edison bulb cronut occupy +1 you probably haven't heard of them echo park distillery chambray.</CheckboxLabeled.Label>
 					</CheckboxLabeled>
 				</span>
 			</section>

--- a/src/components/CheckboxLabeled/examples/interactive.jsx
+++ b/src/components/CheckboxLabeled/examples/interactive.jsx
@@ -37,6 +37,14 @@ export default React.createClass({
 		});
 	},
 
+	handleSelectedHipsum(isSelected) {
+		this.setState({
+			flavors: isSelected
+				? _.concat(this.state.flavors, 'hipsum')
+				: _.without(this.state.flavors, 'hipsum'),
+		});
+	},
+
 	render() {
 		return (
 			<section>
@@ -64,6 +72,14 @@ export default React.createClass({
 							style={style}
 					>
 						<CheckboxLabeled.Label>Strawberry</CheckboxLabeled.Label>
+					</CheckboxLabeled>
+					<CheckboxLabeled
+							isSelected={_.includes(this.state.flavors, 'hipsum')}
+							name='interactive-checkboxes'
+							onSelect={this.handleSelectedHipsum}
+							style={style}
+					>
+						<CheckboxLabeled.Label>Polaroid four dollar toast bespoke succulents. Kickstarter truffaut PBR&B fashion axe, lyft actually viral everyday carry iPhone tote bag mumblecore umami. Skateboard you probably haven't heard of them before they sold out, edison bulb paleo poutine jianbing blue bottle mixtape. Normcore farm-to-table coloring book cliche before they sold out. Roof party authentic hoodie paleo next level, bicycle rights selvage you probably haven't heard of them leggings venmo etsy cronut williamsburg. Dreamcatcher vice gastropub austin fam. Actually subway tile kickstarter, messenger bag shabby chic activated charcoal lomo.</CheckboxLabeled.Label>
 					</CheckboxLabeled>
 				</span>
 			</section>

--- a/src/components/RadioButtonLabeled/RadioButtonLabeled.jsx
+++ b/src/components/RadioButtonLabeled/RadioButtonLabeled.jsx
@@ -91,11 +91,10 @@ const RadioButtonLabeled = createClass({
 						onSelect={onSelect}
 						{...omitProps(passThroughs, RadioButtonLabeled)}
 				/>
-				{
-					labelChildProps
-							? labelChildProps.children
-							: null
-				}
+				<div
+					{...labelChildProps}
+					className={cx('&-label')}
+				/>
 			</label>
 		);
 	},

--- a/src/components/RadioButtonLabeled/RadioButtonLabeled.less
+++ b/src/components/RadioButtonLabeled/RadioButtonLabeled.less
@@ -12,7 +12,7 @@
 	}
 
 	&-label {
-		align-self: center;
+		padding-top: @size-XXS;
 	}
 
 	&&-is-disabled {

--- a/src/components/RadioButtonLabeled/RadioButtonLabeled.less
+++ b/src/components/RadioButtonLabeled/RadioButtonLabeled.less
@@ -1,5 +1,5 @@
 .lucid-RadioButtonLabeled {
-	align-items: center;
+	align-items: flex-start;
 	color: @color-darkGray;
 	cursor: pointer;
 	display: flex;
@@ -9,6 +9,10 @@
 	> .lucid-RadioButton {
 		flex: 0 0 @RadioButton-size;
 		margin-right: @size-XXS;
+	}
+
+	&-label {
+		align-self: center;
 	}
 
 	&&-is-disabled {

--- a/src/components/RadioButtonLabeled/examples/interactive.jsx
+++ b/src/components/RadioButtonLabeled/examples/interactive.jsx
@@ -18,6 +18,12 @@ export default React.createClass({
 		});
 	},
 
+	handleSelectedHipsum() {
+		this.setState({
+			flavor: 'hipsum',
+		});
+	},
+
 	handleSelectedStrawberry() {
 		this.setState({
 			flavor: 'strawberry',
@@ -57,6 +63,14 @@ export default React.createClass({
 							style={style}
 					>
 						<RadioButtonLabeled.Label>Strawberry</RadioButtonLabeled.Label>
+					</RadioButtonLabeled>
+					<RadioButtonLabeled
+							isSelected={this.state.flavor === 'hipsum'}
+							name='interactive-radio-buttons'
+							onSelect={this.handleSelectedHipsum}
+							style={style}
+					>
+						<RadioButtonLabeled.Label>Polaroid four dollar toast bespoke succulents. Kickstarter truffaut PBR&B fashion axe, lyft actually viral everyday carry iPhone tote bag mumblecore umami. Skateboard you probably haven't heard of them before they sold out, edison bulb paleo poutine jianbing blue bottle mixtape. Normcore farm-to-table coloring book cliche before they sold out. Roof party authentic hoodie paleo next level, bicycle rights selvage you probably haven't heard of them leggings venmo etsy cronut williamsburg. Dreamcatcher vice gastropub austin fam. Actually subway tile kickstarter, messenger bag shabby chic activated charcoal lomo.</RadioButtonLabeled.Label>
 					</RadioButtonLabeled>
 				</span>
 			</section>

--- a/src/components/RadioButtonLabeled/examples/interactive.jsx
+++ b/src/components/RadioButtonLabeled/examples/interactive.jsx
@@ -24,6 +24,18 @@ export default React.createClass({
 		});
 	},
 
+	handleSelectedHipsum2() {
+		this.setState({
+			flavor: 'hipsum2',
+		});
+	},
+
+	handleSelectedHipsum3() {
+		this.setState({
+			flavor: 'hipsum3',
+		});
+	},
+
 	handleSelectedStrawberry() {
 		this.setState({
 			flavor: 'strawberry',
@@ -71,6 +83,22 @@ export default React.createClass({
 							style={style}
 					>
 						<RadioButtonLabeled.Label>Polaroid four dollar toast bespoke succulents. Kickstarter truffaut PBR&B fashion axe, lyft actually viral everyday carry iPhone tote bag mumblecore umami. Skateboard you probably haven't heard of them before they sold out, edison bulb paleo poutine jianbing blue bottle mixtape. Normcore farm-to-table coloring book cliche before they sold out. Roof party authentic hoodie paleo next level, bicycle rights selvage you probably haven't heard of them leggings venmo etsy cronut williamsburg. Dreamcatcher vice gastropub austin fam. Actually subway tile kickstarter, messenger bag shabby chic activated charcoal lomo.</RadioButtonLabeled.Label>
+					</RadioButtonLabeled>
+					<RadioButtonLabeled
+							isSelected={this.state.flavor === 'hipsum2'}
+							name='interactive-radio-buttons'
+							onSelect={this.handleSelectedHipsum2}
+							style={style}
+					>
+						<RadioButtonLabeled.Label>Unicorn helvetica glossier pop-up letterpress snackwave raw denim. Lomo blog tattooed helvetica seitan DIY. Tbh kombucha shabby chic cornhole, microdosing seitan snackwave gastropub celiac. Biodiesel 90's fixie drinking vinegar literally unicorn readymade fap, vape wolf direct trade kickstarter pickled disrupt fashion axe. Heirloom subway tile hell of, austin portland meditation PBR&B tacos raclette. Prism fanny pack banh mi trust fund unicorn, thundercats chicharrones salvia pour-over VHS. Distillery organic pork belly squid.</RadioButtonLabeled.Label>
+					</RadioButtonLabeled>
+					<RadioButtonLabeled
+							isSelected={this.state.flavor === 'hipsum3'}
+							name='interactive-radio-buttons'
+							onSelect={this.handleSelectedHipsum3}
+							style={style}
+					>
+						<RadioButtonLabeled.Label>Heirloom keffiyeh schlitz cray. Keytar tumblr dreamcatcher art party polaroid, sriracha etsy pinterest typewriter. IPhone ugh williamsburg man bun waistcoat literally paleo direct trade. Taxidermy cold-pressed pabst green juice, freegan tumblr post-ironic everyday carry disrupt distillery. Hell of lumbersexual cliche, whatever tilde raclette pop-up blue bottle skateboard butcher meditation four dollar toast tattooed health goth pinterest. Poutine polaroid YOLO, biodiesel chambray gentrify microdosing kickstarter bushwick humblebrag yr cred intelligentsia you probably haven't heard of them. Blog meditation locavore tousled, edison bulb cronut occupy +1 you probably haven't heard of them echo park distillery chambray.</RadioButtonLabeled.Label>
 					</RadioButtonLabeled>
 				</span>
 			</section>

--- a/src/components/RadioGroup/RadioGroup.spec.jsx
+++ b/src/components/RadioGroup/RadioGroup.spec.jsx
@@ -170,7 +170,7 @@ describe('RadioGroup', () => {
 				</RadioGroup>
 			);
 
-			wrapper.children().at(1).children().simulate('click');
+			wrapper.childAt(1).childAt(0).simulate('click');
 			assert(onSelect.calledOnce);
 		});
 
@@ -184,7 +184,7 @@ describe('RadioGroup', () => {
 				</RadioGroup>
 			);
 
-			wrapper.children().at(1).children().simulate('click');
+			wrapper.childAt(1).childAt(0).simulate('click');
 			assert.equal(onSelect.args[0][0], 1);
 			assert(_.last(onSelect.args[0]).event instanceof SyntheticEvent);
 		});
@@ -200,7 +200,7 @@ describe('RadioGroup', () => {
 				</RadioGroup>
 			);
 
-			wrapper.children().at(1).children().simulate('click');
+			wrapper.childAt(1).childAt(0).simulate('click');
 			assert(childOnSelect.calledBefore(onSelect));
 		});
 	});


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval

Fixes #529.
Docs here: http://docspot.devnxs.net/projects/lucid/529-improve-label-alignment/#/components/RadioButtonLabeled

This doesn't make a change to `SwitchLabeled` because it doesn't look like the text for that component wraps with longer labels.