### PR TITLE
547 checkbox indeterminate

### DIFF
--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -32,6 +32,13 @@ const Checkbox = createClass({
 		className: string,
 
 		/**
+		 * Indicates whether the component should appear in an "indeterminate"
+		 * or "partially checked" state. This prop takes precedence over
+		 * `isSelected`.
+		 */
+		isIndeterminate: bool,
+
+		/**
 		 * Indicates whether the component should appear and act disabled by
 		 * having a "greyed out" palette and ignoring user interactions.
 		 */
@@ -39,7 +46,8 @@ const Checkbox = createClass({
 
 		/**
 		 * Indicates that the component is in the "selected" state when true
-		 * and in the "unselected" state when false.
+		 * and in the "unselected" state when false. This props is ignored if
+		 * `isIndeterminate` is `true`.
 		 */
 		isSelected: bool,
 
@@ -59,6 +67,7 @@ const Checkbox = createClass({
 
 	getDefaultProps() {
 		return {
+			isIndeterminate: false,
 			isDisabled: false,
 			isSelected: false,
 			onSelect: _.noop,
@@ -76,8 +85,9 @@ const Checkbox = createClass({
 	render() {
 		const {
 			className,
-			isDisabled,
+			isIndeterminate,
 			isSelected,
+			isDisabled,
 			style,
 			...passThroughs,
 		} = this.props;
@@ -86,7 +96,7 @@ const Checkbox = createClass({
 			<div
 				className={cx('&', {
 					'&-is-disabled': isDisabled,
-					'&-is-selected': isSelected,
+					'&-is-selected': isIndeterminate || isSelected,
 				}, className)}
 				onClick={this.handleClicked}
 				onTouchEnd={this.handleClicked}
@@ -103,10 +113,17 @@ const Checkbox = createClass({
 				/>
 				<span onClick={this.handleSpanClick} className={cx('&-visualization-glow')} />
 				<span onClick={this.handleSpanClick} className={cx('&-visualization-container')} />
-				<span onClick={this.handleSpanClick} className={cx('&-visualization-checkmark')}>
-					<span className={cx('&-visualization-checkmark-stem')}></span>
-					<span className={cx('&-visualization-checkmark-kick')}></span>
-				</span>
+				{isIndeterminate ? (
+					<span onClick={this.handleSpanClick} className={cx('&-visualization-indeterminate')}>
+						<span className={cx('&-visualization-indeterminate-line')}></span>
+					</span>
+				) : (
+					<span onClick={this.handleSpanClick} className={cx('&-visualization-checkmark')}>
+						<span className={cx('&-visualization-checkmark-stem')}></span>
+						<span className={cx('&-visualization-checkmark-kick')}></span>
+					</span>
+				)
+				}
 			</div>
 		);
 	},

--- a/src/components/Checkbox/Checkbox.less
+++ b/src/components/Checkbox/Checkbox.less
@@ -40,6 +40,25 @@
 		width: @Checkbox-container-size;
 	}
 
+	&-visualization-indeterminate {
+		opacity: 0;
+		width: @Checkbox-size;
+		height: @Checkbox-size;
+		transform: rotate(0deg);
+		top: 0;
+		left: 0;
+		position: absolute;
+	}
+
+	&-visualization-indeterminate-line {
+		top: 10px;
+		left: 7px;
+		width: 8px;
+		height: 2px;
+		background-color: white;
+		position: absolute;
+	}
+
 	&-visualization-checkmark {
 		opacity: 0;
 		width: @Checkbox-size;
@@ -119,7 +138,7 @@
 		border-color: @Checkbox-disabled-borderColor;
 	}
 
-	&-is-selected &-visualization-checkmark {
+	&-is-selected &-visualization-checkmark, &-visualization-indeterminate {
 		opacity: 1;
 		transition: @Checkbox-animation-timing;
 	}

--- a/src/components/Checkbox/Checkbox.spec.jsx
+++ b/src/components/Checkbox/Checkbox.spec.jsx
@@ -8,7 +8,7 @@ import sinon from 'sinon';
 
 import Checkbox from './Checkbox';
 
-describe('Checkbox', () => {
+describe.only('Checkbox', () => {
 	common(Checkbox);
 	controls(Checkbox, {
 		callbackName: 'onSelect',
@@ -17,77 +17,81 @@ describe('Checkbox', () => {
 	});
 
 	describe('props', () => {
-		it('`isDisabled` sets the `disabled` attribute of the native checkbox element', () => {
-			const trueWrapper = shallow(<Checkbox isDisabled={true} />);
-			const falseWrapper = shallow(<Checkbox isDisabled={false} />);
 
-			assert.equal(trueWrapper.find('.lucid-Checkbox-native').prop('disabled'), true);
-			assert.equal(falseWrapper.find('.lucid-Checkbox-native').prop('disabled'), false);
+		describe('isDisabled', () => {
+
+			it('should set `disabled` attribute to true', () => {
+				const trueWrapper = mount(<Checkbox isDisabled={true} />);
+				assert.equal(trueWrapper.find('.lucid-Checkbox-native').prop('disabled'), true);
+			});
+
+			it('should set `disabled` attribute to false', () => {
+				const falseWrapper = mount(<Checkbox isDisabled={false} />);
+				assert.equal(falseWrapper.find('.lucid-Checkbox-native').prop('disabled'), false);
+			});
+
+			it('`isDisabled` defaults to `false`', () => {
+				const wrapper = mount(<Checkbox />);
+				assert.equal(wrapper.prop('isDisabled'), false);
+			});
+
 		});
 
-		it('`isSelected` sets the `checked` attribute of the native check box element', () => {
-			const trueWrapper = shallow(<Checkbox isSelected={true} />);
-			const falseWrapper = shallow(<Checkbox isSelected={false} />);
+		describe('isSelected', () => {
 
-			assert.equal(trueWrapper.find('.lucid-Checkbox-native').prop('checked'), true);
-			assert.equal(falseWrapper.find('.lucid-Checkbox-native').prop('checked'), false);
+			it('`isSelected` defaults to `false`', () => {
+				const wrapper = mount(<Checkbox />);
+				assert.equal(wrapper.prop('isSelected'), false);
+			});
+
+			it('should set `checked` attribute to true', () => {
+				const trueWrapper = mount(<Checkbox isSelected={true} />);
+				assert.equal(trueWrapper.find('.lucid-Checkbox-native').prop('checked'), true);
+			});
+
+			it('should set `checked` attribute to false', () => {
+				const falseWrapper = mount(<Checkbox isSelected={false} />);
+				assert.equal(falseWrapper.find('.lucid-Checkbox-native').prop('checked'), false);
+			});
+
 		});
 
-	});
-});
-
-describe('Checkbox', () => {
-	function simulateEvent(reactElement, selector, event) {
-		mount(reactElement).find(selector).simulate(event);
-	}
-
-	function verifyArgumentsWhenFalse(event) {
-		_.forEach(['', '-native', '-visualization-container', '-visualization-glow', '-visualization-checkmark'], (classSubString) => {
-			const onSelect = sinon.spy();
-
-			simulateEvent(<Checkbox isSelected={false} onSelect={onSelect} />, `.lucid-Checkbox${classSubString}`, event);
-			assert.equal(onSelect.args[0][0], true);
-			assert(_.last(onSelect.args[0]).event instanceof SyntheticEvent);
-		});
-	}
-
-	function verifyArgumentsWhenTrue(event) {
-		_.forEach(['', '-native', '-visualization-container', '-visualization-glow', '-visualization-checkmark'], (classSubString) => {
-			const onSelect = sinon.spy();
-
-			simulateEvent(<Checkbox isSelected={true} onSelect={onSelect} />, `.lucid-Checkbox${classSubString}`, event);
-			assert.equal(onSelect.args[0][0], false);
-			assert(_.last(onSelect.args[0]).event instanceof SyntheticEvent);
-		});
-	}
-
-	function verifyOnSelect(event) {
-		_.forEach(['', '-native', '-visualization-container', '-visualization-glow', '-visualization-checkmark'], (classSubString) => {
-			const onSelect = sinon.spy();
-
-			simulateEvent(<Checkbox onSelect={onSelect} />, `.lucid-Checkbox${classSubString}`, event);
-			assert(onSelect.calledOnce);
-		});
-	}
-
-	describe('props', () => {
-		it('`isDisabled` defaults to `false`', () => {
-			const wrapper = mount(<Checkbox />);
-
-			assert.equal(wrapper.prop('isDisabled'), false);
+		describe('onSelect', () => {
+			it('`onSelect` defaults to the Lodash `noop` method', () => {
+				const wrapper = mount(<Checkbox />);
+				assert.equal(wrapper.prop('onSelect'), _.noop);
+			});
 		});
 
-		it('`isSelected` defaults to `false`', () => {
-			const wrapper = mount(<Checkbox />);
+		describe('isIndeterminate', () => {
 
-			assert.equal(wrapper.prop('isSelected'), false);
+			it('`isIndeterminate` default to `false`', () => {
+				const wrapper = mount(<Checkbox />);
+				assert.equal(wrapper.prop('isIndeterminate'), false);
+			});
+
+			it('should set the top-level classname `&-is-selected`', () => {
+				const wrapper = shallow(<Checkbox isIndeterminate/>);
+				assert(wrapper.hasClass('lucid-Checkbox-is-selected'));
+			});
+
+			it('should not contain a `span.&-visualization-checkmark`', () => {
+				const wrapper = shallow(<Checkbox isIndeterminate/>);
+				assert.equal(wrapper.find('span.lucid-Checkbox-visualization-checkmark').length, 0);
+			});
+
+			it('should contain a `span.&-visualization-indeterminate`', () => {
+				const wrapper = shallow(<Checkbox isIndeterminate/>);
+				assert.equal(wrapper.find('span.lucid-Checkbox-visualization-indeterminate').length, 1);
+			});
+
+			it('should contain a `span.&-visualization-indeterminate-line`', () => {
+				const wrapper = shallow(<Checkbox isIndeterminate/>);
+				assert.equal(wrapper.find('span.lucid-Checkbox-visualization-indeterminate-line').length, 1);
+			});
+
 		});
 
-		it('`onSelect` defaults to the Lodash `noop` method', () => {
-			const wrapper = mount(<Checkbox />);
-
-			assert.equal(wrapper.prop('onSelect'), _.noop);
-		});
 	});
 
 	describe('pass throughs', () => {
@@ -146,3 +150,35 @@ describe('Checkbox', () => {
 	});
 });
 
+function simulateEvent(reactElement, selector, event) {
+	mount(reactElement).find(selector).simulate(event);
+}
+
+function verifyArgumentsWhenFalse(event) {
+	_.forEach(['', '-native', '-visualization-container', '-visualization-glow', '-visualization-checkmark'], (classSubString) => {
+		const onSelect = sinon.spy();
+
+		simulateEvent(<Checkbox isSelected={false} onSelect={onSelect} />, `.lucid-Checkbox${classSubString}`, event);
+		assert.equal(onSelect.args[0][0], true);
+		assert(_.last(onSelect.args[0]).event instanceof SyntheticEvent);
+	});
+}
+
+function verifyArgumentsWhenTrue(event) {
+	_.forEach(['', '-native', '-visualization-container', '-visualization-glow', '-visualization-checkmark'], (classSubString) => {
+		const onSelect = sinon.spy();
+
+		simulateEvent(<Checkbox isSelected={true} onSelect={onSelect} />, `.lucid-Checkbox${classSubString}`, event);
+		assert.equal(onSelect.args[0][0], false);
+		assert(_.last(onSelect.args[0]).event instanceof SyntheticEvent);
+	});
+}
+
+function verifyOnSelect(event) {
+	_.forEach(['', '-native', '-visualization-container', '-visualization-glow', '-visualization-checkmark'], (classSubString) => {
+		const onSelect = sinon.spy();
+
+		simulateEvent(<Checkbox onSelect={onSelect} />, `.lucid-Checkbox${classSubString}`, event);
+		assert(onSelect.calledOnce);
+	});
+}

--- a/src/components/Checkbox/Checkbox.spec.jsx
+++ b/src/components/Checkbox/Checkbox.spec.jsx
@@ -8,7 +8,7 @@ import sinon from 'sinon';
 
 import Checkbox from './Checkbox';
 
-describe.only('Checkbox', () => {
+describe('Checkbox', () => {
 	common(Checkbox);
 	controls(Checkbox, {
 		callbackName: 'onSelect',

--- a/src/components/Checkbox/examples/interactive.jsx
+++ b/src/components/Checkbox/examples/interactive.jsx
@@ -4,14 +4,14 @@ import { Checkbox } from '../../../index';
 export default React.createClass({
 	getInitialState() {
 		return {
-			isSelected: true,
+			isSelected: 0,
 		};
 	},
 
-	handleSelected(isSelected) {
+	handleSelected() {
 		this.setState({
 			...this.state,
-			isSelected,
+			isSelected: (this.state.isSelected + 1) % 3,
 		});
 	},
 
@@ -21,7 +21,8 @@ export default React.createClass({
 				<li>
 					<label>Plain</label>
 					<Checkbox
-						isSelected={this.state.isSelected}
+						isIndeterminate={this.state.isSelected === 1}
+						isSelected={this.state.isSelected === 0}
 						onSelect={this.handleSelected}
 						tabIndex={20}
 					/>
@@ -38,6 +39,14 @@ export default React.createClass({
 					<label>Disabled selected</label>
 					<Checkbox
 						isSelected={true}
+						isDisabled={true}
+						tabIndex={20}
+					/>
+				</li>
+				<li>
+					<label>Disabled indeterminate</label>
+					<Checkbox
+						isIndeterminate={true}
 						isDisabled={true}
 						tabIndex={20}
 					/>

--- a/src/components/CheckboxLabeled/CheckboxLabeled.jsx
+++ b/src/components/CheckboxLabeled/CheckboxLabeled.jsx
@@ -61,6 +61,7 @@ const CheckboxLabeled = createClass({
 
 	getDefaultProps() {
 		return {
+			isIndeterminate: false,
 			isDisabled: false,
 			isSelected: false,
 			onSelect: _.noop,
@@ -70,6 +71,7 @@ const CheckboxLabeled = createClass({
 	render() {
 		const {
 			className,
+			isIndeterminate,
 			isDisabled,
 			isSelected,
 			onSelect,
@@ -83,13 +85,14 @@ const CheckboxLabeled = createClass({
 			<label
 					className={cx('&', {
 						'&-is-disabled': isDisabled,
-						'&-is-selected': isSelected,
+						'&-is-selected': isIndeterminate || isSelected,
 					}, className)}
 					style={style}
 			>
 				<Checkbox
 						className={className}
 						isDisabled={isDisabled}
+						isIndeterminate={isIndeterminate}
 						isSelected={isSelected}
 						onSelect={onSelect}
 						{...omitProps(passThroughs, CheckboxLabeled)}


### PR DESCRIPTION
fixes #547 

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval

http://docspot.devnxs.net/projects/lucid/547-checkbox-indeterminate/#/components/Checkbox