### PR TITLE
Adds `additionalOffset` to `scrollParentTo`.

### DIFF
--- a/src/components/DropMenu/DropMenu.jsx
+++ b/src/components/DropMenu/DropMenu.jsx
@@ -432,7 +432,7 @@ const DropMenu = createClass({
 				}, optionProps.className)}
 				ref={(optionDOMNode)=> {
 					if (isFocused && !isMouseTriggered) {
-						scrollParentTo(optionDOMNode);
+						scrollParentTo(optionDOMNode, this._header && this._header.offsetHeight);
 					}
 				}}
 			/>
@@ -502,6 +502,7 @@ const DropMenu = createClass({
 								{...headerProps}
 								className={cx('&-Header', headerProps.className)}
 								onKeyDown={this.handleKeydown}
+								ref={(header) => this._header = header}
 							/>
 						}
 						<div

--- a/src/util/dom-helpers.js
+++ b/src/util/dom-helpers.js
@@ -14,13 +14,13 @@ export function getAbsoluteBoundingClientRect(domNode) {
 }
 
 
-export function scrollParentTo(domNode) {
+export function scrollParentTo(domNode, additionalOffset = 0) {
 	if (domNode) {
-		let parentNode = domNode.parentNode;
-		if (parentNode.scrollTop > domNode.offsetTop) {
+		const parentNode = domNode.parentNode;
+		if (parentNode.scrollTop > domNode.offsetTop - additionalOffset) {
 			// if the top of the node is above the scroll line,
 			// align to top
-			parentNode.scrollTop = domNode.offsetTop;
+			parentNode.scrollTop = domNode.offsetTop - additionalOffset;
 		} else if ( parentNode.scrollTop + parentNode.clientHeight < domNode.offsetTop + domNode.offsetHeight) {
 			// else if the bottom of the node is below the fold,
 			// align to bottom

--- a/src/util/dom-helpers.spec.js
+++ b/src/util/dom-helpers.spec.js
@@ -60,6 +60,14 @@ describe('#scrollParentTo', () => {
 		assert.equal(parentNode.scrollTop, 0); //expect parent to be scrolled to the top
 	});
 
+	it('should align using the additionalOffset', () => {
+		// just using plain objects here to avoid having to deal with weird dom positioning
+		const parent = {scrollTop: 10};
+		const child = {parentNode: parent, offsetTop: 15};
+		scrollParentTo(child, 10);
+		assert.equal(parent.scrollTop, 5);
+	});
+
 	it('should align to bottom if the bottom of the node is below the fold', () => {
 		parentNode.scrollTop = 0; // parent element is scrolled up to top
 		parentNode.style.overflowY = 'scroll';
@@ -81,5 +89,4 @@ describe('#scrollParentTo', () => {
 		scrollParentTo(childNode);
 		assert.equal(parentNode.scrollTop, 5); //expect no change in scrolling of parent
 	});
-
 });


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [X] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #552 