### PR TITLE
Reverts OverlayWrapper to be `display: block`.

### DIFF
--- a/src/components/OverlayWrapper/OverlayWrapper.less
+++ b/src/components/OverlayWrapper/OverlayWrapper.less
@@ -1,5 +1,5 @@
 .lucid-OverlayWrapper {
-	display: inline-block;
+	display: block;
 	position: relative;
 
 	&-message-container {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #554 