### PR TITLE
Makes the default EmptyMessageTitle more generic

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -234,7 +234,7 @@ const DataTable = createClass({
 		);
 
 		const emptyMessageBodyProp = _.get(getFirst(this.props, DataTable.EmptyMessageBody), 'props');
-		const emptyMessageTitleProp = _.get(getFirst(this.props, DataTable.EmptyMessageTitle), 'props', {children: 'You have no Line Items.'});
+		const emptyMessageTitleProp = _.get(getFirst(this.props, DataTable.EmptyMessageTitle), 'props', {children: 'You have no items.'});
 
 		return (
 			<OverlayWrapper


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - ~~[ ] Chrome~~
  - ~~[ ] Firefox~~
  - ~~[ ] Safari~~
  - ~~[ ] IE11 (Win 7)~~
  - ~~[ ] Edge (Win 10)~~
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #553 