### PR TITLE
Adds an `isLoading` prop to `DataTable`

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -4,8 +4,7 @@ import { lucidClassNames } from '../../util/style-helpers';
 import { createClass, findTypes, filterTypes, getFirst, omitProps } from '../../util/component-types';
 
 import Checkbox from '../Checkbox/Checkbox';
-import HatchPattern from '../HatchPattern/HatchPattern';
-import OverlayWrapper from '../OverlayWrapper/OverlayWrapper';
+import DataTableWrapper from '../DataTableWrapper/DataTableWrapper';
 import ScrollTable from '../ScrollTable/ScrollTable';
 
 const {
@@ -29,7 +28,7 @@ const {
 
 /**
  *
- * {"categories": ["table"], "madeFrom": ["ScrollTable", "Checkbox"]}
+ * {"categories": ["table"], "madeFrom": ["Checkbox", "DataTableWrapper", "ScrollTable"]}
  *
  * `DataTable` provides a simple abstraction over the `Table` component to make it easier to define data-driven tables and render an array of objects.
  */
@@ -57,6 +56,10 @@ const DataTable = createClass({
 		 * Render each row item to be navigable, allowing `onRowClick` to be triggered.
 		 */
 		isActionable: bool,
+		/**
+		 * Controls the visibility of the `LoadingMessage`.
+		 */
+		isLoading: bool,
 		/**
 		 * Handler for checkbox selection. Signature is `(object, index, { props, event }) => {...}`
 		 */
@@ -201,11 +204,11 @@ const DataTable = createClass({
 	},
 
 	render() {
-
 		const {
 			className,
 			data,
 			isActionable,
+			isLoading,
 			isSelectable,
 			style,
 			...passThroughs,
@@ -237,17 +240,12 @@ const DataTable = createClass({
 		const emptyMessageTitleProp = _.get(getFirst(this.props, DataTable.EmptyMessageTitle), 'props', {children: 'You have no Line Items.'});
 
 		return (
-			<OverlayWrapper
-				hasOverlay={false}
-				isVisible={!data || data.length === 0}
+			<DataTableWrapper
+				isLoading={isLoading}
+				isEmpty={!data || data.length === 0}
 			>
-				<OverlayWrapper.Message className={cx('&-message-container')}>
-					<HatchPattern />
-					<div className={cx('&-message-contents')}>
-						<header {...emptyMessageTitleProp} className={cx('&-message-title', emptyMessageTitleProp.className)} />
-						{emptyMessageBodyProp && <div {...emptyMessageBodyProp} />}
-					</div>
-				</OverlayWrapper.Message>
+				<DataTableWrapper.EmptyMessageBody {...emptyMessageBodyProp} />
+				<DataTableWrapper.EmptyMessageTitle {...emptyMessageTitleProp} />
 				<ScrollTable
 					style={style}
 					{...omitProps(passThroughs, DataTable)}
@@ -356,7 +354,7 @@ const DataTable = createClass({
 					}
 					</Tbody>
 				</ScrollTable>
-			</OverlayWrapper>
+			</DataTableWrapper>
 		);
 	},
 });

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -242,7 +242,7 @@ const DataTable = createClass({
 		return (
 			<DataTableWrapper
 				isLoading={isLoading}
-				isEmpty={!data || data.length === 0}
+				isEmpty={_.isEmpty(data)}
 			>
 				<DataTableWrapper.EmptyMessageBody {...emptyMessageBodyProp} />
 				<DataTableWrapper.EmptyMessageTitle {...emptyMessageTitleProp} />

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -7,7 +7,7 @@ import { common } from '../../util/generic-tests';
 import DataTable from './DataTable';
 import ScrollTable from '../ScrollTable/ScrollTable';
 import Checkbox from '../Checkbox/Checkbox';
-import OverlayWrapper from '../OverlayWrapper/OverlayWrapper';
+import DataTableWrapper from '../DataTableWrapper/DataTableWrapper';
 
 const { Column, ColumnGroup } = DataTable;
 
@@ -436,6 +436,18 @@ describe('DataTable', () => {
 				assert(_.has(onSort.getCall(4).args[1], 'event'), 'last arg must be passed event');
 			});
 		});
+
+		describe('isLoading', () => {
+			it('should show a `LoadingIndicator` if `isLoading`', () => {
+				const wrapper = shallow(
+					<DataTable isLoading />
+				);
+
+				const loadingIndicatorWrapper = wrapper.find(DataTableWrapper).shallow().find('LoadingIndicator');
+
+				assert(loadingIndicatorWrapper.prop('isLoading'));
+			});
+		});
 	});
 
 	describe('child components', () => {
@@ -563,8 +575,8 @@ describe('DataTable', () => {
 				);
 
 				const messageTitleWrapper = wrapper
-					.find(OverlayWrapper).shallow()
-					.find('.lucid-DataTable-message-title').shallow();
+					.find(DataTableWrapper).shallow()
+					.find('.lucid-DataTableWrapper-message-title').shallow();
 
 				assert.equal(messageTitleWrapper.text(), titleText, 'must contain the title text');
 			});
@@ -580,7 +592,7 @@ describe('DataTable', () => {
 				);
 
 				const messageBodyWrapper = wrapper
-					.find(OverlayWrapper).shallow();
+					.find(DataTableWrapper).shallow();
 
 				assert(messageBodyWrapper.contains(bodyElement), 'must contain the body element');
 			});

--- a/src/components/DataTable/examples/9.loading.jsx
+++ b/src/components/DataTable/examples/9.loading.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { DataTable } from '../../../index';
+
+export default React.createClass({
+	render() {
+
+		return(
+			<DataTable
+				isLoading
+				data={[]}
+			>
+				<DataTable.Column
+					field='id'
+				>
+					ID
+				</DataTable.Column>
+
+				<DataTable.Column
+					field='first_name'
+					width={100}
+				>
+					First
+				</DataTable.Column>
+
+				<DataTable.Column
+					field='last_name'
+					align='left'
+					width={100}
+				>
+					Last
+				</DataTable.Column>
+
+				<DataTable.Column
+					field='email'
+					align='center'
+				>
+					E-Mail
+				</DataTable.Column>
+
+				<DataTable.Column
+					field='occupation'
+					align='right'
+					width={100}
+				>
+					Occupation
+				</DataTable.Column>
+			</DataTable>
+		);
+	},
+});

--- a/src/components/DataTableWrapper/DataTableWrapper.jsx
+++ b/src/components/DataTableWrapper/DataTableWrapper.jsx
@@ -1,0 +1,113 @@
+import _ from 'lodash';
+import React from 'react';
+import { createClass, getFirst } from '../../util/component-types';
+import { lucidClassNames } from '../../util/style-helpers';
+
+import HatchPattern from '../HatchPattern/HatchPattern';
+import LoadingIndicator from '../LoadingIndicator/LoadingIndicator';
+import OverlayWrapper from '../OverlayWrapper/OverlayWrapper';
+
+const cx = lucidClassNames.bind('&-DataTableWrapper');
+
+const {
+	any,
+	bool,
+	node,
+	string,
+} = React.PropTypes;
+
+/**
+ *
+ * {"categories": ["utility"], "madeFrom": ["HatchPattern", "LoadingIndicator", "OverlayWrapper"]}
+ *
+ * A wrapper for the DataTable which can display either a `LoadingIndicator` or `OverlayWrapper`.
+ *
+ */
+const DataTableWrapper = createClass({
+	_isPrivate: true,
+
+	displayName: 'DataTableWrapper',
+
+	propTypes: {
+		/**
+		 * Class names that are appended to the defaults.
+		 */
+		className: string,
+		/**
+		 * Any valid React children.
+		 */
+		children: node,
+		/**
+		 * Controls the visibility of the `EmptyMessage`
+		 */
+		isEmpty: bool,
+		/**
+		 * Controls the visibility of the `LoadingMessage`.
+		 */
+		isLoading: bool,
+		/**
+		 * *Child Element*
+		 *
+		 * The element to display in the body of the overlay for an empty data table.
+		 */
+		EmptyMessageBody: any,
+		/**
+		 * *Child Element*
+		 *
+		 * The element to display in the title of the overlay for an empty data table.
+		 */
+		EmptyMessageTitle: any,
+	},
+
+	components: {
+		/**
+		 * Body content for the message to display when the data table has no data.
+		 */
+		EmptyMessageBody: createClass({
+			displayName: 'DataTableWrapper.EmptyMessageBody',
+			propName: 'EmptyMessageBody',
+		}),
+		/**
+		 * Title text for the message to display when the data table has no data.
+		 */
+		EmptyMessageTitle: createClass({
+			displayName: 'DataTableWrapper.EmptyMessageTitle',
+			propName: 'EmptyMessageTitle',
+		}),
+	},
+
+	render() {
+		const {
+			children,
+			isEmpty,
+			isLoading,
+		} = this.props;
+
+		const emptyMessageBodyProp = _.get(getFirst(this.props, DataTableWrapper.EmptyMessageBody), 'props');
+		const emptyMessageTitleProp = _.get(getFirst(this.props, DataTableWrapper.EmptyMessageTitle), 'props', {children: 'You have no Line Items.'});
+
+		return (
+			isLoading ?
+				<LoadingIndicator isLoading>
+					{children}
+				</LoadingIndicator>
+			:
+				<OverlayWrapper
+					hasOverlay={false}
+					isVisible={isEmpty}
+				>
+					<OverlayWrapper.Message className={cx('&-message-container')}>
+						<HatchPattern />
+						<div className={cx('&-message-contents')}>
+							<header {...emptyMessageTitleProp} className={cx('&-message-title', emptyMessageTitleProp.className)} />
+							{emptyMessageBodyProp && <div {...emptyMessageBodyProp} />}
+						</div>
+					</OverlayWrapper.Message>
+
+					{children}
+				</OverlayWrapper>
+		);
+	},
+})
+
+export default DataTableWrapper;

--- a/src/components/DataTableWrapper/DataTableWrapper.less
+++ b/src/components/DataTableWrapper/DataTableWrapper.less
@@ -1,4 +1,4 @@
-.lucid-DataTable {
+.lucid-DataTableWrapper {
 	&-message-container {
 		max-width: 401px;
 		background-color: @color-white;

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ import CrossIcon from './components/Icon/CrossIcon/CrossIcon';
 import DangerIcon from './components/Icon/DangerIcon/DangerIcon';
 import DangerLightIcon from './components/Icon/DangerLightIcon/DangerLightIcon';
 import DataTable from './components/DataTable/DataTable';
+import DataTableWrapper from './components/DataTableWrapper/DataTableWrapper';
 import DataViewIcon from './components/Icon/DataViewIcon/DataViewIcon';
 import Dialog from './components/Dialog/Dialog';
 import DownloadIcon from './components/Icon/DownloadIcon/DownloadIcon';
@@ -199,6 +200,7 @@ export {
 	DangerIcon,
 	DangerLightIcon,
 	DataTable,
+	DataTableWrapper,
 	DataViewIcon,
 	Dialog,
 	DownloadIcon,

--- a/src/styles/components.less
+++ b/src/styles/components.less
@@ -16,7 +16,7 @@
 @import '../components/Point/Point';
 @import '../components/ContextMenu/ContextMenu';
 @import '../components/DropMenu/DropMenu';
-@import '../components/DataTable/DataTable';
+@import '../components/DataTableWrapper/DataTableWrapper';
 @import '../components/Expander/Expander';
 @import '../components/ExpanderPanel/ExpanderPanel';
 @import '../components/Icon/Icon'; // Should come before other icon files


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #557 