### PR TITLE
Fix issue #564. Pass appropriate props to Legend.Item

### DIFF
--- a/src/components/Legend/Legend.jsx
+++ b/src/components/Legend/Legend.jsx
@@ -85,6 +85,10 @@ const Legend = createClass({
 				color: string,
 				pointKind: number,
 				onClick: func,
+				/**
+				 * Class names that are appended to the defaults.
+				 */
+				className: string,
 			},
 		}),
 	},
@@ -128,11 +132,12 @@ const Legend = createClass({
 					color,
 					onClick,
 					children,
+					className: itemClass,
 				}, index) => (
 					<li
 						key={index}
-						className={cx('&-Item')}
-						onClick={_.partial(this.handleItemClick, index, itemProps)}
+						className={cx(itemClass, '&-Item')}
+						onClick={_.partial(this.handleItemClick, index, itemProps[index])}
 					>
 						{hasPoint || hasLine ?
 							<svg


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #564