### PR TITLE
#566: Add yAxisTooltipDataFormatter prop to BarChart

### DIFF
--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -208,6 +208,10 @@ const BarChart = createClass({
 		 * Signature: `(yField, yValueFormatted, yValue) => {}`
 		 */
 		yAxisTooltipFormatter: func,
+		/**
+		 * An optional function used to format data in the tooltips.
+		 */
+		yAxisTooltipDataFormatter: func,
 	},
 
 	statics: {
@@ -279,6 +283,7 @@ const BarChart = createClass({
 			yAxisTickCount,
 			yAxisMin,
 			yAxisTooltipFormatter,
+			yAxisTooltipDataFormatter,
 			yAxisMax = yAxisIsStacked
 				? maxByFieldsStacked(data, yAxisFields)
 				: maxByFields(data, yAxisFields),
@@ -324,7 +329,11 @@ const BarChart = createClass({
 			.domain([yAxisMin, yAxisMax])
 			.range([innerHeight, 0]);
 
-		const yFinalFormatter = yAxisFormatter || yScale.tickFormat();
+		const yAxisFinalFormatter = yAxisFormatter || yScale.tickFormat();
+
+		const yFinalFormatter = yAxisTooltipDataFormatter
+			? yAxisTooltipDataFormatter
+			: yAxisFinalFormatter;
 
 		return (
 			<svg
@@ -396,7 +405,7 @@ const BarChart = createClass({
 					<Axis
 						orient='left'
 						scale={yScale}
-						tickFormat={yFinalFormatter}
+						tickFormat={yAxisFinalFormatter}
 						tickCount={yAxisTickCount}
 					/>
 				</g>

--- a/src/components/BarChart/BarChart.spec.jsx
+++ b/src/components/BarChart/BarChart.spec.jsx
@@ -24,6 +24,7 @@ describe('BarChart', () => {
 			'xAxisFormatter',
 			'yAxisFormatter',
 			'yAxisTooltipFormatter',
+			'yAxisTooltipDataFormatter',
 		],
 		getDefaultProps: () => ({
 			data: [

--- a/src/components/BarChart/examples/9.formatted-tooltips.jsx
+++ b/src/components/BarChart/examples/9.formatted-tooltips.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import BarChart from '../BarChart';
+import * as formatters from '../../../util/formatters';
+
+const data = [
+	{ x: '2015-01-01', y: 1200 },
+	{ x: '2015-01-02', y: 900 },
+	{ x: '2015-01-03', y: 1800 },
+	{ x: '2015-01-04', y: 3000 },
+];
+
+export default React.createClass({
+	render() {
+		return (
+			<div>
+				<BarChart
+					data={data}
+					yAxisTitle='Revenue'
+					yAxisTooltipDataFormatter={formatters.formatAbbreviatedNumber}
+				/>
+			</div>
+		);
+	},
+});

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -443,21 +443,22 @@ const LineChart = createClass({
 			? d3Scale.scaleLinear().domain([y2AxisMin, y2AxisMax]).range([innerHeight, 0])
 			: null;
 
+		const yAxisFinalFormatter = yAxisFormatter || yScale.tickFormat();
+		const y2AxisFinalFormatter = y2AxisFormatter
+			? y2AxisFormatter
+			: y2Scale
+				? y2Scale.tickFormat()
+				: _.identity;
+
 		const xFinalFormatter = xAxisFormatter
 			? xAxisFormatter
 			: xScale.tickFormat();
 		const yFinalFormatter = yAxisTooltipDataFormatter
 			? yAxisTooltipDataFormatter
-			: yAxisFormatter
-				? yAxisFormatter
-				: yScale.tickFormat();
+			: yAxisFinalFormatter;
 		const y2FinalFormatter = y2AxisTooltipDataFormatter
 			? y2AxisTooltipDataFormatter
-				: y2AxisFormatter
-				? y2AxisFormatter
-				: y2Scale
-					? y2Scale.tickFormat()
-					: _.identity;
+				: y2AxisFinalFormatter;
 
 		// This logic is getting a bit complicated
 		const yAxisHasPointsFinal = yAxisHasPoints || yAxisIsStacked;
@@ -630,7 +631,7 @@ const LineChart = createClass({
 					<Axis
 						orient='left'
 						scale={yScale}
-						tickFormat={yAxisFormatter}
+						tickFormat={yAxisFinalFormatter}
 						tickCount={yAxisTickCount}
 						ref='yAxis'
 					/>
@@ -659,7 +660,7 @@ const LineChart = createClass({
 						<Axis
 							orient='right'
 							scale={y2Scale}
-							tickFormat={y2AxisFormatter}
+							tickFormat={y2AxisFinalFormatter}
 							tickCount={y2AxisTickCount}
 							ref='y2Axis'
 						/>


### PR DESCRIPTION
## Changes

![screen shot 2016-10-11 at 12 00 13 pm](https://cloud.githubusercontent.com/assets/4751583/19284553/3a2bc020-8fab-11e6-9039-12cf2222e5d9.png)

- Add `yAxisTooltipDataFormatter` to `BarChart`
- In `LineChart`, cleanup defaults for `yAxisFormatter` and `y2AxisFormatter`
- In `BarChart`, cleanup defaults for `yAxisFormatter`

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #566