### PR TITLE
Fixes issue #568. Adjust colorOffset of lines and points

### DIFF
--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -236,6 +236,11 @@ const LineChart = createClass({
 		 * An optional function used to format data in the tooltips.
 		 */
 		yAxisTooltipDataFormatter: func,
+		/**
+		 * Set the starting index where colors start rotating for points and lines
+		 * along the y axis.
+		 */
+		yAxisColorOffset: number,
 
 
 		/**
@@ -292,6 +297,11 @@ const LineChart = createClass({
 		 * `number` is supported only for backwards compatability.
 		 */
 		y2AxisTitleColor: oneOfType([number, string]),
+		/**
+		 * Set the starting index where colors start rotating for points and lines
+		 * along the y2 axis.
+		 */
+		y2AxisColorOffset: number,
 	},
 
 	statics: {
@@ -332,6 +342,7 @@ const LineChart = createClass({
 			yAxisTitle: null,
 			yAxisTitleColor: '#000',
 			yAxisTooltipFormatter: (yField, yValueFormatted) => `${yField}: ${yValueFormatted}`,
+			yAxisColorOffset: 0,
 
 			y2AxisFields: null,
 			y2AxisIsStacked: false,
@@ -340,6 +351,7 @@ const LineChart = createClass({
 			y2AxisTickCount: null,
 			y2AxisTitle: null,
 			y2AxisTitleColor: '#000',
+			y2AxisColorOffset: 1,
 		};
 	},
 
@@ -384,6 +396,7 @@ const LineChart = createClass({
 			yAxisMax = yAxisIsStacked
 				? maxByFieldsStacked(data, yAxisFields)
 				: maxByFields(data, yAxisFields),
+			yAxisColorOffset,
 
 			y2AxisFields,
 			y2AxisFormatter,
@@ -397,6 +410,7 @@ const LineChart = createClass({
 			y2AxisMax = y2AxisFields && y2AxisIsStacked
 				? maxByFieldsStacked(data, y2AxisFields)
 				: maxByFields(data, y2AxisFields),
+			y2AxisColorOffset,
 
 			...passThroughs,
 		} = this.props;
@@ -695,6 +709,7 @@ const LineChart = createClass({
 						isStacked={yAxisIsStacked}
 						colorMap={colorMap}
 						palette={palette}
+						colorOffset={yAxisColorOffset}
 						ref='yLines'
 					/>
 				</g>
@@ -712,6 +727,7 @@ const LineChart = createClass({
 							isStacked={yAxisIsStacked}
 							colorMap={colorMap}
 							palette={palette}
+							colorOffset={yAxisColorOffset}
 							ref='yPoints'
 						/>
 					</g>
@@ -728,7 +744,7 @@ const LineChart = createClass({
 							yStackedMax={y2AxisMax}
 							data={data}
 							isStacked={y2AxisIsStacked}
-							colorOffset={1}
+							colorOffset={y2AxisColorOffset}
 							colorMap={colorMap}
 							palette={palette}
 							ref='y2Lines'
@@ -747,7 +763,7 @@ const LineChart = createClass({
 							yStackedMax={y2AxisMax}
 							data={data}
 							isStacked={y2AxisIsStacked}
-							colorOffset={1}
+							colorOffset={y2AxisColorOffset}
 							colorMap={colorMap}
 							palette={palette}
 							ref='y2Points'

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -533,8 +533,8 @@ const LineChart = createClass({
 												key={index}
 												hasPoint={yAxisHasPointsFinal}
 												hasLine={yAxisHasLinesFinal}
-												color={_.get(colorMap, field, palette[index % palette.length])}
-												pointKind={yAxisHasPoints ? index : 1}
+												color={_.get(colorMap, field, palette[(index + yAxisColorOffset) % palette.length])}
+												pointKind={yAxisHasPoints ? index + yAxisColorOffset : 1}
 											>
 												{
 													yAxisTooltipFormatter(_.get(legend, field, field),
@@ -550,8 +550,8 @@ const LineChart = createClass({
 												key={index}
 												hasPoint={y2AxisHasPointsFinal}
 												hasLine={y2AxisHasLinesFinal}
-												color={_.get(colorMap, field, palette[index + yAxisFields.length % palette.length])}
-												pointKind={y2AxisHasPoints ? index + yAxisFields.length : 1}
+												color={_.get(colorMap, field, palette[y2AxisColorOffset + index + yAxisFields.length  % palette.length])}
+												pointKind={y2AxisHasPoints ? y2AxisColorOffset + index + yAxisFields.length : 1}
 											>
 												{
 													yAxisTooltipFormatter(_.get(legend, field, field),
@@ -599,8 +599,8 @@ const LineChart = createClass({
 											key={index}
 											hasPoint={yAxisHasPointsFinal}
 											hasLine={yAxisHasLinesFinal}
-											color={_.get(colorMap, field, palette[index % palette.length])}
-											pointKind={yAxisHasPoints ? index : 1}
+											color={_.get(colorMap, field, palette[index + yAxisColorOffset % palette.length])}
+											pointKind={yAxisHasPoints ? index + yAxisColorOffset : 1}
 										>
 											{_.get(legend, field, field)}
 										</Legend.Item>
@@ -610,8 +610,8 @@ const LineChart = createClass({
 											key={index}
 											hasPoint={y2AxisHasPointsFinal}
 											hasLine={y2AxisHasLinesFinal}
-											color={_.get(colorMap, field, palette[index + yAxisFields.length % palette.length])}
-											pointKind={y2AxisHasPoints ? index + yAxisFields.length : 1}
+											color={_.get(colorMap, field, palette[y2AxisColorOffset + index + yAxisFields.length  % palette.length])}
+											pointKind={y2AxisHasPoints ? y2AxisColorOffset + index + yAxisFields.length  : 1}
 										>
 											{_.get(legend, field, field)}
 										</Legend.Item>
@@ -744,7 +744,7 @@ const LineChart = createClass({
 							yStackedMax={y2AxisMax}
 							data={data}
 							isStacked={y2AxisIsStacked}
-							colorOffset={y2AxisColorOffset}
+							colorOffset={y2AxisColorOffset + yAxisFields.length}
 							colorMap={colorMap}
 							palette={palette}
 							ref='y2Lines'
@@ -763,7 +763,7 @@ const LineChart = createClass({
 							yStackedMax={y2AxisMax}
 							data={data}
 							isStacked={y2AxisIsStacked}
-							colorOffset={y2AxisColorOffset}
+							colorOffset={y2AxisColorOffset + yAxisFields.length}
 							colorMap={colorMap}
 							palette={palette}
 							ref='y2Points'

--- a/src/components/LineChart/examples/11.color-offset.jsx
+++ b/src/components/LineChart/examples/11.color-offset.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+	LineChart,
+} from '../../../index';
+
+const data = [
+	{ x: new Date('2015-01-01T00:00:00-08:00'), apples: 184, pears: 117 },
+	{ x: new Date('2015-01-02T00:00:00-08:00'), apples: 191, pears: 118 },
+	{ x: new Date('2015-01-03T00:00:00-08:00'), apples: 114, pears: 103 },
+	{ x: new Date('2015-01-04T00:00:00-08:00'), apples: 24, pears: 85 },
+	{ x: new Date('2015-01-05T00:00:00-08:00'), apples: 4, pears: 81 },
+	{ x: new Date('2015-01-06T00:00:00-08:00'), apples: 72, pears: 94 },
+	{ x: new Date('2015-01-07T00:00:00-08:00'), apples: 166, pears: 113 },
+	{ x: new Date('2015-01-08T00:00:00-08:00'), apples: 199, pears: 120 },
+	{ x: new Date('2015-01-09T00:00:00-08:00'), apples: 141, pears: 108 },
+	{ x: new Date('2015-01-10T00:00:00-08:00'), apples: 46, pears: 89 },
+	{ x: new Date('2015-01-11T00:00:00-08:00'), apples: 0, pears: 80 },
+	{ x: new Date('2015-01-12T00:00:00-08:00'), apples: 46, pears: 89 },
+	{ x: new Date('2015-01-13T00:00:00-08:00'), apples: 142, pears: 108 },
+	{ x: new Date('2015-01-14T00:00:00-08:00'), apples: 199, pears: 120 },
+	{ x: new Date('2015-01-15T00:00:00-08:00'), apples: 165, pears: 113 },
+];
+
+export default React.createClass({
+	render() {
+		return (
+			<LineChart
+				data={data}
+				margin={{
+					right: 80,
+				}}
+				hasLegend
+
+				yAxisFields={[ 'apples' ]}
+				yAxisColorOffset={3}
+
+				y2AxisFields={[ 'pears' ]}
+				y2AxisColorOffset={4}
+			/>
+		);
+	},
+});


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #568