### PR TITLE
#544: Don't show gray bottom border when a complex tab is active

### DIFF
--- a/src/components/Tabs/Tabs.less
+++ b/src/components/Tabs/Tabs.less
@@ -135,6 +135,7 @@
 			}
 		}
 		.lucid-Tabs-Tab-is-active {
+			border-bottom: @Tabs-border-width solid @color-white;
 			.Tabs-mixin-tab-arrow-background(@color-white);
 		}
 		.lucid-Tabs-Tab + .lucid-Tabs-Tab-is-disabled {


### PR DESCRIPTION
## Changes

<img width="703" alt="screen shot 2016-10-13 at 11 14 32 am" src="https://cloud.githubusercontent.com/assets/4751583/19361132/4538cd8c-9136-11e6-8b75-67df76803206.png">


## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

Fixes #544