### PR TITLE
Switches Tab flex-basis to ensure even width.

### DIFF
--- a/src/components/Tabs/Tabs.less
+++ b/src/components/Tabs/Tabs.less
@@ -14,7 +14,7 @@
 	}
 
 	&-Tab {
-		flex: 1 1 0;
+		flex: 1 1 0px;
 		height: inherit;
 		display: flex;
 		justify-content: center;

--- a/src/components/Tabs/Tabs.less
+++ b/src/components/Tabs/Tabs.less
@@ -14,7 +14,7 @@
 	}
 
 	&-Tab {
-		flex: 1 1 auto;
+		flex: 1 1 0;
 		height: inherit;
 		display: flex;
 		justify-content: center;


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #563 

Docs uploaded here: http://docspot.devnxs.net/projects/lucid/563-tab-width/