### PR TITLE
allow validation styling without an error message

### DIFF
--- a/src/components/Validation/Validation.jsx
+++ b/src/components/Validation/Validation.jsx
@@ -35,6 +35,9 @@ const Validation = createClass({
 		 * In most cases this will be a string, but it also accepts any valid React
 		 * element. If this is a falsey value, then no error message will be
 		 * displayed.
+		 *
+		 * If this is the literal `true`, it will add the `-is-error` class to the
+		 * wrapper div, but not render the `-error-content` `div`.
 		 */
 		Error: any,
 

--- a/src/components/Validation/Validation.jsx
+++ b/src/components/Validation/Validation.jsx
@@ -67,7 +67,7 @@ const Validation = createClass({
 				}, className)}
 			>
 				{children}
-				{errorChildProps && errorChildProps.children ?
+				{errorChildProps && errorChildProps.children && errorChildProps.children !== true ?
 					<div className={cx('&-error-content')} >
 						{errorChildProps.children}
 					</div>


### PR DESCRIPTION
use case here is sometimes I want to show an invalid state for `TextFieldValidated` for example, but without a message, because I have the validation message at a parent component level. So I want the styling, but I don't want the extra div because that messes with layout.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] ~~One core team UX approval~~

