### PR TITLE
Adds `isFullWidth` prop to `DataTable`.

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -37,10 +37,6 @@ const DataTable = createClass({
 
 	propTypes: {
 		/**
-		 * Styles that are passed through to the root container.
-		 */
-		style: object,
-		/**
 		 * Class names that are appended to the defaults.
 		 */
 		className: string,
@@ -49,17 +45,29 @@ const DataTable = createClass({
 		 */
 		data: arrayOf(object),
 		/**
-		 * Render a checkbox in the first column allowing `onSelect` and `onSelectAll` to be triggered.
-		 */
-		isSelectable: bool,
-		/**
 		 * Render each row item to be navigable, allowing `onRowClick` to be triggered.
 		 */
 		isActionable: bool,
 		/**
+		 * If `true`, the table will be set to fill the width of its parent container.
+		 */
+		isFullWidth: bool,
+		/**
 		 * Controls the visibility of the `LoadingMessage`.
 		 */
 		isLoading: bool,
+		/**
+		 * Render a checkbox in the first column allowing `onSelect` and `onSelectAll` to be triggered.
+		 */
+		isSelectable: bool,
+		/**
+		 * Styles that are passed through to the root container.
+		 */
+		style: object,
+		/**
+		 * Handler for row click. Signature is `(object, index, { props, event }) => {...}`
+		 */
+		onRowClick: func,
 		/**
 		 * Handler for checkbox selection. Signature is `(object, index, { props, event }) => {...}`
 		 */
@@ -68,10 +76,6 @@ const DataTable = createClass({
 		 * Handler for checkbox selection in the table header. Signature is `({ props, event }) => {...}`
 		 */
 		onSelectAll: func,
-		/**
-		 * Handler for row click. Signature is `(object, index, { props, event }) => {...}`
-		 */
-		onRowClick: func,
 		/**
 		 * Handler for column header click (for sorting). Signature is `(field, { props, event }) => {...}`
 		 */
@@ -97,11 +101,11 @@ const DataTable = createClass({
 
 	getDefaultProps() {
 		return {
-			isSelectable: false,
 			isActionable: false,
+			isSelectable: false,
+			onRowClick: _.noop,
 			onSelect: _.noop,
 			onSelectAll: _.noop,
-			onRowClick: _.noop,
 			onSort: _.noop,
 		};
 	},
@@ -186,6 +190,7 @@ const DataTable = createClass({
 			className,
 			data,
 			isActionable,
+			isFullWidth,
 			isLoading,
 			isSelectable,
 			style,
@@ -225,8 +230,11 @@ const DataTable = createClass({
 				{emptyStateWrapper.props.children}
 				<ScrollTable
 					style={style}
+					tableWidth={isFullWidth ? '100%' : null}
 					{...omitProps(passThroughs, DataTable)}
-					className={cx('&', className)}
+					className={cx('&', {
+						'&-full-width': isFullWidth,
+					}, className)}
 				>
 					<Thead>
 						<Tr>

--- a/src/components/DataTable/DataTable.less
+++ b/src/components/DataTable/DataTable.less
@@ -1,0 +1,5 @@
+.lucid-DataTable {
+	&.lucid-DataTable-full-width {
+		width: 100%;
+	}
+}

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -475,6 +475,16 @@ describe('DataTable', () => {
 				assert(loadingIndicatorWrapper.prop('isLoading'));
 			});
 		});
+
+		describe('isFullWidth', () => {
+			it('should apply the `&-full-width` class if `isFullWidth` is true', () => {
+				const wrapper = shallow(
+					<DataTable isFullWidth />
+				);
+
+				assert(wrapper.find(ScrollTable).hasClass('lucid-DataTable-full-width'));
+			});
+		});
 	});
 
 	describe('child components', () => {

--- a/src/components/DataTable/examples/6.empty.jsx
+++ b/src/components/DataTable/examples/6.empty.jsx
@@ -20,6 +20,7 @@ export default React.createClass({
 			<DataTable
 				data={_.map(data, (row, index) => (index === activeIndex ? {...row, isActive: true} : row))}
 				density='extended'
+				isFullWidth
 			>
 				<DataTable.Column
 					field='id'

--- a/src/components/DataTable/examples/7.empty-with-custom-title-and-body.jsx
+++ b/src/components/DataTable/examples/7.empty-with-custom-title-and-body.jsx
@@ -22,6 +22,7 @@ export default React.createClass({
 			<DataTable
 				data={data}
 				density='extended'
+				isFullWidth
 			>
 				<EmptyStateWrapper>
 					<Title>

--- a/src/components/DataTable/examples/8.empty-with-image.jsx
+++ b/src/components/DataTable/examples/8.empty-with-image.jsx
@@ -20,6 +20,7 @@ export default React.createClass({
 			<DataTable
 				data={data}
 				density='extended'
+				isFullWidth
 			>
 				<EmptyStateWrapper>
 					<Title>

--- a/src/components/DataTable/examples/9.loading.jsx
+++ b/src/components/DataTable/examples/9.loading.jsx
@@ -6,6 +6,7 @@ export default React.createClass({
 
 		return(
 			<DataTable
+				isFullWidth
 				isLoading
 				data={[]}
 			>

--- a/src/styles/components.less
+++ b/src/styles/components.less
@@ -15,6 +15,7 @@
 @import '../components/PieChart/PieChart';
 @import '../components/Point/Point';
 @import '../components/ContextMenu/ContextMenu';
+@import '../components/DataTable/DataTable';
 @import '../components/DropMenu/DropMenu';
 @import '../components/EmptyStateWrapper/EmptyStateWrapper';
 @import '../components/Expander/Expander';


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

Fixes #598 