### PR TITLE
remove redundant propTypes from TextFieldValidated

### DIFF
--- a/src/components/TextFieldValidated/TextFieldValidated.jsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.jsx
@@ -36,8 +36,6 @@ const TextFieldValidated = createClass({
 	},
 
 	propTypes: {
-		...TextField.propTypes,
-
 		/**
 		 * Passed to the root container.
 		 */

--- a/src/components/TextFieldValidated/TextFieldValidated.spec.jsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.spec.jsx
@@ -1,7 +1,18 @@
+import React from 'react';
 import { common } from '../../util/generic-tests';
 import TextFieldValidated from './TextFieldValidated';
+import TextField from '../TextField/TextField';
+import { shallow } from 'enzyme';
+import assert from 'assert';
 
 describe('TextFieldValidated', () => {
 	common(TextFieldValidated);
-});
 
+	describe('props', () => {
+		it('should pass through props to TextField', () => {
+			const onBlur = () => {};
+			const wrapper = shallow(<TextFieldValidated onBlur={onBlur} />);
+			assert.equal(wrapper.find(TextField).prop('onBlur'), onBlur);
+		});
+	});
+});


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~

