### PR TITLE
Updates `emptyCell` to use `--`.

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -315,9 +315,8 @@ const DataTable = createClass({
 													width: columnProps.width,
 												}}
 												key={'row' + index + _.get(columnProps, 'field', columnIndex)}
-												isEmpty={isEmpty}
 											>
-												{isEmpty ? 'No Data' : cellValue}
+												{isEmpty ? '--' : cellValue}
 											</Td>
 									)})}
 								</Tr>

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -45,6 +45,10 @@ const DataTable = createClass({
 		 */
 		data: arrayOf(object),
 		/**
+		 * The text to display in cells which have no data.
+		 */
+		emptyCellText: string,
+		/**
 		 * Render each row item to be navigable, allowing `onRowClick` to be triggered.
 		 */
 		isActionable: bool,
@@ -101,6 +105,7 @@ const DataTable = createClass({
 
 	getDefaultProps() {
 		return {
+			emptyCellText: '--',
 			isActionable: false,
 			isSelectable: false,
 			onRowClick: _.noop,
@@ -189,6 +194,7 @@ const DataTable = createClass({
 		const {
 			className,
 			data,
+			emptyCellText,
 			isActionable,
 			isFullWidth,
 			isLoading,
@@ -316,7 +322,7 @@ const DataTable = createClass({
 												}}
 												key={'row' + index + _.get(columnProps, 'field', columnIndex)}
 											>
-												{isEmpty ? '--' : cellValue}
+												{isEmpty ? emptyCellText : cellValue}
 											</Td>
 									)})}
 								</Tr>

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -216,8 +216,7 @@ describe('DataTable', () => {
 					assert.equal(tdsWrapper.at(0).children().text(), _.get(testDataWithEmptyCells[index], 'id'), 'first cell must match id of current row');
 					assert(!tdsWrapper.at(0).prop('isEmpty'), 'should not be marked as empty, despite not being a string');
 					assert.equal(tdsWrapper.at(1).children().text(), _.get(testDataWithEmptyCells[index], 'first_name'), 'second cell must match first_name of current row');
-					assert(tdsWrapper.at(2).props().isEmpty, 'should be marked as an empty-cell');
-					assert.equal(tdsWrapper.at(2).children().text(), 'No Data', 'third (empty) cell should be `No Data`');
+					assert.equal(tdsWrapper.at(2).children().text(), '--', 'third (empty) cell should be `--`');
 					assert.equal(tdsWrapper.at(3).children().text(), _.get(testDataWithEmptyCells[index], 'email'), 'fourth cell must match email of current row');
 					assert.equal(tdsWrapper.at(4).children().text(), _.get(testDataWithEmptyCells[index], 'occupation'), 'fifth cell must match occupation of current row');
 				});

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -469,10 +469,6 @@ const Td = createClass({
 		 * Define the cell as being the first 1-height cell in the row.
 		 */
 		isFirstSingle: bool,
-		/**
-		 * Should be `true` to render with a `No Data` indicator.
-		 */
-		isEmpty: bool,
 	},
 
 	getDefaultProps() {
@@ -494,7 +490,6 @@ const Td = createClass({
 			align,
 			hasBorderRight,
 			hasBorderLeft,
-			isEmpty,
 			...passThroughs,
 		} = this.props;
 
@@ -511,7 +506,6 @@ const Td = createClass({
 				'&-align-right': align === 'right',
 				'&-has-border-right': hasBorderRight,
 				'&-has-border-left': hasBorderLeft,
-				'&-is-empty': isEmpty,
 			}, className)} />
 		);
 	},

--- a/src/components/Table/Table.less
+++ b/src/components/Table/Table.less
@@ -232,13 +232,6 @@
 			&.lucid-Table-has-border-left {
 				border-left: @border-table-body;
 			}
-
-			&.lucid-Table-is-empty {
-				background: @pattern-diagonal-striped;
-				color: @color-mediumGray;
-				text-align: center;
-				text-shadow: @color-white 1px 1px;
-			}
 		}
 	}
 

--- a/src/components/Table/Table.spec.jsx
+++ b/src/components/Table/Table.spec.jsx
@@ -319,16 +319,6 @@ describe('Table', () => {
 						assert.equal(wrapper.find('td.lucid-Table-has-border-left').length, 1);
 					});
 				});
-
-				describe('isEmpty', () => {
-					it('should apply the class name `lucid-Table-is-empty`', () => {
-						const wrapper = shallow(
-							<Td isEmpty />
-						);
-
-						assert.equal(wrapper.find('td.lucid-Table-is-empty').length, 1);
-					});
-				});
 			});
 		});
 	});


### PR DESCRIPTION
## PR Checklist
- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval

Fixes #602 
