### PR TITLE
Added `keyword-spacing` lint rule and fixed spacing issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
 	"rules": {
 		"quotes": [2, "single"],
 		"jsx-quotes": [2, "prefer-single"],
+		"keyword-spacing": 0,
 		"comma-dangle": [2, "always-multiline"],
 		"react/prop-types": 2,
 		"no-trailing-spaces": 2,

--- a/src/components/DataTable/examples/01.basic.jsx
+++ b/src/components/DataTable/examples/01.basic.jsx
@@ -76,7 +76,7 @@ const data = [
 export default React.createClass({
 	render() {
 
-		return(
+		return (
 			<DataTable
 				data={data}
 			>

--- a/src/components/DataTable/examples/02.column-groups.jsx
+++ b/src/components/DataTable/examples/02.column-groups.jsx
@@ -73,7 +73,7 @@ const data = [
 export default React.createClass({
 	render() {
 
-		return(
+		return (
 			<DataTable
 				data={data}
 				density='extended'

--- a/src/components/DataTable/examples/03.selectable-and-navigable-rows.jsx
+++ b/src/components/DataTable/examples/03.selectable-and-navigable-rows.jsx
@@ -79,7 +79,7 @@ const data = [
 export default React.createClass({
 	render() {
 
-		return(
+		return (
 			<DataTable
 				data={data}
 				density='extended'

--- a/src/components/DataTable/examples/04.interactive-table.jsx
+++ b/src/components/DataTable/examples/04.interactive-table.jsx
@@ -153,7 +153,7 @@ export default React.createClass({
 			currentlySortedFieldDirection,
 		} = this.state;
 
-		return(
+		return (
 			<DataTable
 				data={_.map(data, (row, index) => (index === activeIndex ? {...row, isActive: true} : row))}
 				density='extended'

--- a/src/components/DataTable/examples/05.disabled-rows.jsx
+++ b/src/components/DataTable/examples/05.disabled-rows.jsx
@@ -87,7 +87,7 @@ const data = [
 export default React.createClass({
 	render() {
 
-		return(
+		return (
 			<DataTable
 				data={data}
 			>

--- a/src/components/DataTable/examples/06.empty.jsx
+++ b/src/components/DataTable/examples/06.empty.jsx
@@ -16,7 +16,7 @@ export default React.createClass({
 			data,
 		} = this.state;
 
-		return(
+		return (
 			<DataTable
 				data={_.map(data, (row, index) => (index === activeIndex ? {...row, isActive: true} : row))}
 				density='extended'

--- a/src/components/DataTable/examples/07.empty-with-custom-title-and-body.jsx
+++ b/src/components/DataTable/examples/07.empty-with-custom-title-and-body.jsx
@@ -18,7 +18,7 @@ export default React.createClass({
 			data,
 		} = this.state;
 
-		return(
+		return (
 			<DataTable
 				data={data}
 				density='extended'

--- a/src/components/DataTable/examples/08.empty-with-image.jsx
+++ b/src/components/DataTable/examples/08.empty-with-image.jsx
@@ -16,7 +16,7 @@ export default React.createClass({
 	render() {
 		const {data} = this.state;
 
-		return(
+		return (
 			<DataTable
 				data={data}
 				density='extended'

--- a/src/components/DataTable/examples/09.loading.jsx
+++ b/src/components/DataTable/examples/09.loading.jsx
@@ -4,7 +4,7 @@ import { DataTable } from '../../../index';
 export default React.createClass({
 	render() {
 
-		return(
+		return (
 			<DataTable
 				isFullWidth
 				isLoading

--- a/src/components/DataTable/examples/10.min-rows.jsx
+++ b/src/components/DataTable/examples/10.min-rows.jsx
@@ -49,7 +49,7 @@ export default React.createClass({
 			data,
 		} = this.state;
 
-		return(
+		return (
 			<DataTable
 				data={_.map(data, (row, index) => (index === activeIndex ? {...row, isActive: true} : row))}
 				density='extended'

--- a/src/components/ExpanderPanel/ExpanderPanel.jsx
+++ b/src/components/ExpanderPanel/ExpanderPanel.jsx
@@ -99,7 +99,7 @@ const ExpanderPanel = createClass({
 	},
 
 	handleToggle(event) {
-		if(!this.props.isDisabled){
+		if (!this.props.isDisabled){
 			this.props.onToggle(!this.props.isExpanded, {
 				event,
 				props: this.props,

--- a/src/components/ScrollTable/examples/1.standard.jsx
+++ b/src/components/ScrollTable/examples/1.standard.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<ScrollTable>
 				<Thead>
 					<Tr>

--- a/src/components/ScrollTable/examples/2.with-border.jsx
+++ b/src/components/ScrollTable/examples/2.with-border.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<ScrollTable hasBorder>
 				<Thead>
 					<Tr>

--- a/src/components/ScrollTable/examples/3.set-width-and-height.jsx
+++ b/src/components/ScrollTable/examples/3.set-width-and-height.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<ScrollTable
 				hasWordWrap={false}
 				style={{

--- a/src/components/ScrollTable/examples/4.full-width.jsx
+++ b/src/components/ScrollTable/examples/4.full-width.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<ScrollTable hasWordWrap={false}>
 				<Thead>
 					<Tr>

--- a/src/components/ScrollTable/examples/5.set-table-width.jsx
+++ b/src/components/ScrollTable/examples/5.set-table-width.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<ScrollTable
 				tableWidth={2000}
 			>

--- a/src/components/Sidebar/examples/01.default-side-bar.jsx
+++ b/src/components/Sidebar/examples/01.default-side-bar.jsx
@@ -3,7 +3,7 @@ import { Sidebar } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Sidebar>
 				<Sidebar.Bar>
 					Minim 90's paleo retro, fugiat aliqua hashtag enim photo booth listicle next level. Consectetur fap proident magna culpa. Art party meh ad, four loko slow-carb venmo distillery wolf cornhole nisi.

--- a/src/components/Sidebar/examples/02.disable-resize.jsx
+++ b/src/components/Sidebar/examples/02.disable-resize.jsx
@@ -4,7 +4,7 @@ import { Sidebar } from '../../../index';
 export default React.createClass({
 
 	render() {
-		return(
+		return (
 			<Sidebar isResizeDisabled={true}>
 				<Sidebar.Bar>
 					Cold-pressed aesthetic biodiesel twee, heirloom vice iPhone austin. Truffaut wolf offal roof party, neutra yr drinking vinegar bitters single-origin coffee austin mlkshk mixtape semiotics blog. Pickled squid asymmetrical locavore before they sold out whatever.

--- a/src/components/Sidebar/examples/03.initial-collapsed.jsx
+++ b/src/components/Sidebar/examples/03.initial-collapsed.jsx
@@ -3,7 +3,7 @@ import { Sidebar } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Sidebar initialState={{isExpanded: false}}>
 				<Sidebar.Bar>
 					Try-hard cornhole ea artisan, laborum wolf eiusmod chillwave irure. Lomo chicharrones taxidermy narwhal. Cronut deep v PBR&B photo booth tilde. Asymmetrical waistcoat williamsburg 3 wolf moon, poutine magna dreamcatcher disrupt eiusmod thundercats farm-to-table lumbersexual nisi mlkshk tote bag.

--- a/src/components/Sidebar/examples/04.position-right.jsx
+++ b/src/components/Sidebar/examples/04.position-right.jsx
@@ -3,7 +3,7 @@ import { Sidebar } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Sidebar position='right'>
 				<Sidebar.Bar>
 					Paleo art party disrupt, consequat kogi fashion axe tofu trust fund raw denim readymade. Seitan banjo salvia organic ethical. Next level pork belly sustainable tumblr nostrud.

--- a/src/components/Sidebar/examples/05.custom-title.jsx
+++ b/src/components/Sidebar/examples/05.custom-title.jsx
@@ -3,7 +3,7 @@ import { Sidebar } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Sidebar>
 				<Sidebar.Title>Sidebar Title <button>Edit</button></Sidebar.Title>
 				<Sidebar.Bar>

--- a/src/components/Sidebar/examples/06.custom-width.jsx
+++ b/src/components/Sidebar/examples/06.custom-width.jsx
@@ -3,7 +3,7 @@ import { Sidebar } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Sidebar width={400}>
 				<Sidebar.Bar>
 					Meditation photo booth actually chicharrones sed consectetur voluptate stumptown. Food truck nihil ut mixtape, ex deep v polaroid aesthetic. Duis street art stumptown nihil, aliquip vero VHS heirloom waistcoat adipisicing post-ironic lo-fi biodiesel.

--- a/src/components/Sidebar/examples/07.control-expand.jsx
+++ b/src/components/Sidebar/examples/07.control-expand.jsx
@@ -14,7 +14,7 @@ export default React.createClass({
 	},
 
 	render() {
-		return(
+		return (
 			<section>
 				<button onClick={this.handleToggle}>toggle</button>
 				<Sidebar isExpanded={this.state.isExpanded} onToggle={this.handleToggle}>

--- a/src/components/Sidebar/examples/08.handle-toggle-and-resize.jsx
+++ b/src/components/Sidebar/examples/08.handle-toggle-and-resize.jsx
@@ -22,7 +22,7 @@ export default React.createClass({
 	},
 
 	render() {
-		return(
+		return (
 			<section>
 				<p>isExpanded: {`${this.state.isExpanded}`}</p>
 				<p>resizeWidth: {`${this.state.resizeWidth}`}</p>

--- a/src/components/Sidebar/examples/09.nested-sidebars.jsx
+++ b/src/components/Sidebar/examples/09.nested-sidebars.jsx
@@ -3,7 +3,7 @@ import { Sidebar } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Sidebar>
 				<Sidebar.Bar>
 					Bitters shabby chic tacos, sapiente drinking vinegar readymade gochujang typewriter. Gluten-free cred sartorial pop-up commodo.

--- a/src/components/SplitHorizontal/examples/1.default-split.jsx
+++ b/src/components/SplitHorizontal/examples/1.default-split.jsx
@@ -3,7 +3,7 @@ import { SplitHorizontal } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<SplitHorizontal>
 				<SplitHorizontal.TopPane>
 					<p>Bicycle rights tofu hashtag blue bottle viral. Mixtape kinfolk mustache, iPhone godard voluptate direct trade pork belly truffaut duis sunt. 8-bit microdosing retro, excepteur direct trade offal listicle kale chips selvage master cleanse sustainable laborum migas helvetica. Man bun esse synth man braid fashion axe post-ironic id, fanny pack PBR&B. Scenester truffaut culpa yr heirloom, fanny pack intelligentsia dreamcatcher dolore nisi green juice ad you probably haven't heard of them raw denim. Before they sold out laborum poutine 90's, blog voluptate chambray whatever. Excepteur ea kinfolk, irure photo booth brooklyn art party master cleanse mlkshk pug.</p>

--- a/src/components/SplitHorizontal/examples/2.animated-collapse.jsx
+++ b/src/components/SplitHorizontal/examples/2.animated-collapse.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitHorizontal/examples/3.set-pane-as-primary.jsx
+++ b/src/components/SplitHorizontal/examples/3.set-pane-as-primary.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitHorizontal/examples/4.set-height-of-pane.jsx
+++ b/src/components/SplitHorizontal/examples/4.set-height-of-pane.jsx
@@ -3,7 +3,7 @@ import { SplitHorizontal } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 
 				<SplitHorizontal>

--- a/src/components/SplitHorizontal/examples/5.customize-divider.jsx
+++ b/src/components/SplitHorizontal/examples/5.customize-divider.jsx
@@ -3,7 +3,7 @@ import { SplitHorizontal } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<SplitHorizontal>
 				<SplitHorizontal.TopPane>
 					<p>Waistcoat man bun sartorial, PBR&B artisan blue bottle laboris disrupt pug dreamcatcher readymade gluten-free fingerstache placeat. Enim salvia celiac, veniam polaroid stumptown velit PBR&B. Ramps delectus cupidatat dolore. Portland try-hard slow-carb cronut, drinking vinegar readymade nulla pug aliqua cray VHS eiusmod odio incididunt wolf. 3 wolf moon gentrify mustache blog freegan, literally ut helvetica stumptown godard synth direct trade. Sapiente slow-carb deep v, YOLO direct trade irony before they sold out tempor. Sunt aliqua seitan banjo.</p>

--- a/src/components/SplitHorizontal/examples/6.no-animation.jsx
+++ b/src/components/SplitHorizontal/examples/6.no-animation.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitHorizontal/examples/7.collapse-shift.jsx
+++ b/src/components/SplitHorizontal/examples/7.collapse-shift.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitHorizontal/examples/8.handle-resize.jsx
+++ b/src/components/SplitHorizontal/examples/8.handle-resize.jsx
@@ -17,7 +17,7 @@ export default React.createClass({
 	},
 
 	render() {
-		return(
+		return (
 			<section>
 
 			New Height: {`${this.state.newHeight}`}

--- a/src/components/SplitVertical/examples/1.default-split.jsx
+++ b/src/components/SplitVertical/examples/1.default-split.jsx
@@ -3,7 +3,7 @@ import { SplitVertical } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<SplitVertical>
 				<SplitVertical.LeftPane>
 					<p>Bicycle rights tofu hashtag blue bottle viral. Mixtape kinfolk mustache, iPhone godard voluptate direct trade pork belly truffaut duis sunt. 8-bit microdosing retro, excepteur direct trade offal listicle kale chips selvage master cleanse sustainable laborum migas helvetica. Man bun esse synth man braid fashion axe post-ironic id, fanny pack PBR&B. Scenester truffaut culpa yr heirloom, fanny pack intelligentsia dreamcatcher dolore nisi green juice ad you probably haven't heard of them raw denim. Before they sold out laborum poutine 90's, blog voluptate chambray whatever. Excepteur ea kinfolk, irure photo booth brooklyn art party master cleanse mlkshk pug.</p>

--- a/src/components/SplitVertical/examples/2.animated-collapse.jsx
+++ b/src/components/SplitVertical/examples/2.animated-collapse.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitVertical/examples/3.set-pane-as-primary.jsx
+++ b/src/components/SplitVertical/examples/3.set-pane-as-primary.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitVertical/examples/4.set-width-of-pane.jsx
+++ b/src/components/SplitVertical/examples/4.set-width-of-pane.jsx
@@ -3,7 +3,7 @@ import { SplitVertical } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<SplitVertical>
 				<SplitVertical.LeftPane width={250}>
 					<p>Jean shorts reprehenderit in, commodo godard skateboard retro heirloom street art church-key. Gochujang sint hella food truck, officia next level sriracha listicle knausgaard try-hard 3 wolf moon kale chips. Offal scenester quinoa, hammock qui sint direct trade heirloom. Bushwick letterpress pabst, odio nihil sapiente ex cold-pressed flannel laboris wayfarers retro marfa jean shorts. Chia next level cardigan, deserunt church-key asymmetrical ennui messenger bag portland. Aute selvage cred gastropub freegan literally. Readymade artisan distillery occaecat qui.</p>

--- a/src/components/SplitVertical/examples/5.customize-divider.jsx
+++ b/src/components/SplitVertical/examples/5.customize-divider.jsx
@@ -3,7 +3,7 @@ import { SplitVertical } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<SplitVertical>
 				<SplitVertical.LeftPane>
 					<p>Waistcoat man bun sartorial, PBR&B artisan blue bottle laboris disrupt pug dreamcatcher readymade gluten-free fingerstache placeat. Enim salvia celiac, veniam polaroid stumptown velit PBR&B. Ramps delectus cupidatat dolore. Portland try-hard slow-carb cronut, drinking vinegar readymade nulla pug aliqua cray VHS eiusmod odio incididunt wolf. 3 wolf moon gentrify mustache blog freegan, literally ut helvetica stumptown godard synth direct trade. Sapiente slow-carb deep v, YOLO direct trade irony before they sold out tempor. Sunt aliqua seitan banjo.</p>

--- a/src/components/SplitVertical/examples/6.no-animation.jsx
+++ b/src/components/SplitVertical/examples/6.no-animation.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitVertical/examples/7.collapse-shift.jsx
+++ b/src/components/SplitVertical/examples/7.collapse-shift.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 		this.setState({isExpanded: !this.state.isExpanded});
 	},
 	render() {
-		return(
+		return (
 			<section>
 
 				<button onClick={this.handleToggle}>toggle</button>

--- a/src/components/SplitVertical/examples/8.handle-resize.jsx
+++ b/src/components/SplitVertical/examples/8.handle-resize.jsx
@@ -17,7 +17,7 @@ export default React.createClass({
 	},
 
 	render() {
-		return(
+		return (
 			<section>
 
 			New Width: {`${this.state.newWidth}`}

--- a/src/components/SplitVertical/examples/9.no-resize.jsx
+++ b/src/components/SplitVertical/examples/9.no-resize.jsx
@@ -3,7 +3,7 @@ import { SplitVertical } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<SplitVertical isResizeable={false}>
 				<SplitVertical.LeftPane>
 					<p>Occupy biodiesel nesciunt pug fugiat. VHS accusamus intelligentsia, chartreuse raw denim kogi bushwick cold-pressed chia heirloom sint forage. Cornhole affogato swag duis hella, pabst bitters trust fund heirloom viral blog selfies green juice commodo nulla. Single-origin coffee 8-bit ugh jean shorts proident, tote bag small batch meditation poutine next level lo-fi. Ethical before they sold out shoreditch, etsy man braid semiotics ea health goth squid aliquip drinking vinegar kinfolk excepteur polaroid. Meh schlitz cred tattooed chartreuse 3 wolf moon. Lumbersexual poutine kinfolk hella chartreuse thundercats.</p>

--- a/src/components/StickySection/examples/1.with-lower-bound.jsx
+++ b/src/components/StickySection/examples/1.with-lower-bound.jsx
@@ -3,7 +3,7 @@ import { StickySection } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{
 				color: 'rgba(128,128,128,.25)',
 				width: 800,

--- a/src/components/StickySection/examples/2.with-lower-bound-and-scroll-viewport-width.jsx
+++ b/src/components/StickySection/examples/2.with-lower-bound-and-scroll-viewport-width.jsx
@@ -3,7 +3,7 @@ import { StickySection } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{
 				color: 'rgba(128,128,128,.25)',
 				width: 800,

--- a/src/components/StickySection/examples/3.standard.jsx
+++ b/src/components/StickySection/examples/3.standard.jsx
@@ -3,7 +3,7 @@ import { StickySection } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{
 				color: 'rgba(128,128,128,.25)',
 				marginBottom: 700,

--- a/src/components/Submarine/examples/1.default-submarine.jsx
+++ b/src/components/Submarine/examples/1.default-submarine.jsx
@@ -3,7 +3,7 @@ import { Submarine } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{ height: 300, background: 'lightgray', outline: '1px solid lightgray' }}>
 				<Submarine>
 					<Submarine.Bar>

--- a/src/components/Submarine/examples/2.disable-resize.jsx
+++ b/src/components/Submarine/examples/2.disable-resize.jsx
@@ -4,7 +4,7 @@ import { Submarine } from '../../../index';
 export default React.createClass({
 
 	render() {
-		return(
+		return (
 			<section style={{ height: 300, background: 'lightgray', outline: '1px solid lightgray' }}>
 				<Submarine isResizeDisabled={true}>
 					<Submarine.Bar>

--- a/src/components/Submarine/examples/3.initial-collapsed.jsx
+++ b/src/components/Submarine/examples/3.initial-collapsed.jsx
@@ -3,7 +3,7 @@ import { Submarine } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{ height: 300, background: 'lightgray', outline: '1px solid lightgray' }}>
 				<Submarine initialState={{isExpanded: false}}>
 					<Submarine.Bar>

--- a/src/components/Submarine/examples/4.position-top.jsx
+++ b/src/components/Submarine/examples/4.position-top.jsx
@@ -3,7 +3,7 @@ import { Submarine } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{ height: 300, background: 'lightgray', outline: '1px solid lightgray' }}>
 				<Submarine position='top'>
 					<Submarine.Bar>

--- a/src/components/Submarine/examples/5.custom-title.jsx
+++ b/src/components/Submarine/examples/5.custom-title.jsx
@@ -3,7 +3,7 @@ import { Submarine } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{ height: 300, background: 'lightgray', outline: '1px solid lightgray' }}>
 				<Submarine>
 					<Submarine.Title>Submarine Title <button>Edit</button></Submarine.Title>

--- a/src/components/Submarine/examples/6.custom-height.jsx
+++ b/src/components/Submarine/examples/6.custom-height.jsx
@@ -3,7 +3,7 @@ import { Submarine } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{ height: 300, background: 'lightgray', outline: '1px solid lightgray' }}>
 				<Submarine height={100}>
 					<Submarine.Bar>

--- a/src/components/Submarine/examples/7.control-expand.jsx
+++ b/src/components/Submarine/examples/7.control-expand.jsx
@@ -14,7 +14,7 @@ export default React.createClass({
 	},
 
 	render() {
-		return(
+		return (
 			<section>
 				<button onClick={this.handleToggle}>toggle</button>
 

--- a/src/components/Submarine/examples/8.handle-toggle-and-resize.jsx
+++ b/src/components/Submarine/examples/8.handle-toggle-and-resize.jsx
@@ -22,7 +22,7 @@ export default React.createClass({
 	},
 
 	render() {
-		return(
+		return (
 			<section>
 				<p>isExpanded: {`${this.state.isExpanded}`}</p>
 				<p>resizeHeight: {`${this.state.resizeHeight}`}</p>

--- a/src/components/Submarine/examples/9.nested-submarines.jsx
+++ b/src/components/Submarine/examples/9.nested-submarines.jsx
@@ -3,7 +3,7 @@ import { Submarine } from '../../../index';
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<section style={{ height: 600, background: 'lightgray', outline: '1px solid lightgray' }}>
 
 				<Submarine position='top'>

--- a/src/components/Table/examples/1.standard.jsx
+++ b/src/components/Table/examples/1.standard.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Table>
 				<Thead>
 					<Tr>

--- a/src/components/Table/examples/2.compressed.jsx
+++ b/src/components/Table/examples/2.compressed.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Table density='compressed'>
 				<Thead>
 					<Tr>

--- a/src/components/Table/examples/3.with-border.jsx
+++ b/src/components/Table/examples/3.with-border.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Table hasBorder>
 				<Thead>
 					<Tr>

--- a/src/components/Table/examples/4.with-empty-column.jsx
+++ b/src/components/Table/examples/4.with-empty-column.jsx
@@ -11,7 +11,7 @@ const {
 
 export default React.createClass({
 	render() {
-		return(
+		return (
 			<Table>
 				<Thead>
 					<Tr>

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -158,7 +158,7 @@ const TextField = createClass({
 		this._updateWhenReady = _.debounce((newValue) => {
 			if (this.state.isHolding) {
 				this._updateWhenReady(newValue);
-			} else if(newValue !== this.state.value) {
+			} else if (newValue !== this.state.value) {
 				this.setState({ value: newValue });
 			}
 		}, this.props.lazyLevel);

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -31,7 +31,7 @@ export const logger = (function() {
 const onceMap = {};
 
 function once(key, fn) {
-	if(!_.has(onceMap, key)) {
+	if (!_.has(onceMap, key)) {
 		_.set(onceMap, key, true);
 		fn();
 	}


### PR DESCRIPTION
This rule requires spaces after **if** and **return** keywords.

## PR Checklist

- ~~Manually tested across supported browsers~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

