### PR TITLE
Added `no-confusing-arrow` lint rule with fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
 		"jsx-quotes": [2, "prefer-single"],
 		"key-spacing": 2,
 		"keyword-spacing": 0,
+		"no-confusing-arrow": [2, {"allowParens": true}],
 		"no-trailing-spaces": 2,
 		"no-undef": 2,
 		"no-unused-vars": 2,

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -261,7 +261,7 @@ const DataTable = createClass({
 									/>
 								</Th>
 							) : null}
-							{_.map(childComponentElements, ({ props, type }, index) => type === DataTable.Column ? (
+							{_.map(childComponentElements, ({ props, type }, index) => (type === DataTable.Column ? (
 								<Th
 									{..._.omit(props, ['field', 'children', 'width', 'title'])}
 									onClick={DataTable.shouldColumnHandleSort(props) ? _.partial(this.handleSort, props.field) : null}
@@ -281,7 +281,7 @@ const DataTable = createClass({
 								>
 									{props.title || props.children}
 								</Th>
-							))}
+							)))}
 						</Tr>
 						{hasGroupedColumns ? (
 							<Tr>

--- a/src/components/ToolTip/ToolTip.jsx
+++ b/src/components/ToolTip/ToolTip.jsx
@@ -210,11 +210,11 @@ const ToolTip = createClass({
 		const targetProps = _.first(_.map(findTypes(this.props, ToolTip.Target), 'props'));
 		const title = _.chain(findTypes(this.props, ToolTip.Title)).map('props').first().get('children').value();
 		const body = _.chain(findTypes(this.props, ToolTip.Body)).map('props').first().get('children').value();
-		const getAlignmentOffset = n => alignment === ContextMenu.CENTER
+		const getAlignmentOffset = n => (alignment === ContextMenu.CENTER
 			? 0
 			: alignment === ContextMenu.START
 				? n / 2 - 22.5
-				: -(n / 2 - 22.5);
+				: -(n / 2 - 22.5));
 
 		return (
 			<ContextMenu

--- a/src/util/redux.js
+++ b/src/util/redux.js
@@ -43,7 +43,7 @@ export function getReduxPrimitives({
 
 	const reducer = createReduxReducer(reducers, initialState, rootPath);
 	const selector = selectors ? reduceSelectors(selectors) : _.identity;
-	const rootPathSelector = state => _.isEmpty(rootPath) ? state : _.get(state, rootPath);
+	const rootPathSelector = state => (_.isEmpty(rootPath) ? state : _.get(state, rootPath));
 	const mapStateToProps = createSelector(
 		[rootPathSelector],
 		rootState => rootSelector(selector(rootState))

--- a/src/util/redux.spec.js
+++ b/src/util/redux.spec.js
@@ -256,7 +256,7 @@ describe('redux utils', () => {
 
 					const mapDispatchToProps = connectors[1];
 					const mockGetState = sinon.spy(() => rootState);
-					const mockDispatch = sinon.spy(action => isFunction(action) ? action(mockDispatch, mockGetState, ...extraArgs) : action);
+					const mockDispatch = sinon.spy(action => (isFunction(action) ? action(mockDispatch, mockGetState, ...extraArgs) : action));
 					const dispatchTree = mapDispatchToProps(mockDispatch);
 
 					beforeEach(() => {


### PR DESCRIPTION
Prevents the situation where arrow functions are used ambiguously with conditional expressions

http://eslint.org/docs/rules/no-confusing-arrow

## PR Checklist

- ~~Manually tested across supported browsers~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~