### PR TITLE
Added `no-multiple-empty-lines` lint rule with fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
 		"key-spacing": 2,
 		"keyword-spacing": 0,
 		"no-confusing-arrow": [2, {"allowParens": true}],
+		"no-multiple-empty-lines": 2,
 		"no-trailing-spaces": 2,
 		"no-undef": 2,
 		"no-unused-vars": 2,

--- a/src/components/Autocomplete/Autocomplete.spec.jsx
+++ b/src/components/Autocomplete/Autocomplete.spec.jsx
@@ -116,7 +116,6 @@ describe('Autocomplete', () => {
 		});
 
 
-
 		describe('DropMenu', () => {
 			it('should pass thru all DropMenu props to the underlying DropMenu', () => {
 				const explicitDropMenuProps = {
@@ -267,7 +266,6 @@ describe('Autocomplete', () => {
 
 				document.body.removeChild(rootMountNode);
 			});
-
 
 			it('should be called when the input value changes to a non-empty value', () => {
 				const onExpand = sinon.spy();

--- a/src/components/AxisLabel/AxisLabel.spec.jsx
+++ b/src/components/AxisLabel/AxisLabel.spec.jsx
@@ -10,6 +10,3 @@ describe('AxisLabel', () => {
 		}),
 	});
 });
-
-
-

--- a/src/components/Panel/Panel.spec.jsx
+++ b/src/components/Panel/Panel.spec.jsx
@@ -114,9 +114,6 @@ describe('Panel', () => {
 
 	});
 
-
-
-
 	describe('any other children', () => {
 	});
 });


### PR DESCRIPTION
Limits empty lines to two

## PR Checklist

- ~~Manually tested across supported browsers~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

