### PR TITLE
Reverts minRows default to 0; Adds back logic for rendering 10 rows w…

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -117,7 +117,7 @@ const DataTable = createClass({
 			onSelect: _.noop,
 			onSelectAll: _.noop,
 			onSort: _.noop,
-			minRows: 10,
+			minRows: 0,
 		};
 	},
 
@@ -333,7 +333,7 @@ const DataTable = createClass({
 									);})}
 							</Tr>
 						))}
-						{_.times(minRows - _.size(data), (index) => (
+						{_.times(_.size(data) === 0 ? 10 : minRows - _.size(data), (index) => (
 							<Tr
 								isDisabled
 								key={'row' + index}

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -226,7 +226,7 @@ describe('DataTable', () => {
 		});
 
 		describe('minRows', () => {
-			it('should render the number of `minRows` if data is an empty array', () => {
+			it('should render 10 empty rows if data is an empty array', () => {
 				const wrapper = shallow(
 					<DataTable minRows={7} />
 				);
@@ -236,7 +236,7 @@ describe('DataTable', () => {
 						.find(ScrollTable.Tbody).shallow()
 							.find(ScrollTable.Tr);
 
-				assert.equal(TrWrapper.length, 7, 'should render 7 empty rows');
+				assert.equal(TrWrapper.length, 10, 'should render 10 empty rows');
 			});
 
 			it('should render a row for each element in the array if there is more data than `minRows`', () => {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
~~- [ ] One core team UX approval~~

…ith empty data.

Fixes #646 