### PR TITLE
Removes redundant CSS from Arrow and Caret icons

### DIFF
--- a/src/components/Icon/ArrowIcon/ArrowIcon.less
+++ b/src/components/Icon/ArrowIcon/ArrowIcon.less
@@ -1,9 +1,4 @@
-@ArrowIcon-size: 16px;
-
 .lucid-ArrowIcon {
-	height: @ArrowIcon-size;
-	width: @ArrowIcon-size;
-
 	&-is-down { transform: rotate(90deg) }
 	&-is-up { transform: rotate(270deg) }
 	&-is-left { transform: rotate(180deg) }

--- a/src/components/Icon/CaretIcon/CaretIcon.less
+++ b/src/components/Icon/CaretIcon/CaretIcon.less
@@ -1,9 +1,4 @@
-@CaretIcon-size: 16px;
-
 .lucid-CaretIcon {
-	height: @CaretIcon-size;
-	width: @CaretIcon-size;
-
 	&-is-down { transform: rotate(0deg) }
 	&-is-up { transform: rotate(180deg) }
 	&-is-left { transform: rotate(90deg) }

--- a/src/components/SearchableSelect/SearchableSelect.jsx
+++ b/src/components/SearchableSelect/SearchableSelect.jsx
@@ -364,7 +364,10 @@ const SearchableSelect = createClass({
 						>
 							{isItemSelected ? flattenedOptionsData[selectedIndex].optionProps.children : placeholder}
 						</span>
-						<CaretIcon direction={isExpanded ? direction : 'down'} />
+						<CaretIcon
+							direction={isExpanded ? direction : 'down'}
+							size={8}
+						/>
 					</div>
 				</DropMenu.Control>
 				<DropMenu.Header className={cx('&-Search-container')}>

--- a/src/components/SearchableSelect/SearchableSelect.less
+++ b/src/components/SearchableSelect/SearchableSelect.less
@@ -32,8 +32,6 @@
 
 		.lucid-CaretIcon {
 			fill: @color-black;
-			width: 8px;
-			height: 8px;
 			margin-left: auto;
 		}
 

--- a/src/components/SingleSelect/SingleSelect.jsx
+++ b/src/components/SingleSelect/SingleSelect.jsx
@@ -206,7 +206,10 @@ const SingleSelect = createClass({
 						>
 							{isItemSelected ? flattenedOptionsData[selectedIndex].optionProps.children : placeholder}
 						</span>
-						<CaretIcon direction={isExpanded ? direction : 'down'} />
+						<CaretIcon
+							direction={isExpanded ? direction : 'down'}
+							size={8}
+						/>
 					</div>
 				</DropMenu.Control>
 				{hasReset && isItemSelected ? (

--- a/src/components/SingleSelect/SingleSelect.less
+++ b/src/components/SingleSelect/SingleSelect.less
@@ -32,8 +32,6 @@
 
 		.lucid-CaretIcon {
 			fill: @color-black;
-			width: 8px;
-			height: 8px;
 			margin-left: auto;
 		}
 

--- a/src/components/SingleSelect/__snapshots__/SingleSelect.spec.jsx.snap
+++ b/src/components/SingleSelect/__snapshots__/SingleSelect.spec.jsx.snap
@@ -27,6 +27,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 03.d
       </span>
       <CaretIcon
         direction="down"
+        size={8}
         viewBox="0 3 16 8" />
     </div>
   </DropMenu.Control>
@@ -73,6 +74,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 04.d
       </span>
       <CaretIcon
         direction="down"
+        size={8}
         viewBox="0 3 16 8" />
     </div>
   </DropMenu.Control>
@@ -117,6 +119,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 05.g
       </span>
       <CaretIcon
         direction="down"
+        size={8}
         viewBox="0 3 16 8" />
     </div>
   </DropMenu.Control>
@@ -200,6 +203,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 06.n
       </span>
       <CaretIcon
         direction="down"
+        size={8}
         viewBox="0 3 16 8" />
     </div>
   </DropMenu.Control>
@@ -252,6 +256,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 08.r
       </span>
       <CaretIcon
         direction="down"
+        size={8}
         viewBox="0 3 16 8" />
     </div>
   </DropMenu.Control>
@@ -320,6 +325,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 11.s
       </span>
       <CaretIcon
         direction="down"
+        size={8}
         viewBox="0 3 16 8" />
     </div>
   </DropMenu.Control>


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
~~[ ] One core team UX approval~~

Fixes #649 
