### PR TITLE
Added `no-extra-parens` lint rule with fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
 		"key-spacing": 2,
 		"keyword-spacing": 0,
 		"no-confusing-arrow": [2, {"allowParens": true}],
+		"no-extra-parens": 2,
 		"no-multiple-empty-lines": 2,
 		"no-trailing-spaces": 2,
 		"no-undef": 2,

--- a/src/components/SearchableSelect/SearchableSelect.jsx
+++ b/src/components/SearchableSelect/SearchableSelect.jsx
@@ -177,7 +177,7 @@ const SearchableSelect = createClass({
 			return node.children
 							.filter((child) => !_.isString(child))
 							.map((child) => this.getCombinedChildText(child.props))
-							.reduce(((combinedText, childText) => combinedText + childText), _.find(node.children, _.isString) || '');
+							.reduce((combinedText, childText) => combinedText + childText, _.find(node.children, _.isString) || '');
 		},
 
 		defaultOptionFilter(searchText, optionProps) {


### PR DESCRIPTION
## PR Checklist

- ~~Manually tested across supported browsers~~
- ~~Unit tests written (`common` at minimum)~~
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~

