### PR TITLE
Fixes #657 by setting flex-shrink: 0 to header/footer

### DIFF
--- a/src/components/Panel/Panel.less
+++ b/src/components/Panel/Panel.less
@@ -18,6 +18,10 @@
 	& > &-Header {
 		padding: @size-standard;
 		border-bottom: @border-lightBorder;
+
+		.lucid-Panel-is-scrollable& {
+			flex-shrink: 0;
+		}
 	}
 
 	& > &-content {
@@ -36,6 +40,10 @@
 		text-align: right;
 		padding: @size-standard;
 		border-top: @border-lightBorder;
+
+		.lucid-Panel-is-scrollable& {
+			flex-shrink: 0;
+		}
 	}
 
 }


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~

