### PR TITLE
Fixes weird typo in selector

### DIFF
--- a/src/components/SplitButton/SplitButton.less
+++ b/src/components/SplitButton/SplitButton.less
@@ -13,14 +13,14 @@
 			&:active:focus {
 				border-top-right-radius: 0;
 				border-bottom-right-radius: 0;
-			}			
+			}
 		}
 
-		&.lucid-SplitButton-Button-node {
+		&.lucid-SplitButton-Button-drop {
 			&:active:focus {
 				border-top-left-radius: 0;
 				border-bottom-left-radius: 0;
-			}			
+			}
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
~~[ ] One core team UX approval~~

