### PR TITLE
Fix double firing touch events

### DIFF
--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -99,7 +99,6 @@ const Checkbox = createClass({
 					'&-is-selected': isIndeterminate || isSelected,
 				}, className)}
 				onClick={this.handleClicked}
-				onTouchEnd={this.handleClicked}
 				style={style}
 			>
 				<input

--- a/src/components/Checkbox/Checkbox.spec.jsx
+++ b/src/components/Checkbox/Checkbox.spec.jsx
@@ -133,20 +133,6 @@ describe('Checkbox', () => {
 			verifyArgumentsWhenFalse('click');
 		});
 	});
-
-	describe('user taps on the rendered control', () => {
-		it('calls the function passed in as the `onSelect` prop...', () => {
-			verifyOnSelect('touchend');
-		});
-
-		it('...and when `isSelected` is true passes along false as the first argument and a React synthetic event as the second argument.', () => {
-			verifyArgumentsWhenTrue('touchend');
-		});
-
-		it('...and when `isSelected` is false passes along true as the first argument and a React synthetic event as the second argument.', () => {
-			verifyArgumentsWhenFalse('touchend');
-		});
-	});
 });
 
 function simulateEvent(reactElement, selector, event) {

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.jsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.jsx.snap
@@ -1,8 +1,7 @@
 exports[`Checkbox [common] example testing should match snapshot(s) for interactive 1`] = `
 <div
   className="lucid-Checkbox lucid-Checkbox-is-selected"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={true}
     className="lucid-Checkbox-native"
@@ -30,8 +29,7 @@ exports[`Checkbox [common] example testing should match snapshot(s) for interact
 exports[`Checkbox [common] example testing should match snapshot(s) for interactive 2`] = `
 <div
   className="lucid-Checkbox lucid-Checkbox-is-disabled"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={false}
     className="lucid-Checkbox-native"
@@ -59,8 +57,7 @@ exports[`Checkbox [common] example testing should match snapshot(s) for interact
 exports[`Checkbox [common] example testing should match snapshot(s) for interactive 3`] = `
 <div
   className="lucid-Checkbox lucid-Checkbox-is-disabled lucid-Checkbox-is-selected"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={true}
     className="lucid-Checkbox-native"
@@ -88,8 +85,7 @@ exports[`Checkbox [common] example testing should match snapshot(s) for interact
 exports[`Checkbox [common] example testing should match snapshot(s) for interactive 4`] = `
 <div
   className="lucid-Checkbox lucid-Checkbox-is-disabled lucid-Checkbox-is-selected"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={false}
     className="lucid-Checkbox-native"

--- a/src/components/RadioButton/RadioButton.jsx
+++ b/src/components/RadioButton/RadioButton.jsx
@@ -96,7 +96,6 @@ const RadioButton = createClass({
 						'&-is-selected': isSelected,
 					}, className)}
 					onClick={this.handleClicked}
-					onTouchEnd={this.handleClicked}
 					style={style}
 			>
 				<input

--- a/src/components/RadioButton/RadioButton.spec.jsx
+++ b/src/components/RadioButton/RadioButton.spec.jsx
@@ -123,18 +123,4 @@ describe('RadioButton', () => {
 			verifyNoOnSelect('click');
 		});
 	});
-
-	describe('user taps on the rendered control', () => {
-		it('calls the function passed in as the `onSelect` prop if `isSelected` is false...', () => {
-			verifyOnSelect('touchend');
-		});
-
-		it('...and passes along true as the first argument and a React synthetic event as the second argument.', () => {
-			verifyArguments('touchend');
-		});
-
-		it('does not call the function passed in as the `onSelect` prop if `isSelected` is true.', () => {
-			verifyNoOnSelect('touchend');
-		});
-	});
 });

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.jsx.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.jsx.snap
@@ -1,8 +1,7 @@
 exports[`RadioButton [common] example testing should match snapshot(s) for interactive 1`] = `
 <span
   className="lucid-RadioButton"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={false}
     className="lucid-RadioButton-native"
@@ -26,8 +25,7 @@ exports[`RadioButton [common] example testing should match snapshot(s) for inter
 exports[`RadioButton [common] example testing should match snapshot(s) for states 1`] = `
 <span
   className="lucid-RadioButton"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={false}
     className="lucid-RadioButton-native"
@@ -50,8 +48,7 @@ exports[`RadioButton [common] example testing should match snapshot(s) for state
 exports[`RadioButton [common] example testing should match snapshot(s) for states 2`] = `
 <span
   className="lucid-RadioButton lucid-RadioButton-is-selected"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={true}
     className="lucid-RadioButton-native"
@@ -74,8 +71,7 @@ exports[`RadioButton [common] example testing should match snapshot(s) for state
 exports[`RadioButton [common] example testing should match snapshot(s) for states 3`] = `
 <span
   className="lucid-RadioButton lucid-RadioButton-is-disabled"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={false}
     className="lucid-RadioButton-native"
@@ -98,8 +94,7 @@ exports[`RadioButton [common] example testing should match snapshot(s) for state
 exports[`RadioButton [common] example testing should match snapshot(s) for states 4`] = `
 <span
   className="lucid-RadioButton lucid-RadioButton-is-disabled lucid-RadioButton-is-selected"
-  onClick={[Function]}
-  onTouchEnd={[Function]}>
+  onClick={[Function]}>
   <input
     checked={true}
     className="lucid-RadioButton-native"


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
  - [x] iPhone 6S Safari
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~One core team UX approval~

Fixes #670