### PR TITLE
Add Collapsible props to VerticalListMenu.Item

### DIFF
--- a/src/components/VerticalListMenu/VerticalListMenu.jsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.jsx
@@ -16,6 +16,7 @@ const {
 	number,
 	node,
 	object,
+	shape,
 } = React.PropTypes;
 
 /**
@@ -71,6 +72,11 @@ const VerticalListMenu = createClass({
 				 * Signature: `(index, { event, props}) => {}`
 				 */
 				onToggle: func,
+				/**
+				 * Props that are passed through to the underlying Collapsible
+				 * component if the item has children.
+				 */
+				Collapsible: shape(Collapsible.propTypes),
 			},
 		}),
 	},
@@ -153,6 +159,7 @@ const VerticalListMenu = createClass({
 					const {
 						hasExpander = false,
 						isActionable = true,
+						Collapsible: collapsibleProps = Collapsible.getDefaultProps(),
 					} = itemChildProp;
 
 					const itemChildrenAsArray = React.Children.toArray(itemChildProp.children);
@@ -202,6 +209,7 @@ const VerticalListMenu = createClass({
 
 							{!_.isEmpty(listChildren) ? (
 								<Collapsible
+									{...collapsibleProps}
 									className={cx('&-Item-nested-list')}
 									isExpanded={actualIsExpanded}
 								>

--- a/src/components/VerticalListMenu/__snapshots__/VerticalListMenu.spec.jsx.snap
+++ b/src/components/VerticalListMenu/__snapshots__/VerticalListMenu.spec.jsx.snap
@@ -608,3 +608,381 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
   </VerticalListMenu.Item>
 </ul>
 `;
+
+exports[`VerticalListMenu [common] example testing should match snapshot(s) for 4.no-animations 1`] = `
+<ul
+  className="lucid-VerticalListMenu"
+  style={
+    Object {
+      "width": 250,
+    }
+  }>
+  <li
+    className="lucid-VerticalListMenu-Item">
+    <div
+      className="lucid-VerticalListMenu-Item-content lucid-VerticalListMenu-Item-content-is-actionable"
+      onClick={[Function]}>
+      <div
+        className="lucid-VerticalListMenu-Item-content-text">
+        Level one
+      </div>
+    </div>
+  </li>
+  <li
+    className="lucid-VerticalListMenu-Item">
+    <div
+      className="lucid-VerticalListMenu-Item-content lucid-VerticalListMenu-Item-content-is-actionable"
+      onClick={[Function]}>
+      <div
+        className="lucid-VerticalListMenu-Item-content-text">
+        Level one with VerticalListMenu
+      </div>
+      <div
+        className="lucid-VerticalListMenu-Item-expander"
+        onClick={[Function]}>
+        <ChevronIcon
+          direction="down" />
+      </div>
+    </div>
+    <Collapsible
+      className="lucid-VerticalListMenu-Item-nested-list"
+      isAnimated={false}
+      isExpanded={false}
+      isMountControlled={false}
+      mountControlThreshold={4}
+      rootType="div">
+      <VerticalListMenu>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+        <VerticalListMenu.Item>
+          Level two
+        </VerticalListMenu.Item>
+      </VerticalListMenu>
+    </Collapsible>
+  </li>
+  <li
+    className="lucid-VerticalListMenu-Item">
+    <div
+      className="lucid-VerticalListMenu-Item-content lucid-VerticalListMenu-Item-content-is-actionable"
+      onClick={[Function]}>
+      <div
+        className="lucid-VerticalListMenu-Item-content-text">
+        Level one
+      </div>
+    </div>
+  </li>
+  <VerticalListMenu.Item>
+    Level one
+  </VerticalListMenu.Item>
+  <VerticalListMenu.Item
+    Collapsible={
+      Object {
+        "isAnimated": false,
+        "isMountControlled": false,
+      }
+    }
+    hasExpander={true}>
+    Level one with VerticalListMenu
+    <VerticalListMenu>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+      <VerticalListMenu.Item>
+        Level two
+      </VerticalListMenu.Item>
+    </VerticalListMenu>
+  </VerticalListMenu.Item>
+  <VerticalListMenu.Item>
+    Level one
+  </VerticalListMenu.Item>
+</ul>
+`;

--- a/src/components/VerticalListMenu/examples/4.no-animations.jsx
+++ b/src/components/VerticalListMenu/examples/4.no-animations.jsx
@@ -1,0 +1,28 @@
+import _ from 'lodash';
+import React from 'react';
+import { VerticalListMenu } from '../../../index';
+
+export default React.createClass({
+	render() {
+		return (
+			<VerticalListMenu style={{ width: 250 }}>
+				<VerticalListMenu.Item>Level one</VerticalListMenu.Item>
+				<VerticalListMenu.Item
+					Collapsible={{
+						isAnimated: false, // don't animate
+						isMountControlled: false, // don't remove items from the dom when they are hidden
+					}}
+					hasExpander={true}
+				>
+					Level one with VerticalListMenu
+					<VerticalListMenu>
+						{_.times(50, (n) => {
+							return <VerticalListMenu.Item key={n}>Level two</VerticalListMenu.Item>;
+						})}
+					</VerticalListMenu>
+				</VerticalListMenu.Item>
+				<VerticalListMenu.Item>Level one</VerticalListMenu.Item>
+			</VerticalListMenu>
+		);
+	},
+});


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~

Fixes #684 

http://docspot.devnxs.net/projects/lucid/684-collapsible-props-on-verticallistmenu/#/components/VerticalListMenu