### PR TITLE
create scroll listener on mount instead of exported singleton

### DIFF
--- a/src/components/Resizer/Resizer.jsx
+++ b/src/components/Resizer/Resizer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { lucidClassNames } from '../../util/style-helpers';
 import { createClass, omitProps } from '../../util/component-types';
-import { elementResizeDetector } from './Resizer.util';
+import elementResizeDetectorMaker from 'element-resize-detector';
 
 const cx = lucidClassNames.bind('&-Resizer');
 
@@ -48,11 +48,12 @@ const Resizer = createClass({
 	},
 
 	componentDidMount() {
-		elementResizeDetector.listenTo(this._element, this.handleResize);
+		this.resizeDetector = elementResizeDetectorMaker({strategy: 'scroll'});
+		this.resizeDetector.listenTo(this._element, this.handleResize);
 	},
 
 	componentWillUnmount() {
-		elementResizeDetector.removeListener(this._element, this.handleResize);
+		this.resizeDetector.removeListener(this._element, this.handleResize);
 	},
 
 	render() {

--- a/src/components/Resizer/Resizer.spec.jsx
+++ b/src/components/Resizer/Resizer.spec.jsx
@@ -1,17 +1,21 @@
-jest.mock('./Resizer.util');
+jest.mock('element-resize-detector', () => {
+	return function() {
+		return {
+			listenTo: jest.fn((_element, handleResize) => {
+				handleResize({
+					offsetWidth: 50,
+					offsetHeight: 100,
+				});
+			}),
+			removeListener: jest.fn(),
+		};
+	};
+});
 import _ from 'lodash';
 import React from 'react';
 import { common } from '../../util/generic-tests';
 import { mount } from 'enzyme';
 import Resizer from './Resizer';
-import { elementResizeDetector } from './Resizer.util';
-
-elementResizeDetector.listenTo = jest.fn((_element, handleResize) => {
-	handleResize({
-		offsetWidth: 50,
-		offsetHeight: 100,
-	});
-});
 
 describe('Resizer', () => {
 	common(Resizer, {
@@ -31,11 +35,10 @@ describe('Resizer', () => {
 				</Resizer>
 			);
 
-			expect(elementResizeDetector.removeListener).not.toHaveBeenCalled();
+			expect(wrapper.node.resizeDetector.removeListener).not.toHaveBeenCalled();
 
 			wrapper.unmount();
-
-			expect(elementResizeDetector.removeListener).toHaveBeenCalled();
+			expect(wrapper.node.resizeDetector.removeListener).toHaveBeenCalled();
 		});
 	});
 

--- a/src/components/Resizer/Resizer.util.js
+++ b/src/components/Resizer/Resizer.util.js
@@ -1,3 +1,0 @@
-import elementResizeDetectorMaker from 'element-resize-detector';
-
-export const elementResizeDetector = elementResizeDetectorMaker({strategy: 'scroll'});


### PR DESCRIPTION
the existing module exports an instance of `element-resize-detector` which tries to bind event listeners on `document.body` which may not be available at instantiation.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~[ ] One core team UX approval~~
