### PR TITLE
Fix async hybrid setState overwrite bug.

### DIFF
--- a/src/util/state-management.js
+++ b/src/util/state-management.js
@@ -148,9 +148,13 @@ export function buildHybridComponent(baseComponent, {
 			return _.mergeWith({}, omitFunctionPropsDeep(baseComponent.getDefaultProps()), initialState, omitFunctionPropsDeep(this.props), safeMerge);
 		},
 		componentWillMount() {
+			let synchronousState = this.state; //store reference to state, use in place of `this.state` in `getState`
 			this.boundContext = getStatefulPropsContext(reducers, {
-				getState: () => _.mergeWith({}, omitFunctionPropsDeep(this.state), omitFunctionPropsDeep(this.props), safeMerge),
-				setState: (state) => { this.setState(state); },
+				getState: () => _.mergeWith({}, omitFunctionPropsDeep(synchronousState), omitFunctionPropsDeep(this.props), safeMerge),
+				setState: (state) => {
+					synchronousState = state; //synchronously update the state reference
+					this.setState(state);
+				},
 			});
 		},
 		render() {


### PR DESCRIPTION
Fix bug where hybrid component reducers called in the same tick would overwrite the last state.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~
