### PR TITLE
Fix SingleSelect in RadioGroup bug

### DIFF
--- a/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
@@ -112,6 +112,90 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
 </span>
 `;
 
+exports[`RadioGroup [common] example testing should match snapshot(s) for nested-select 1`] = `
+<span
+  className="lucid-RadioGroup"
+>
+  <RadioButtonLabeled
+    Label={
+      Object {
+        "children": "Alvin",
+      }
+    }
+    callbackId={0}
+    isDisabled={false}
+    isSelected={true}
+    name="lucid-RadioGroup-2"
+    onSelect={[Function]}
+    style={
+      Object {
+        "marginRight": "13px",
+      }
+    }
+  >
+    <RadioGroup.Label>
+      Alvin
+    </RadioGroup.Label>
+  </RadioButtonLabeled>
+  <RadioButtonLabeled
+    Label={
+      Object {
+        "children": "Simon",
+      }
+    }
+    callbackId={1}
+    isDisabled={false}
+    isSelected={false}
+    name="lucid-RadioGroup-2"
+    onSelect={[Function]}
+    style={
+      Object {
+        "marginRight": "13px",
+      }
+    }
+  >
+    <RadioGroup.Label>
+      Simon
+    </RadioGroup.Label>
+  </RadioButtonLabeled>
+  <RadioButtonLabeled
+    Label={
+      Object {
+        "children": <SingleSelect>
+          <SingleSelect.Option>
+              One
+          </SingleSelect.Option>
+          <SingleSelect.Option>
+              Two
+          </SingleSelect.Option>
+      </SingleSelect>,
+      }
+    }
+    callbackId={2}
+    isDisabled={false}
+    isSelected={false}
+    name="lucid-RadioGroup-2"
+    onSelect={[Function]}
+    style={
+      Object {
+        "marginRight": "13px",
+      }
+    }
+  >
+    <RadioGroup.Label>
+      <SingleSelect>
+        <SingleSelect.Option>
+          One
+        </SingleSelect.Option>
+        <SingleSelect.Option>
+          Two
+        </SingleSelect.Option>
+      </SingleSelect>
+    </RadioGroup.Label>
+  </RadioButtonLabeled>
+</span>
+`;
+
 exports[`RadioGroup [common] example testing should match snapshot(s) for selected-index-as-prop 1`] = `
 <span
   className="lucid-RadioGroup"

--- a/src/components/RadioGroup/examples/nested-select.jsx
+++ b/src/components/RadioGroup/examples/nested-select.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { RadioGroup, SingleSelect } from '../../../index';
+
+const style = {
+	marginRight: '13px',
+};
+
+export default React.createClass({
+	render() {
+		return (
+			<RadioGroup>
+				<RadioGroup.RadioButton style={style}>
+					<RadioGroup.Label>Alvin</RadioGroup.Label>
+				</RadioGroup.RadioButton>
+				<RadioGroup.RadioButton style={style}>
+					<RadioGroup.Label>Simon</RadioGroup.Label>
+				</RadioGroup.RadioButton>
+				<RadioGroup.RadioButton style={style}>
+					<RadioGroup.Label>
+						<SingleSelect>
+							<SingleSelect.Option>One</SingleSelect.Option>
+							<SingleSelect.Option>Two</SingleSelect.Option>
+						</SingleSelect>
+					</RadioGroup.Label>
+				</RadioGroup.RadioButton>
+			</RadioGroup>
+		);
+	},
+});

--- a/src/util/dom-helpers.js
+++ b/src/util/dom-helpers.js
@@ -35,3 +35,30 @@ export function dispatchDOMEvent(node, eventName, assignedEventProps) {
 	node.dispatchEvent(_.assign(event, assignedEventProps));
 	return event;
 }
+
+
+/**
+ * sharesAncestor
+ *
+ * Recursively looks at `node` and its parents for `findNodeName` and makes
+ * sure it contains `siblingNode`.
+ *
+ * @param {element} node - dom node to check if any of its ancestors are a `<label>`
+ * @param {element} siblingNode - dom node to see if it shares an ancestor
+ * @param {string} findNodeName - dom node name, should be uppercased, e.g. `LABEL` or `SPAN`
+ * @returns {boolean}
+ */
+export function sharesAncestor(node, siblingNode, findNodeName) {
+	const nodeName = _.get(node, 'nodeName');
+	const parentNode = _.get(node, 'parentNode');
+
+	if (nodeName === findNodeName) {
+		return node.contains(siblingNode);
+	}
+
+	if (parentNode) {
+		return false || sharesAncestor(parentNode, siblingNode, findNodeName);
+	}
+
+	return false;
+}

--- a/src/util/dom-helpers.js
+++ b/src/util/dom-helpers.js
@@ -40,24 +40,24 @@ export function dispatchDOMEvent(node, eventName, assignedEventProps) {
 /**
  * sharesAncestor
  *
- * Recursively looks at `node` and its parents for `findNodeName` and makes
+ * Recursively looks at `node` and its parents for `nodeName` and makes
  * sure it contains `siblingNode`.
  *
  * @param {element} node - dom node to check if any of its ancestors are a `<label>`
  * @param {element} siblingNode - dom node to see if it shares an ancestor
- * @param {string} findNodeName - dom node name, should be uppercased, e.g. `LABEL` or `SPAN`
+ * @param {string} nodeName - dom node name, should be uppercased, e.g. `LABEL` or `SPAN`
  * @returns {boolean}
  */
-export function sharesAncestor(node, siblingNode, findNodeName) {
-	const nodeName = _.get(node, 'nodeName');
+export function sharesAncestor(node, siblingNode, nodeName) {
+	const currentNodeName = _.get(node, 'nodeName');
 	const parentNode = _.get(node, 'parentNode');
 
-	if (nodeName === findNodeName) {
+	if (currentNodeName === nodeName) {
 		return node.contains(siblingNode);
 	}
 
 	if (parentNode) {
-		return false || sharesAncestor(parentNode, siblingNode, findNodeName);
+		return sharesAncestor(parentNode, siblingNode, nodeName);
 	}
 
 	return false;

--- a/src/util/dom-helpers.spec.js
+++ b/src/util/dom-helpers.spec.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import {
 	getAbsoluteBoundingClientRect,
 	scrollParentTo,
+	sharesAncestor,
 } from './dom-helpers';
 
 describe('#getAbsoluteBoundingClientRect', () => {
@@ -98,5 +99,43 @@ describe('#scrollParentTo', () => {
 		parentNode.scrollTop = 5; // parent element is scrolled down by 5px
 		scrollParentTo(childNode);
 		assert.equal(parentNode.scrollTop, 5); //expect no change in scrolling of parent
+	});
+});
+
+describe('#sharesAncestor', () => {
+	it('should correctly find an ancestor', () => {
+		const siblingNode = {};
+		const contains = jest.fn().mockReturnValue(true);
+
+		const node = {
+			nodeName: 'DIV',
+			parentNode: {
+				nodeName: 'SPAN',
+				parentNode: {
+					nodeName: 'SECTION',
+					contains,
+				},
+			},
+		};
+
+		expect(sharesAncestor(node, siblingNode, 'SECTION')).toBe(true);
+		expect(contains).toHaveBeenCalledWith(siblingNode);
+	});
+
+	it('should correctly find not an ancestor', () => {
+		const node = {
+			nodeName: 'DIV',
+			parentNode: {
+				nodeName: 'SPAN',
+				parentNode: {
+					nodeName: 'DIV',
+					parentNode: {
+						nodeName: 'SPAN',
+					},
+				},
+			},
+		};
+
+		expect(sharesAncestor(node, null, 'SECTION')).toBe(false);
 	});
 });


### PR DESCRIPTION
Fixes #662

Detects if a body click was a `<label>` and doesn't trigger the on click
out handler if that's the case.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 (Win 7)
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~
