### PR TITLE
Add support for DropMenu.Option onClick handler that is passed through

### DIFF
--- a/src/components/DropMenu/DropMenu.jsx
+++ b/src/components/DropMenu/DropMenu.jsx
@@ -414,6 +414,7 @@ const DropMenu = createClass({
 
 		if (!optionProps.isDisabled && focusedIndex !== optionIndex) {
 			onFocusOption(optionIndex, { props: optionProps, event });
+			optionProps.onClick({{ props: optionProps, event }});
 		}
 	},
 


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11 (Win 7)
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
