### PR TITLE
Check for `collapseShift` changes in SplitHorizontal/SplitVertical

### DIFF
--- a/src/components/SplitHorizontal/SplitHorizontal.jsx
+++ b/src/components/SplitHorizontal/SplitHorizontal.jsx
@@ -295,7 +295,10 @@ const SplitHorizontal = createClass({
 
 		const { secondaryRef } = this.getPanes();
 
-		if (this.props.isExpanded && !isExpanded) {
+		if (
+			!isExpanded && // check if collapseShift changed or secondary pane collapsed
+			(this.props.isExpanded || this.props.collapseShift !== collapseShift)
+		) {
 			// collapse secondary
 			const secondaryRect = secondaryRef.getBoundingClientRect();
 			this.collapseSecondary(secondaryRect.height - collapseShift);

--- a/src/components/SplitVertical/SplitVertical.jsx
+++ b/src/components/SplitVertical/SplitVertical.jsx
@@ -300,7 +300,10 @@ const SplitVertical = createClass({
 
 		const { secondaryRef } = this.getPanes();
 
-		if (this.props.isExpanded && !isExpanded) {
+		if (
+			!isExpanded && // check if collapseShift changed or secondary pane collapsed
+			(this.props.isExpanded || this.props.collapseShift !== collapseShift)
+		) {
 			// collapse secondary
 			const secondaryRect = secondaryRef.getBoundingClientRect();
 			this.collapseSecondary(secondaryRect.width - collapseShift);

--- a/src/components/Submarine/__snapshots__/Submarine.spec.jsx.snap
+++ b/src/components/Submarine/__snapshots__/Submarine.spec.jsx.snap
@@ -599,7 +599,9 @@ exports[`Submarine [common] example testing should match snapshot(s) for 10.hidd
     >
       <div
         className="lucid-Submarine-Bar-Title"
-      />
+      >
+        This can be totally hidden from view
+      </div>
       <div
         className="lucid-Submarine-expander"
         onMouseDown={[Function]}
@@ -612,7 +614,7 @@ exports[`Submarine [common] example testing should match snapshot(s) for 10.hidd
     <div
       className="lucid-Submarine-Bar-content"
     >
-      You will never see me!
+      Slow-carb meditation four loko, kickstarter umami tilde craft beer kombucha deep v plaid yr cardigan gastropub ennui snackwave. Vape health goth selvage twee lumbersexual, tattooed iceland cred street art slow-carb craft beer pinterest banjo typewriter pop-up. Echo park bicycle rights put a bird on it, sriracha blue bottle ethical pinterest readymade messenger bag. Tousled slow-carb occupy messenger bag readymade, leggings celiac cloud bread tofu. Wayfarers chia jianbing, twee yuccie seitan meggings food truck meh neutra bushwick mlkshk four loko. Franzen unicorn tofu lumbersexual waistcoat. Taxidermy gluten-free yuccie vinyl waistcoat.
     </div>
   </SplitHorizontal.BottomPane>
   <SplitHorizontal.Divider

--- a/src/components/Submarine/examples/10.hidden-bar.jsx
+++ b/src/components/Submarine/examples/10.hidden-bar.jsx
@@ -3,27 +3,62 @@ import createClass from 'create-react-class';
 import { Submarine } from '../../../index';
 
 export default createClass({
+	getInitialState() {
+		return {
+			isHidden: true,
+		};
+	},
+
+	handleToggleIsHidden() {
+		this.setState({
+			isHidden: !this.state.isHidden,
+		});
+	},
+
 	render() {
 		return (
-			<section
-				style={{
-					height: 300,
-					background: 'lightgray',
-					outline: '1px solid lightgray',
-				}}
-			>
-				<Submarine isHidden={true}>
-					<Submarine.Bar>
-						You will never see me!
-					</Submarine.Bar>
-					<Submarine.Primary>
-						Pickled pinterest hot chicken taxidermy edison bulb. Butcher austin
-						listicle fingerstache unicorn flexitarian. Tumblr cred quinoa
-						normcore, mumblecore cardigan cold-pressed dreamcatcher craft beer
-						ad direct trade vero accusamus cray. Roof party chia shabby chic
-						synth.
-					</Submarine.Primary>
-				</Submarine>
+			<section>
+				<button onClick={this.handleToggleIsHidden}>toggle `isHidden`</button>
+
+				<section
+					style={{
+						height: 300,
+						background: 'lightgray',
+						outline: '1px solid lightgray',
+					}}
+				>
+
+					<Submarine isHidden={this.state.isHidden}>
+
+						<Submarine.Title>
+							This can be totally hidden from view
+						</Submarine.Title>
+
+						<Submarine.Bar>
+							Slow-carb meditation four loko, kickstarter umami tilde craft
+							beer kombucha deep v plaid yr cardigan gastropub ennui snackwave.
+							Vape health goth selvage twee lumbersexual, tattooed iceland cred
+							street art slow-carb craft beer pinterest banjo typewriter
+							pop-up. Echo park bicycle rights put a bird on it, sriracha blue
+							bottle ethical pinterest readymade messenger bag. Tousled
+							slow-carb occupy messenger bag readymade, leggings celiac cloud
+							bread tofu. Wayfarers chia jianbing, twee yuccie seitan meggings
+							food truck meh neutra bushwick mlkshk four loko. Franzen unicorn
+							tofu lumbersexual waistcoat. Taxidermy gluten-free yuccie vinyl
+							waistcoat.
+						</Submarine.Bar>
+
+						<Submarine.Primary>
+							Pickled pinterest hot chicken taxidermy edison bulb. Butcher austin
+							listicle fingerstache unicorn flexitarian. Tumblr cred quinoa
+							normcore, mumblecore cardigan cold-pressed dreamcatcher craft beer
+							ad direct trade vero accusamus cray. Roof party chia shabby chic
+							synth.
+						</Submarine.Primary>
+
+					</Submarine>
+
+				</section>
 			</section>
 		);
 	},


### PR DESCRIPTION
* Add check for changes in `collapseShift` in SplitHorizontal/SplitVertical
* Modify Submarine example to toggle `isHidden` property

http://docspot.devnxs.net/projects/lucid/bugfix-splithorizontal-check-collapseshift/#/components/Submarine
(_Hidden Bar_ example)

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval
