### PR TITLE
Disable SplitButton caret when all child Buttons are disabled

### DIFF
--- a/src/components/SplitButton/SplitButton.jsx
+++ b/src/components/SplitButton/SplitButton.jsx
@@ -182,9 +182,10 @@ const SplitButton = createClass({
 							hasOnlyIcon
 							isActive={isExpanded}
 							kind={kind}
-							isDisabled={_.every([primaryButtonProps, ...buttonChildProps], {
-								isDisabled: true,
-							})}
+							isDisabled={_.every(
+								[primaryButtonProps, ...buttonChildProps],
+								'isDisabled'
+							)}
 						>
 							<CaretIcon
 								className={cx('&-CaretIcon')}

--- a/src/components/SplitButton/SplitButton.jsx
+++ b/src/components/SplitButton/SplitButton.jsx
@@ -182,6 +182,9 @@ const SplitButton = createClass({
 							hasOnlyIcon
 							isActive={isExpanded}
 							kind={kind}
+							isDisabled={_.every([primaryButtonProps, ...buttonChildProps], {
+								isDisabled: true,
+							})}
 						>
 							<CaretIcon
 								className={cx('&-CaretIcon')}


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

<img width="271" alt="screen shot 2017-06-16 at 10 47 38 am" src="https://user-images.githubusercontent.com/1967266/27238341-58649d48-5281-11e7-9896-96d2d40de657.png">

