### PR TITLE
only setState on TextField when mounted

### DIFF
--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -138,21 +138,32 @@ const TextField = createClass({
 		// Because we want the debounceLevel to be configurable, we can't put the
 		// debounced handler directly on the react class, so we set it up right
 		// before mount
+		this._isMounted = true;
 		this._handleChangeDebounced = _.debounce((...args) => {
 			this.props.onChangeDebounced(...args);
 		}, this.props.debounceLevel);
 
 		this._releaseHold = _.debounce(() => {
+			if (!this._isMounted) {
+				return;
+			}
 			this.setState({ isHolding: false });
 		}, this.props.lazyLevel);
 
 		this._updateWhenReady = _.debounce(newValue => {
+			if (!this._isMounted) {
+				return;
+			}
 			if (this.state.isHolding) {
 				this._updateWhenReady(newValue);
 			} else if (newValue !== this.state.value) {
 				this.setState({ value: newValue });
 			}
 		}, this.props.lazyLevel);
+	},
+
+	componentWillUnmount() {
+		this._isMounted = false;
 	},
 
 	componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
if the TextField is unmounted before setState is called, an error is thrown. this checks to see if it is mounted before setting state.

strategy taken from https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~One core team UX approval~
