### PR TITLE
SplitButton: Fix to pass thru primary button className

### DIFF
--- a/src/components/SplitButton/SplitButton.jsx
+++ b/src/components/SplitButton/SplitButton.jsx
@@ -171,7 +171,10 @@ const SplitButton = createClass({
 					<ButtonGroup>
 						<Button
 							{...primaryButtonProps}
-							className={cx('&-Button-primary')}
+							className={cx(
+								'&-Button-primary',
+								_.get(primaryButtonProps, 'className')
+							)}
 							kind={kind}
 							type={type}
 							size={size}


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~One core team UX approval~
