### PR TITLE
change default HelpIcon colors

### DIFF
--- a/src/components/Icon/HelpIcon/HelpIcon.less
+++ b/src/components/Icon/HelpIcon/HelpIcon.less
@@ -1,0 +1,13 @@
+.lucid-HelpIcon {
+	.opacity(.35);
+	fill: @color-disabledText;
+
+	&.lucid-Icon-is-clickable {
+		cursor: pointer;
+
+		&:hover {
+			fill: darken(@color-disabledText, 20%);
+		}
+	}
+}
+

--- a/src/styles/components.less
+++ b/src/styles/components.less
@@ -32,6 +32,7 @@
 @import '../components/Icon/EligibilityIcon/EligibilityIcon';
 @import '../components/Icon/InfoIcon/InfoIcon';
 @import '../components/Icon/InfoLightIcon/InfoLightIcon';
+@import '../components/Icon/HelpIcon/HelpIcon';
 @import '../components/Icon/LoadingIcon/LoadingIcon';
 @import '../components/Icon/MinusCircleIcon/MinusCircleIcon';
 @import '../components/Icon/MinusCircleLightIcon/MinusCircleLightIcon';


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval

fixes #810 
