### PR TITLE
Sidebar: fix gripper icon centering

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -294,10 +294,7 @@ const Sidebar = createClass({
 						{barProps.children}
 					</div>
 				</BarPane>
-				<SplitVertical.Divider
-					className={cx('&-Divider')}
-					style={{ width: '7px' }}
-				>
+				<SplitVertical.Divider className={cx('&-Divider')} style={{ width: 7 }}>
 					<GripperVerticalIcon className={cx('&-Divider-gripper')} />
 				</SplitVertical.Divider>
 				<PrimaryPane

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -294,7 +294,10 @@ const Sidebar = createClass({
 						{barProps.children}
 					</div>
 				</BarPane>
-				<SplitVertical.Divider className={cx('&-Divider')}>
+				<SplitVertical.Divider
+					className={cx('&-Divider')}
+					style={{ width: '7px' }}
+				>
 					<GripperVerticalIcon className={cx('&-Divider-gripper')} />
 				</SplitVertical.Divider>
 				<PrimaryPane

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
@@ -55,7 +55,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 01.defaul
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -127,7 +127,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 02.disabl
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -199,7 +199,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 03.initia
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -271,7 +271,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 04.positi
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -369,7 +369,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 05.custom
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -441,7 +441,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 06.custom
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -513,7 +513,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 07.contro
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -585,7 +585,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 08.handle
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -657,7 +657,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 09.nested
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >
@@ -1841,7 +1841,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 10.nested
     className="lucid-Sidebar-Divider"
     style={
       Object {
-        "width": "7px",
+        "width": 7,
       }
     }
   >

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
@@ -53,6 +53,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 01.defaul
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -120,6 +125,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 02.disabl
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -187,6 +197,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 03.initia
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -254,6 +269,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 04.positi
   </SplitVertical.RightPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -347,6 +367,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 05.custom
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -414,6 +439,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 06.custom
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -481,6 +511,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 07.contro
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -548,6 +583,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 08.handle
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -615,6 +655,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 09.nested
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"
@@ -1794,6 +1839,11 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 10.nested
   </SplitVertical.LeftPane>
   <SplitVertical.Divider
     className="lucid-Sidebar-Divider"
+    style={
+      Object {
+        "width": "7px",
+      }
+    }
   >
     <GripperVerticalIcon
       className="lucid-Sidebar-Divider-gripper"


### PR DESCRIPTION
fixes #801 

http://docspot.devnxs.net/projects/lucid/801-sidebar-gripper/

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
