### PR TITLE
821 - update tag styling to mitigate having too much concentrated teal

### DIFF
--- a/src/components/Tag/Tag.less
+++ b/src/components/Tag/Tag.less
@@ -11,8 +11,8 @@
 
 	.lucid-Tag-inner {
 		border-radius: @size-borderRadius;
-		background: @color-primary-10;
-		border: 1px solid @color-primary-30;
+		background: @color-lightGray;
+		border: 1px solid @color-gray;
 		font-weight: bold;
 		font-size: @size-font;
 		color: @color-textColor;
@@ -49,24 +49,24 @@
 		}
 
 		.lucid-Tag-leaf& {
-			border: none;
 			border-radius: 3px;
-			background: @color-primary;
+			border-color: @featured-color-primary-borderColorMedium;
+			background: @color-white;
 			font-size: @size-standard;
 			font-weight: normal;
-			color: @color-white;
+			color: @color-black;
 
 			.lucid-Tag-inner-content {
 				height: 100%;
 
 				.lucid-Tag-remove {
 					.lucid-Tag-remove-button {
-						fill: @color-white-50;
+						fill: @color-mediumGray;
 					}
 
 					&:hover {
 						.lucid-Tag-remove-button {
-							fill: @color-white;
+							fill: @color-darkGray;
 						}
 					}
 				}

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -158,6 +158,7 @@
 @featured-color-primary-backgroundColorLight: tint(@featured-color-primary, 90%);
 @featured-color-primary-backgroundColor: tint(@featured-color-primary, 70%);
 @featured-color-primary-borderColorLite: tint(@featured-color-primary, 60%);
+@featured-color-primary-borderColorMedium: tint(@featured-color-primary, 30%);
 @featured-color-primary-gradientStartColor: tint(@featured-color-primary, 30%);
 @featured-color-primary-gradientEndColor: @featured-color-primary;
 @featured-color-primary-borderColor: @featured-color-primary;


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
