### PR TITLE
831: Add navigation and variable width styling props for Tabs

### DIFF
--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -139,7 +139,7 @@ const Tab = createClass({
 								fill="none"
 								stroke="#fff"
 								strokeWidth="1"
-								points={isNavigation ? '0,37 7.9,18.5 0,0' : '0,28 7.9,14 0,0'}
+								points={isNavigation ? '0,37 7.3,18.5 0,0' : '0,28 7.9,14 0,0'}
 							/>
 						</svg>
 					</span>}

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -73,11 +73,6 @@ const Tab = createClass({
 		Title: node,
 
 		/**
-		 * Width (with unit) to be passed as the `style` to the `Tab`
-		 */
-		width: string,
-
-		/**
 		 * If `true` component will be styled to be more visually prominent for use with page-level navigation.
 		 */
 		isNavigation: bool,
@@ -99,11 +94,9 @@ const Tab = createClass({
 			isProgressive,
 			isSelected,
 			Title,
-			width,
 			isNavigation,
+			...passThroughs
 		} = this.props;
-
-		const style = width ? { width } : {};
 
 		return (
 			<li
@@ -113,8 +106,8 @@ const Tab = createClass({
 					'&-Tab-is-active-and-open': isOpen && isSelected,
 					'&-Tab-is-progressive': isProgressive && !isLastTab,
 				})}
-				style={style}
 				onClick={this.handleClick}
+				{...passThroughs}
 			>
 				<span className={cx('&-Tab-content')}>{Title}</span>
 				{isProgressive &&

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -71,6 +71,16 @@ const Tab = createClass({
 		 * The content to be rendered as the `Title` of the `Tab`.
 		 */
 		Title: node,
+
+		/**
+		 * Width (with unit) to be passed as the `style` to the `Tab`
+		 */
+		width: string,
+
+		/**
+		 * If `true` component will be styled to be more visually prominent for use with page-level navigation.
+		 */
+		isNavigation: bool,
 	},
 
 	handleClick(event) {
@@ -89,7 +99,11 @@ const Tab = createClass({
 			isProgressive,
 			isSelected,
 			Title,
+			width,
+			isNavigation,
 		} = this.props;
+
+		const style = width ? { width } : {};
 
 		return (
 			<li
@@ -99,17 +113,21 @@ const Tab = createClass({
 					'&-Tab-is-active-and-open': isOpen && isSelected,
 					'&-Tab-is-progressive': isProgressive && !isLastTab,
 				})}
+				style={style}
 				onClick={this.handleClick}
 			>
 				<span className={cx('&-Tab-content')}>{Title}</span>
 				{isProgressive &&
 					!isLastTab &&
 					<span className={cx('&-Tab-arrow')}>
-						<svg className={cx('&-Tab-arrow-svg')} viewBox="0 0 8 28">
+						<svg
+							className={cx('&-Tab-arrow-svg')}
+							viewBox={isNavigation ? '0 0 8 37' : '0 0 8 28'}
+						>
 							<polygon
 								className={cx('&-Tab-arrow-background')}
 								fill="#fff"
-								points="0,0 8,14 0,28"
+								points={isNavigation ? '0,0 8,18.5 0,37' : '0,0 8,14 0,28'}
 							/>
 							<polyline
 								className={cx('&-Tab-arrow-tab-line')}
@@ -121,7 +139,7 @@ const Tab = createClass({
 								fill="none"
 								stroke="#fff"
 								strokeWidth="1"
-								points="0,28 7.9,14 0,0"
+								points={isNavigation ? '0,37 7.9,18.5 0,0' : '0,28 7.9,14 0,0'}
 							/>
 						</svg>
 					</span>}
@@ -191,6 +209,16 @@ const Tabs = createClass({
 		hasMultilineTitle: bool,
 
 		/**
+		 *  If `true` the width will be evenly distributed to all tabs.  `False` typically used in conjunction with `Tab.width`
+		 */
+		hasFullWidthTabs: bool,
+
+		/**
+		 * If `true` component will be styled to be more visually prominent for use with page-level navigation.
+		 */
+		isNavigation: bool,
+
+		/**
 		 * *Child Element*
 		 *
 		 * Can be used to define one or more individual `Tab`s in the sequence of `Tabs`.
@@ -206,6 +234,8 @@ const Tabs = createClass({
 			isOpen: true,
 			isProgressive: false,
 			hasMultilineTitle: false,
+			hasFullWidthTabs: true,
+			isNavigation: false,
 		};
 	},
 
@@ -222,6 +252,8 @@ const Tabs = createClass({
 			isOpen,
 			isProgressive,
 			selectedIndex,
+			hasFullWidthTabs,
+			isNavigation,
 			...passThroughs
 		} = this.props;
 
@@ -241,6 +273,8 @@ const Tabs = createClass({
 				<ul
 					className={cx('&-bar', {
 						'&-bar-is-multiline': hasMultilineTitle,
+						'&-variable-width': !hasFullWidthTabs,
+						'&-navigation-tabs': isNavigation,
 					})}
 				>
 					{_.map(tabChildProps, (tabProps, index) => (
@@ -250,6 +284,7 @@ const Tabs = createClass({
 							isLastTab={index === tabChildProps.length - 1}
 							isOpen={isOpen}
 							isProgressive={isProgressive}
+							isNavigation={isNavigation}
 							isSelected={index === actualSelectedIndex}
 							onSelect={this.handleClicked}
 							Title={_.get(

--- a/src/components/Tabs/Tabs.less
+++ b/src/components/Tabs/Tabs.less
@@ -18,17 +18,15 @@
 	}
 
 	&-navigation-tabs {
-		border-color: @color-borderColorLight;
 		.lucid-Tabs-Tab {
 			height: 40px;
 			font-size: 15pt;
-			border-color: @color-borderColorLight;
+			font-weight: 200;
 		}
 	}
 
 	&-variable-width {
-		border-bottom-width: @Tabs-border-width;
-		border-bottom-style: solid;
+		border-bottom: @Tabs-border-width solid @color-borderColorLight;
 		.lucid-Tabs-Tab {
 			flex: none;
 		}
@@ -47,15 +45,12 @@
 		color: @color-primary;
 		user-select: none;
 		margin-bottom: -@Tabs-border-width;
-		border-width: @Tabs-border-width;
-		border-color: @color-borderColor;
-		border-style: solid;
-		border-right-width: 0;
+		border: @Tabs-border-width solid @color-borderColorLight;
+		border-right: 0;
 		background-color: @color-white;
 
 		&:last-of-type {
-			border-right-width: @Tabs-border-width;
-			border-right-style: solid;
+			border-right: @Tabs-border-width solid @color-borderColorLight;
 		}
 
 		&:hover {
@@ -135,9 +130,7 @@
 	}
 
 	&-Tab-is-active-and-open {
-		&.lucid-Tabs-Tab {
-			border-bottom: @Tabs-border-width solid @color-white;
-		}
+		border-bottom: @Tabs-border-width solid @color-white;
 
 		// `z-index: -1` fixes a very minor visual bug here in IE 11, but it
 		// introduces a bigger bug when using Tabs inside Dialogs.

--- a/src/components/Tabs/Tabs.less
+++ b/src/components/Tabs/Tabs.less
@@ -14,6 +14,24 @@
 		display: flex;
 		margin: 0;
 		padding: 0;
+		border-color: @color-borderColor;
+	}
+
+	&-navigation-tabs {
+		border-color: @color-borderColorLight;
+		.lucid-Tabs-Tab {
+			height: 40px;
+			font-size: 15pt;
+			border-color: @color-borderColorLight;
+		}
+	}
+
+	&-variable-width {
+		border-bottom-width: @Tabs-border-width;
+		border-bottom-style: solid;
+		.lucid-Tabs-Tab {
+			flex: none;
+		}
 	}
 
 	&-Tab {
@@ -29,12 +47,15 @@
 		color: @color-primary;
 		user-select: none;
 		margin-bottom: -@Tabs-border-width;
-		border: @Tabs-border-width solid @color-borderColor;
-		border-right: 0;
+		border-width: @Tabs-border-width;
+		border-color: @color-borderColor;
+		border-style: solid;
+		border-right-width: 0;
 		background-color: @color-white;
 
 		&:last-of-type {
-			border-right: @Tabs-border-width solid @color-borderColor;
+			border-right-width: @Tabs-border-width;
+			border-right-style: solid;
 		}
 
 		&:hover {
@@ -114,7 +135,9 @@
 	}
 
 	&-Tab-is-active-and-open {
-		border-bottom: @Tabs-border-width solid @color-white;
+		&.lucid-Tabs-Tab {
+			border-bottom: @Tabs-border-width solid @color-white;
+		}
 
 		// `z-index: -1` fixes a very minor visual bug here in IE 11, but it
 		// introduces a bigger bug when using Tabs inside Dialogs.

--- a/src/components/Tabs/Tabs.spec.jsx
+++ b/src/components/Tabs/Tabs.spec.jsx
@@ -178,5 +178,27 @@ describe('Tabs', () => {
 				0
 			);
 		});
+
+		it('hasFullWidthTabs', () => {
+			const wrapper = shallow(
+				<Tabs hasFullWidthTabs={false}>
+					<Tabs.Tab Title="Lollipop">Yuck</Tabs.Tab>
+					<Tabs.Tab Title="Slurpee">Yum</Tabs.Tab>
+				</Tabs>
+			);
+
+			assert.equal(wrapper.find('.lucid-Tabs-variable-width').length, 1);
+		});
+
+		it('isNavigation', () => {
+			const wrapper = shallow(
+				<Tabs isNavigation={true}>
+					<Tabs.Tab Title="Lollipop">Yuck</Tabs.Tab>
+					<Tabs.Tab Title="Slurpee">Yum</Tabs.Tab>
+				</Tabs>
+			);
+
+			assert.equal(wrapper.find('.lucid-Tabs-navigation-tabs').length, 1);
+		});
 	});
 });

--- a/src/components/Tabs/Tabs.spec.jsx
+++ b/src/components/Tabs/Tabs.spec.jsx
@@ -155,6 +155,7 @@ describe('Tabs', () => {
 					isSelected: false,
 					Title: '',
 					children: 'Two',
+					isNavigation: false,
 				});
 			});
 

--- a/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -11,6 +11,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 1-title-as-p
       Title="One"
       index={0}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={true}
@@ -23,6 +24,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 1-title-as-p
       index={1}
       isDisabled={true}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -34,6 +36,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 1-title-as-p
       Title="Three"
       index={2}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -45,6 +48,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 1-title-as-p
       Title="Five"
       index={3}
       isLastTab={true}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -72,6 +76,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 2-title-as-c
       Title="One"
       index={0}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={true}
@@ -86,6 +91,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 2-title-as-c
       Title="Two"
       index={1}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -100,6 +106,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 2-title-as-c
       Title="Three"
       index={2}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -115,6 +122,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 2-title-as-c
       index={3}
       isDisabled={true}
       isLastTab={true}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -148,6 +156,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 3-progressio
       Title="One"
       index={0}
       isLastTab={false}
+      isNavigation={false}
       isOpen={false}
       isProgressive={true}
       isSelected={true}
@@ -159,6 +168,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 3-progressio
       Title="Two"
       index={1}
       isLastTab={false}
+      isNavigation={false}
       isOpen={false}
       isProgressive={true}
       isSelected={false}
@@ -170,6 +180,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 3-progressio
       Title="Three"
       index={2}
       isLastTab={false}
+      isNavigation={false}
       isOpen={false}
       isProgressive={true}
       isSelected={false}
@@ -182,6 +193,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 3-progressio
       index={3}
       isDisabled={true}
       isLastTab={false}
+      isNavigation={false}
       isOpen={false}
       isProgressive={true}
       isSelected={false}
@@ -194,6 +206,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 3-progressio
       index={4}
       isDisabled={true}
       isLastTab={true}
+      isNavigation={false}
       isOpen={false}
       isProgressive={true}
       isSelected={false}
@@ -235,6 +248,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 4-complex-ti
       }
       index={0}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={true}
@@ -266,6 +280,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 4-complex-ti
       }
       index={1}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -315,6 +330,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 4-complex-ti
       }
       index={2}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -360,6 +376,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 4-complex-ti
       index={3}
       isDisabled={true}
       isLastTab={true}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -403,6 +420,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 5-tab-as-pro
       Title="Bert"
       index={0}
       isLastTab={false}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={true}
@@ -414,6 +432,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 5-tab-as-pro
       Title="Ernie"
       index={1}
       isLastTab={true}
+      isNavigation={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -426,6 +445,137 @@ exports[`Tabs [common] example testing should match snapshot(s) for 5-tab-as-pro
     className="lucid-Tabs-content"
   >
     Bert
+  </div>
+</div>
+`;
+
+exports[`Tabs [common] example testing should match snapshot(s) for 6-tabs-variable-width 1`] = `
+<div
+  className="lucid-Tabs"
+>
+  <ul
+    className="lucid-Tabs-bar lucid-Tabs-variable-width"
+  >
+    <Tabs.Tab
+      Title="One"
+      index={0}
+      isLastTab={false}
+      isNavigation={false}
+      isOpen={true}
+      isProgressive={false}
+      isSelected={true}
+      onSelect={[Function]}
+      width="17%"
+    >
+      <Tabs.Title>
+        One
+      </Tabs.Title>
+      One content
+    </Tabs.Tab>
+    <Tabs.Tab
+      Title="Two"
+      index={1}
+      isLastTab={false}
+      isNavigation={false}
+      isOpen={true}
+      isProgressive={false}
+      isSelected={false}
+      onSelect={[Function]}
+      width="17%"
+    >
+      <Tabs.Title>
+        Two
+      </Tabs.Title>
+      Two content
+    </Tabs.Tab>
+    <Tabs.Tab
+      Title="Three"
+      index={2}
+      isLastTab={true}
+      isNavigation={false}
+      isOpen={true}
+      isProgressive={false}
+      isSelected={false}
+      onSelect={[Function]}
+      width="17%"
+    >
+      <Tabs.Title>
+        Three
+      </Tabs.Title>
+      Three content
+    </Tabs.Tab>
+  </ul>
+  <div
+    className="lucid-Tabs-content"
+  >
+    <Tabs.Title>
+      One
+    </Tabs.Title>
+    One content
+  </div>
+</div>
+`;
+
+exports[`Tabs [common] example testing should match snapshot(s) for 7-navigation-tabs 1`] = `
+<div
+  className="lucid-Tabs"
+>
+  <ul
+    className="lucid-Tabs-bar lucid-Tabs-navigation-tabs"
+  >
+    <Tabs.Tab
+      Title="One"
+      index={0}
+      isLastTab={false}
+      isNavigation={true}
+      isOpen={true}
+      isProgressive={false}
+      isSelected={true}
+      onSelect={[Function]}
+    >
+      <Tabs.Title>
+        One
+      </Tabs.Title>
+      One content
+    </Tabs.Tab>
+    <Tabs.Tab
+      Title="Two"
+      index={1}
+      isLastTab={false}
+      isNavigation={true}
+      isOpen={true}
+      isProgressive={false}
+      isSelected={false}
+      onSelect={[Function]}
+    >
+      <Tabs.Title>
+        Two
+      </Tabs.Title>
+      Two content
+    </Tabs.Tab>
+    <Tabs.Tab
+      Title="Three"
+      index={2}
+      isLastTab={true}
+      isNavigation={true}
+      isOpen={true}
+      isProgressive={false}
+      isSelected={false}
+      onSelect={[Function]}
+    >
+      <Tabs.Title>
+        Three
+      </Tabs.Title>
+      Three content
+    </Tabs.Tab>
+  </ul>
+  <div
+    className="lucid-Tabs-content"
+  >
+    <Tabs.Title>
+      One
+    </Tabs.Title>
+    One content
   </div>
 </div>
 `;

--- a/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -465,7 +465,11 @@ exports[`Tabs [common] example testing should match snapshot(s) for 6-tabs-varia
       isProgressive={false}
       isSelected={true}
       onSelect={[Function]}
-      width="17%"
+      style={
+        Object {
+          "width": "17%",
+        }
+      }
     >
       <Tabs.Title>
         One
@@ -481,7 +485,11 @@ exports[`Tabs [common] example testing should match snapshot(s) for 6-tabs-varia
       isProgressive={false}
       isSelected={false}
       onSelect={[Function]}
-      width="17%"
+      style={
+        Object {
+          "width": "17%",
+        }
+      }
     >
       <Tabs.Title>
         Two
@@ -497,7 +505,11 @@ exports[`Tabs [common] example testing should match snapshot(s) for 6-tabs-varia
       isProgressive={false}
       isSelected={false}
       onSelect={[Function]}
-      width="17%"
+      style={
+        Object {
+          "width": "17%",
+        }
+      }
     >
       <Tabs.Title>
         Three

--- a/src/components/Tabs/examples/6-tabs-variable-width.jsx
+++ b/src/components/Tabs/examples/6-tabs-variable-width.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Tabs } from '../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<Tabs hasFullWidthTabs={false}>
+					<Tabs.Tab width="17%">
+						<Tabs.Title>One</Tabs.Title>
+						One content
+					</Tabs.Tab>
+					<Tabs.Tab width="17%">
+						<Tabs.Title>Two</Tabs.Title>
+						Two content
+					</Tabs.Tab>
+					<Tabs.Tab width="17%">
+						<Tabs.Title>Three</Tabs.Title>
+						Three content
+					</Tabs.Tab>
+				</Tabs>
+			</div>
+		);
+	},
+});

--- a/src/components/Tabs/examples/6-tabs-variable-width.jsx
+++ b/src/components/Tabs/examples/6-tabs-variable-width.jsx
@@ -4,18 +4,19 @@ import { Tabs } from '../../../index';
 
 export default createClass({
 	render() {
+		const tabStyle = { width: '17%' };
 		return (
 			<div>
 				<Tabs hasFullWidthTabs={false}>
-					<Tabs.Tab width="17%">
+					<Tabs.Tab style={tabStyle}>
 						<Tabs.Title>One</Tabs.Title>
 						One content
 					</Tabs.Tab>
-					<Tabs.Tab width="17%">
+					<Tabs.Tab style={tabStyle}>
 						<Tabs.Title>Two</Tabs.Title>
 						Two content
 					</Tabs.Tab>
-					<Tabs.Tab width="17%">
+					<Tabs.Tab style={tabStyle}>
 						<Tabs.Title>Three</Tabs.Title>
 						Three content
 					</Tabs.Tab>

--- a/src/components/Tabs/examples/7-navigation-tabs.jsx
+++ b/src/components/Tabs/examples/7-navigation-tabs.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Tabs } from '../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<Tabs isNavigation={true} isProgressive={true}>
+					<Tabs.Tab>
+						<Tabs.Title>One</Tabs.Title>
+						One content
+					</Tabs.Tab>
+
+					<Tabs.Tab>
+						<Tabs.Title>Two</Tabs.Title>
+						Two content
+					</Tabs.Tab>
+
+					<Tabs.Tab>
+						<Tabs.Title>Three</Tabs.Title>
+						Three content
+					</Tabs.Tab>
+
+				</Tabs>
+			</div>
+		);
+	},
+});

--- a/src/components/Tabs/examples/7-navigation-tabs.jsx
+++ b/src/components/Tabs/examples/7-navigation-tabs.jsx
@@ -6,7 +6,7 @@ export default createClass({
 	render() {
 		return (
 			<div>
-				<Tabs isNavigation={true} isProgressive={true}>
+				<Tabs isNavigation={true}>
 					<Tabs.Tab>
 						<Tabs.Title>One</Tabs.Title>
 						One content


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [/] Chrome
  - [/] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [/ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
