### PR TITLE
828: revert link styling for button and add new kind "invisible"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucid-ui",
-  "version": "2.21.1-0",
+  "version": "2.21.0",
   "description": "A UI component library from AppNexus.",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucid-ui",
-  "version": "2.21.0",
+  "version": "2.21.1-0",
   "description": "A UI component library from AppNexus.",
   "main": "dist/index.js",
   "repository": {

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -44,7 +44,15 @@ const Button = createClass({
 		/**
 		 * Style variations of the Button
 		 */
-		kind: oneOf(['primary', 'link', 'success', 'warning', 'danger', 'info']),
+		kind: oneOf([
+			'primary',
+			'link',
+			'success',
+			'warning',
+			'danger',
+			'info',
+			'invisible',
+		]),
 		/**
 		 * Size variations of the Button
 		 */
@@ -107,6 +115,7 @@ const Button = createClass({
 						'&-is-active': isActive,
 						'&-primary': kind === 'primary',
 						'&-link': kind === 'link',
+						'&-invisible': kind === 'invisible',
 						'&-success': kind === 'success',
 						'&-warning': kind === 'warning',
 						'&-danger': kind === 'danger',

--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -123,13 +123,14 @@
 		background: none;
 		color: @color-linkColor;
 
-		&:hover:not(.lucid-Button-is-disabled),
-		&:active:not(.lucid-Button-is-disabled),
-		&:focus:not(.lucid-Button-is-disabled) {
+		&:hover,
+		&:active,
+		&:focus {
 			.lucid-Icon { fill: @color-linkColorHover; }
 
-			background: @color-lightGray;
+			background: none;
 			color: @color-linkColorHover;
+			text-decoration: underline;
 			box-shadow: none;
 		}
 
@@ -149,7 +150,6 @@
 				line-height: 1.4em;
 			}
 		}
-
 	}
 
 	&&-link&-has-only-icon {

--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -159,6 +159,43 @@
 		}
 	}
 
+	&&-invisible {
+		.gradient-reset();
+		.make-is-disabled(lucid-Button);
+
+		border: none;
+		background: none;
+		color: @color-linkColor;
+
+		&:hover:not(.lucid-Button-is-disabled),
+		&:active:not(.lucid-Button-is-disabled),
+		&:focus:not(.lucid-Button-is-disabled) {
+			.lucid-Icon { fill: @color-linkColorHover; }
+
+			background: @color-lightGray;
+			color: @color-linkColorHover;
+			box-shadow: none;
+		}
+
+		&:active::before {
+			opacity: 0;
+		}
+
+		.lucid-Button-content {
+			line-height: 1em;
+		}
+
+		.lucid-Icon {
+			fill: @color-primary;
+			margin-right: 0.25em;
+
+			+ span {
+				line-height: 1.4em;
+			}
+		}
+
+	}
+
 	// Sizes
 	&&-short {
 		height: @Button-size-height-small;

--- a/src/components/Button/__snapshots__/Button.spec.jsx.snap
+++ b/src/components/Button/__snapshots__/Button.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 1`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -27,7 +27,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 2`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -48,7 +48,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 3`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -68,7 +68,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 4`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -103,7 +103,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 6`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -123,7 +123,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 7`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -144,7 +144,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 8`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -164,7 +164,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 9`] 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -199,7 +199,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 11`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -219,7 +219,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 12`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -240,7 +240,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 13`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -260,7 +260,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 14`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -295,7 +295,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 16`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -315,7 +315,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 17`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -336,7 +336,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 18`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -356,7 +356,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 19`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -391,7 +391,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 1`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -426,7 +426,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 3`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -461,7 +461,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 5`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -496,7 +496,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 7`]
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -531,7 +531,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 1`] =
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -566,7 +566,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 3`] =
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -601,7 +601,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 5`] =
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -636,7 +636,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 7`] =
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -671,7 +671,7 @@ exports[`Button [common] example testing should match snapshot(s) for invisible 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -691,7 +691,7 @@ exports[`Button [common] example testing should match snapshot(s) for invisible 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -711,7 +711,7 @@ exports[`Button [common] example testing should match snapshot(s) for invisible 
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -747,7 +747,7 @@ exports[`Button [common] example testing should match snapshot(s) for link 1`] =
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -767,7 +767,7 @@ exports[`Button [common] example testing should match snapshot(s) for link 2`] =
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -787,7 +787,7 @@ exports[`Button [common] example testing should match snapshot(s) for link 3`] =
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -823,7 +823,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 1`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -858,7 +858,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 3`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -893,7 +893,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 5`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -928,7 +928,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 7`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -963,7 +963,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 1`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -998,7 +998,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 3`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -1033,7 +1033,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 5`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -1068,7 +1068,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 7`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -1103,7 +1103,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 1`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -1138,7 +1138,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 3`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -1173,7 +1173,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 5`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"
@@ -1208,7 +1208,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 7`
   onClick={[Function]}
   style={
     Object {
-      "marginRight": "5px",
+      "marginRight": "5",
     }
   }
   type="button"

--- a/src/components/Button/__snapshots__/Button.spec.jsx.snap
+++ b/src/components/Button/__snapshots__/Button.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 1`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -27,7 +27,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 2`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -48,7 +48,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 3`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -68,7 +68,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 4`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -103,7 +103,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 6`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -123,7 +123,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 7`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -144,7 +144,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 8`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -164,7 +164,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 9`] 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -199,7 +199,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 11`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -219,7 +219,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 12`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -240,7 +240,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 13`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -260,7 +260,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 14`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -295,7 +295,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 16`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -315,7 +315,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 17`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -336,7 +336,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 18`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -356,7 +356,7 @@ exports[`Button [common] example testing should match snapshot(s) for basic 19`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -391,7 +391,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 1`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -426,7 +426,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 3`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -461,7 +461,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 5`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -496,7 +496,7 @@ exports[`Button [common] example testing should match snapshot(s) for danger 7`]
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -531,7 +531,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 1`] =
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -566,7 +566,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 3`] =
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -601,7 +601,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 5`] =
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -636,7 +636,7 @@ exports[`Button [common] example testing should match snapshot(s) for info 7`] =
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -671,7 +671,7 @@ exports[`Button [common] example testing should match snapshot(s) for invisible 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -691,7 +691,7 @@ exports[`Button [common] example testing should match snapshot(s) for invisible 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -711,7 +711,7 @@ exports[`Button [common] example testing should match snapshot(s) for invisible 
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -747,7 +747,7 @@ exports[`Button [common] example testing should match snapshot(s) for link 1`] =
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -767,7 +767,7 @@ exports[`Button [common] example testing should match snapshot(s) for link 2`] =
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -787,7 +787,7 @@ exports[`Button [common] example testing should match snapshot(s) for link 3`] =
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -823,7 +823,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 1`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -858,7 +858,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 3`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -893,7 +893,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 5`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -928,7 +928,7 @@ exports[`Button [common] example testing should match snapshot(s) for primary 7`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -963,7 +963,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 1`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -998,7 +998,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 3`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -1033,7 +1033,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 5`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -1068,7 +1068,7 @@ exports[`Button [common] example testing should match snapshot(s) for success 7`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -1103,7 +1103,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 1`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -1138,7 +1138,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 3`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -1173,7 +1173,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 5`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"
@@ -1208,7 +1208,7 @@ exports[`Button [common] example testing should match snapshot(s) for warning 7`
   onClick={[Function]}
   style={
     Object {
-      "margin-right": "5px",
+      "marginRight": "5px",
     }
   }
   type="button"

--- a/src/components/Button/__snapshots__/Button.spec.jsx.snap
+++ b/src/components/Button/__snapshots__/Button.spec.jsx.snap
@@ -664,6 +664,82 @@ exports[`Button [common] example testing should match snapshot(s) for info 8`] =
 </button>
 `;
 
+exports[`Button [common] example testing should match snapshot(s) for invisible 1`] = `
+<button
+  className="lucid-Button lucid-Button-invisible"
+  disabled={false}
+  onClick={[Function]}
+  style={
+    Object {
+      "margin-right": "5px",
+    }
+  }
+  type="button"
+>
+  <span
+    className="lucid-Button-content"
+  >
+    Invisible
+  </span>
+</button>
+`;
+
+exports[`Button [common] example testing should match snapshot(s) for invisible 2`] = `
+<button
+  className="lucid-Button lucid-Button-is-disabled lucid-Button-invisible"
+  disabled={true}
+  onClick={[Function]}
+  style={
+    Object {
+      "margin-right": "5px",
+    }
+  }
+  type="button"
+>
+  <span
+    className="lucid-Button-content"
+  >
+    Invisible disabled
+  </span>
+</button>
+`;
+
+exports[`Button [common] example testing should match snapshot(s) for invisible 3`] = `
+<button
+  className="lucid-Button lucid-Button-invisible"
+  disabled={false}
+  onClick={[Function]}
+  style={
+    Object {
+      "margin-right": "5px",
+    }
+  }
+  type="button"
+>
+  <span
+    className="lucid-Button-content"
+  >
+    <PlusIcon />
+    Invisible
+  </span>
+</button>
+`;
+
+exports[`Button [common] example testing should match snapshot(s) for invisible 4`] = `
+<button
+  className="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon"
+  disabled={false}
+  onClick={[Function]}
+  type="button"
+>
+  <span
+    className="lucid-Button-content"
+  >
+    <PlusIcon />
+  </span>
+</button>
+`;
+
 exports[`Button [common] example testing should match snapshot(s) for link 1`] = `
 <button
   className="lucid-Button lucid-Button-link"

--- a/src/components/Button/examples/basic.jsx
+++ b/src/components/Button/examples/basic.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Button/examples/basic.jsx
+++ b/src/components/Button/examples/basic.jsx
@@ -4,7 +4,7 @@ import { Button, CheckIcon } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/danger.jsx
+++ b/src/components/Button/examples/danger.jsx
@@ -4,7 +4,7 @@ import { Button } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/danger.jsx
+++ b/src/components/Button/examples/danger.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Button/examples/info.jsx
+++ b/src/components/Button/examples/info.jsx
@@ -4,7 +4,7 @@ import { Button } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/info.jsx
+++ b/src/components/Button/examples/info.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Button/examples/invisible.jsx
+++ b/src/components/Button/examples/invisible.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Button/examples/invisible.jsx
+++ b/src/components/Button/examples/invisible.jsx
@@ -4,7 +4,7 @@ import { Button, PlusIcon } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/invisible.jsx
+++ b/src/components/Button/examples/invisible.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Button, PlusIcon } from '../../../index';
+
+const sectionStyle = {
+	display: 'flex',
+	'flex-direction': 'column',
+};
+
+const articleStyle = {
+	display: 'flex',
+	margin: '5px 0',
+};
+
+const buttonStyle = {
+	'margin-right': '5px',
+};
+
+export default createClass({
+	render() {
+		return (
+			<section style={sectionStyle}>
+				<article style={articleStyle}>
+					<Button style={buttonStyle} kind="invisible">Invisible</Button>
+					<Button style={buttonStyle} kind="invisible" isDisabled={true}>
+						Invisible disabled
+					</Button>
+					<Button style={buttonStyle} kind="invisible">
+						<PlusIcon />Invisible
+					</Button>
+					<Button kind="invisible" hasOnlyIcon><PlusIcon /></Button>
+				</article>
+			</section>
+		);
+	},
+});

--- a/src/components/Button/examples/link.jsx
+++ b/src/components/Button/examples/link.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Button/examples/link.jsx
+++ b/src/components/Button/examples/link.jsx
@@ -4,7 +4,7 @@ import { Button, PlusIcon } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/primary.jsx
+++ b/src/components/Button/examples/primary.jsx
@@ -4,7 +4,7 @@ import { Button } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/primary.jsx
+++ b/src/components/Button/examples/primary.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Button/examples/success.jsx
+++ b/src/components/Button/examples/success.jsx
@@ -4,7 +4,7 @@ import { Button } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/success.jsx
+++ b/src/components/Button/examples/success.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Button/examples/warning.jsx
+++ b/src/components/Button/examples/warning.jsx
@@ -4,7 +4,7 @@ import { Button } from '../../../index';
 
 const sectionStyle = {
 	display: 'flex',
-	'flex-direction': 'column',
+	flexDirection: 'column',
 };
 
 const articleStyle = {
@@ -13,7 +13,7 @@ const articleStyle = {
 };
 
 const buttonStyle = {
-	'margin-right': '5px',
+	marginRight: '5px',
 };
 
 export default createClass({

--- a/src/components/Button/examples/warning.jsx
+++ b/src/components/Button/examples/warning.jsx
@@ -9,11 +9,11 @@ const sectionStyle = {
 
 const articleStyle = {
 	display: 'flex',
-	margin: '5px 0',
+	margin: '5 0',
 };
 
 const buttonStyle = {
-	marginRight: '5px',
+	marginRight: '5',
 };
 
 export default createClass({

--- a/src/components/Dialog/__snapshots__/Dialog.spec.jsx.snap
+++ b/src/components/Dialog/__snapshots__/Dialog.spec.jsx.snap
@@ -57,8 +57,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 1.small 1`
           hasOnlyIcon={false}
           isActive={false}
           isDisabled={false}
-          kind="link"
+          kind="invisible"
           onClick={[Function]}
+          style={
+            Object {
+              "marginRight": "9px",
+            }
+          }
           type="button"
         >
           Cancel
@@ -82,8 +87,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 1.small 1`
         hasOnlyIcon={false}
         isActive={false}
         isDisabled={false}
-        kind="link"
+        kind="invisible"
         onClick={[Function]}
+        style={
+          Object {
+            "marginRight": "9px",
+          }
+        }
         type="button"
       >
         Cancel
@@ -280,8 +290,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 2.medium 1
           hasOnlyIcon={false}
           isActive={false}
           isDisabled={false}
-          kind="link"
+          kind="invisible"
           onClick={[Function]}
+          style={
+            Object {
+              "marginRight": "9px",
+            }
+          }
           type="button"
         >
           Cancel
@@ -305,8 +320,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 2.medium 1
         hasOnlyIcon={false}
         isActive={false}
         isDisabled={false}
-        kind="link"
+        kind="invisible"
         onClick={[Function]}
+        style={
+          Object {
+            "marginRight": "9px",
+          }
+        }
         type="button"
       >
         Cancel
@@ -510,8 +530,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 3.large-wi
           hasOnlyIcon={false}
           isActive={false}
           isDisabled={false}
-          kind="link"
+          kind="invisible"
           onClick={[Function]}
+          style={
+            Object {
+              "marginRight": "9px",
+            }
+          }
           type="button"
         >
           Cancel
@@ -535,8 +560,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 3.large-wi
         hasOnlyIcon={false}
         isActive={false}
         isDisabled={false}
-        kind="link"
+        kind="invisible"
         onClick={[Function]}
+        style={
+          Object {
+            "marginRight": "9px",
+          }
+        }
         type="button"
       >
         Cancel
@@ -581,8 +611,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 4.no-modal
           hasOnlyIcon={false}
           isActive={false}
           isDisabled={false}
-          kind="link"
+          kind="invisible"
           onClick={[Function]}
+          style={
+            Object {
+              "marginRight": "9px",
+            }
+          }
           type="button"
         >
           Cancel
@@ -606,8 +641,13 @@ exports[`Dialog [common] example testing should match snapshot(s) for 4.no-modal
         hasOnlyIcon={false}
         isActive={false}
         isDisabled={false}
-        kind="link"
+        kind="invisible"
         onClick={[Function]}
+        style={
+          Object {
+            "marginRight": "9px",
+          }
+        }
         type="button"
       >
         Cancel

--- a/src/components/Dialog/examples/1.small.jsx
+++ b/src/components/Dialog/examples/1.small.jsx
@@ -24,9 +24,9 @@ export default createClass({
 				<Dialog isShown={this.state.isShown} Header="Header" size="small">
 					<div key={'info'}>
 						For better UX, we recommend NOT handling onEscape and
-						onBackgroundClick when isModal is true. The term "modal" implies that
-						the user needs to interact with one of the buttons in the footer to
-						exit the dialog.
+						onBackgroundClick when isModal is true. The term "modal" implies
+						that the user needs to interact with one of the buttons in the
+						footer to exit the dialog.
 					</div>
 					{_.times(10).map(i => {
 						return <div key={i}>Body</div>;
@@ -35,7 +35,7 @@ export default createClass({
 						<Button
 							kind="invisible"
 							onClick={_.partial(this.handleShow, false)}
-							style={{ marginRight: '5px' }}
+							style={{ marginRight: '9px' }}
 						>
 							Cancel
 						</Button>

--- a/src/components/Dialog/examples/1.small.jsx
+++ b/src/components/Dialog/examples/1.small.jsx
@@ -32,7 +32,11 @@ export default createClass({
 						return <div key={i}>Body</div>;
 					})}
 					<Dialog.Footer>
-						<Button kind="link" onClick={_.partial(this.handleShow, false)}>
+						<Button
+							kind="invisible"
+							onClick={_.partial(this.handleShow, false)}
+							style={{ marginRight: '5px' }}
+						>
 							Cancel
 						</Button>
 						<Button kind="primary">Save</Button>

--- a/src/components/Dialog/examples/2.medium.jsx
+++ b/src/components/Dialog/examples/2.medium.jsx
@@ -24,9 +24,9 @@ export default createClass({
 				<Dialog isShown={this.state.isShown} Header="Header" size="medium">
 					<div key={'info'}>
 						For better UX, we recommend NOT handling onEscape and
-						onBackgroundClick when isModal is true. The term "modal" implies that
-						the user needs to interact with one of the buttons in the footer to
-						exit the dialog.
+						onBackgroundClick when isModal is true. The term "modal" implies
+						that the user needs to interact with one of the buttons in the
+						footer to exit the dialog.
 					</div>
 					{_.times(50).map(i => {
 						return <div key={i}>Body</div>;
@@ -35,7 +35,7 @@ export default createClass({
 						<Button
 							kind="invisible"
 							onClick={_.partial(this.handleShow, false)}
-							style={{ marginRight: '5px' }}
+							style={{ marginRight: '9px' }}
 						>
 							Cancel
 						</Button>

--- a/src/components/Dialog/examples/2.medium.jsx
+++ b/src/components/Dialog/examples/2.medium.jsx
@@ -32,7 +32,11 @@ export default createClass({
 						return <div key={i}>Body</div>;
 					})}
 					<Dialog.Footer>
-						<Button kind="link" onClick={_.partial(this.handleShow, false)}>
+						<Button
+							kind="invisible"
+							onClick={_.partial(this.handleShow, false)}
+							style={{ marginRight: '5px' }}
+						>
 							Cancel
 						</Button>
 						<Button kind="primary">Save</Button>

--- a/src/components/Dialog/examples/3.large-with-rich-header.jsx
+++ b/src/components/Dialog/examples/3.large-with-rich-header.jsx
@@ -28,9 +28,9 @@ export default createClass({
 					</Dialog.Header>
 					<div key={'info'}>
 						For better UX, we recommend NOT handling onEscape and
-						onBackgroundClick when isModal is true. The term "modal" implies that
-						the user needs to interact with one of the buttons in the footer to
-						exit the dialog.
+						onBackgroundClick when isModal is true. The term "modal" implies
+						that the user needs to interact with one of the buttons in the
+						footer to exit the dialog.
 					</div>
 					{_.times(50).map(i => {
 						return <div key={i}>Body</div>;
@@ -39,7 +39,7 @@ export default createClass({
 						<Button
 							kind="invisible"
 							onClick={_.partial(this.handleShow, false)}
-							style={{ marginRight: '5px' }}
+							style={{ marginRight: '9px' }}
 						>
 							Cancel
 						</Button>

--- a/src/components/Dialog/examples/3.large-with-rich-header.jsx
+++ b/src/components/Dialog/examples/3.large-with-rich-header.jsx
@@ -36,7 +36,11 @@ export default createClass({
 						return <div key={i}>Body</div>;
 					})}
 					<Dialog.Footer>
-						<Button kind="link" onClick={_.partial(this.handleShow, false)}>
+						<Button
+							kind="invisible"
+							onClick={_.partial(this.handleShow, false)}
+							style={{ marginRight: '5px' }}
+						>
 							Cancel
 						</Button>
 						<Button kind="primary">Save</Button>

--- a/src/components/Dialog/examples/4.no-modal.jsx
+++ b/src/components/Dialog/examples/4.no-modal.jsx
@@ -35,7 +35,11 @@ export default createClass({
 					pressing "escape" to close this Dialog.
 
 					<Dialog.Footer>
-						<Button kind="link" onClick={_.partial(this.handleShow, false)}>
+						<Button
+							kind="invisible"
+							onClick={_.partial(this.handleShow, false)}
+							style={{ marginRight: '5px' }}
+						>
 							Cancel
 						</Button>
 						<Button kind="primary">Save</Button>

--- a/src/components/Dialog/examples/4.no-modal.jsx
+++ b/src/components/Dialog/examples/4.no-modal.jsx
@@ -29,22 +29,19 @@ export default createClass({
 					Header="Header"
 					size="small"
 				>
-
 					In most cases, you'll probably just use an isModal Dialog, but this
-					example shows that the Dialog doesn't have to be a modal. Try
-					pressing "escape" to close this Dialog.
-
+					example shows that the Dialog doesn't have to be a modal. Try pressing
+					"escape" to close this Dialog.
 					<Dialog.Footer>
 						<Button
 							kind="invisible"
 							onClick={_.partial(this.handleShow, false)}
-							style={{ marginRight: '5px' }}
+							style={{ marginRight: '9px' }}
 						>
 							Cancel
 						</Button>
 						<Button kind="primary">Save</Button>
 					</Dialog.Footer>
-
 				</Dialog>
 			</div>
 		);


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [X] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
