### PR TITLE
Perf improvements for DateSelect and ConextMenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucid-ui",
-  "version": "2.23.0",
+  "version": "2.24.0-beta.0",
   "description": "A UI component library from AppNexus.",
   "main": "dist/index.js",
   "repository": {

--- a/src/components/Autocomplete/Autocomplete.spec.jsx
+++ b/src/components/Autocomplete/Autocomplete.spec.jsx
@@ -10,6 +10,17 @@ import { DropMenuDumb as DropMenu } from '../DropMenu/DropMenu';
 import * as KEYCODE from '../../constants/key-code';
 
 describe('Autocomplete', () => {
+	let requestAnimationFramePreviewValue;
+
+	beforeAll(() => {
+		requestAnimationFramePreviewValue = window.requestAnimationFrame;
+		window.requestAnimationFrame = callback => setTimeout(callback, 32);
+	});
+
+	afterAll(() => {
+		window.requestAnimationFrame = requestAnimationFramePreviewValue;
+	});
+
 	common(Autocomplete);
 
 	describe('render', () => {

--- a/src/components/BarChart/BarChart.spec.jsx
+++ b/src/components/BarChart/BarChart.spec.jsx
@@ -16,6 +16,17 @@ import EmptyStateWrapper from '../EmptyStateWrapper/EmptyStateWrapper';
 const { EmptyStateWrapper: { Title, Body } } = BarChart;
 
 describe('BarChart', () => {
+	let requestAnimationFramePreviewValue;
+
+	beforeAll(() => {
+		requestAnimationFramePreviewValue = window.requestAnimationFrame;
+		window.requestAnimationFrame = callback => setTimeout(callback, 32);
+	});
+
+	afterAll(() => {
+		window.requestAnimationFrame = requestAnimationFramePreviewValue;
+	});
+
 	let wrapper;
 
 	afterEach(() => {

--- a/src/components/ContextMenu/ContextMenu.spec.jsx
+++ b/src/components/ContextMenu/ContextMenu.spec.jsx
@@ -8,6 +8,17 @@ import { mount } from 'enzyme';
 import ContextMenu from './ContextMenu';
 
 describe('ContextMenu', () => {
+	let requestAnimationFramePreviewValue;
+
+	beforeAll(() => {
+		requestAnimationFramePreviewValue = window.requestAnimationFrame;
+		window.requestAnimationFrame = callback => setTimeout(callback, 32);
+	});
+
+	afterAll(() => {
+		window.requestAnimationFrame = requestAnimationFramePreviewValue;
+	});
+
 	common(ContextMenu, {
 		exemptFunctionProps: ['getAlignmentOffset'],
 		getDefaultProps: () => ({

--- a/src/components/DateSelect/DateSelect.less
+++ b/src/components/DateSelect/DateSelect.less
@@ -6,7 +6,7 @@
 	align-items: center;
 	font-size: @size-font;
 
-	&-InfiniteSlidePanel {
+	&-slidePanel {
 		flex: 1;
 		height: 100%;
 	}

--- a/src/components/DateSelect/__snapshots__/DateSelect.spec.jsx.snap
+++ b/src/components/DateSelect/__snapshots__/DateSelect.spec.jsx.snap
@@ -19,7 +19,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <InfiniteSlidePanel
-    className="lucid-DateSelect-InfiniteSlidePanel"
+    className="lucid-DateSelect-InfiniteSlidePanel lucid-DateSelect-slidePanel"
     offset={0}
     onSwipe={[Function]}
     slidesToShow={1}
@@ -60,7 +60,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <InfiniteSlidePanel
-    className="lucid-DateSelect-InfiniteSlidePanel"
+    className="lucid-DateSelect-InfiniteSlidePanel lucid-DateSelect-slidePanel"
     offset={0}
     onSwipe={[Function]}
     slidesToShow={1}
@@ -101,7 +101,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <InfiniteSlidePanel
-    className="lucid-DateSelect-InfiniteSlidePanel"
+    className="lucid-DateSelect-InfiniteSlidePanel lucid-DateSelect-slidePanel"
     offset={0}
     onSwipe={[Function]}
     slidesToShow={1}
@@ -142,7 +142,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <InfiniteSlidePanel
-    className="lucid-DateSelect-InfiniteSlidePanel"
+    className="lucid-DateSelect-InfiniteSlidePanel lucid-DateSelect-slidePanel"
     offset={0}
     onSwipe={[Function]}
     slidesToShow={1}
@@ -183,7 +183,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <InfiniteSlidePanel
-    className="lucid-DateSelect-InfiniteSlidePanel"
+    className="lucid-DateSelect-InfiniteSlidePanel lucid-DateSelect-slidePanel"
     offset={0}
     onSwipe={[Function]}
     slidesToShow={3}
@@ -224,7 +224,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <InfiniteSlidePanel
-    className="lucid-DateSelect-InfiniteSlidePanel"
+    className="lucid-DateSelect-InfiniteSlidePanel lucid-DateSelect-slidePanel"
     offset={0}
     onSwipe={[Function]}
     slidesToShow={1}
@@ -266,7 +266,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <InfiniteSlidePanel
-    className="lucid-DateSelect-InfiniteSlidePanel"
+    className="lucid-DateSelect-InfiniteSlidePanel lucid-DateSelect-slidePanel"
     offset={0}
     onSwipe={[Function]}
     slidesToShow={1}
@@ -276,6 +276,63 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
       className="lucid-DateSelect-slide"
     />
   </InfiniteSlidePanel>
+  <div>
+    <ChevronThinIcon
+      className="lucid-DateSelect-chevron"
+      direction="right"
+      isClickable={true}
+      onClick={[Function]}
+      size={32}
+    />
+  </div>
+</section>
+`;
+
+exports[`DateSelect common tests [common] example testing should match snapshot(s) for 8.disable-slide-panel 1`] = `
+<section
+  className="lucid-DateSelect"
+  style={
+    Object {
+      "minWidth": 249,
+    }
+  }
+>
+  <div>
+    <ChevronThinIcon
+      className="lucid-DateSelect-chevron"
+      direction="left"
+      isClickable={true}
+      onClick={[Function]}
+      size={32}
+    />
+  </div>
+  <div
+    className="lucid-DateSelect-slidePanel"
+  >
+    <div
+      className="lucid-DateSelect-slide"
+    >
+      <div
+        className="lucid-DateSelect-slide-content"
+      >
+        <CalendarMonth
+          className="lucid-DateSelect-CalendarMonth"
+          cursor={null}
+          disabledDays={null}
+          from={null}
+          initialMonth={2016-02-17T22:25:23.000Z}
+          monthOffset={0}
+          onDayClick={[Function]}
+          onDayMouseEnter={[Function]}
+          onDayMouseLeave={[Function]}
+          selectMode="day"
+          selectedDays={null}
+          shouldComponentUpdate={true}
+          to={null}
+        />
+      </div>
+    </div>
+  </div>
   <div>
     <ChevronThinIcon
       className="lucid-DateSelect-chevron"

--- a/src/components/DateSelect/examples/8.disable-slide-panel.jsx
+++ b/src/components/DateSelect/examples/8.disable-slide-panel.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { DateSelect } from '../../../index';
+
+export default createClass({
+	getInitialState() {
+		return {
+			selectedDate: null,
+		};
+	},
+
+	handleSelectDate(date) {
+		this.setState({
+			selectedDate: date,
+		});
+	},
+
+	render() {
+		const { selectedDate } = this.state;
+
+		return (
+			<section style={{ maxWidth: 400 }}>
+
+				<DateSelect
+					selectedDays={selectedDate}
+					onSelectDate={this.handleSelectDate}
+					monthsShown={1}
+					useSlidePanel={false}
+				/>
+
+				selected date:
+				{' '}
+				{selectedDate && selectedDate.toLocaleDateString('en-US')}
+
+			</section>
+		);
+	},
+});

--- a/src/components/DropMenu/DropMenu.spec.jsx
+++ b/src/components/DropMenu/DropMenu.spec.jsx
@@ -12,6 +12,17 @@ import * as KEYCODE from '../../constants/key-code';
 const { Control, Header, Option, OptionGroup, NullOption } = DropMenu;
 
 describe('DropMenu', () => {
+	let requestAnimationFramePreviewValue;
+
+	beforeAll(() => {
+		requestAnimationFramePreviewValue = window.requestAnimationFrame;
+		window.requestAnimationFrame = callback => setTimeout(callback, 32);
+	});
+
+	afterAll(() => {
+		window.requestAnimationFrame = requestAnimationFramePreviewValue;
+	});
+
 	common(DropMenu);
 
 	describe('render', () => {

--- a/src/components/SearchableSelect/SearchableSelect.spec.jsx
+++ b/src/components/SearchableSelect/SearchableSelect.spec.jsx
@@ -11,6 +11,17 @@ import { DropMenuDumb as DropMenu } from '../DropMenu/DropMenu';
 const { Placeholder, Option, OptionGroup, SearchField } = SearchableSelect;
 
 describe('SearchableSelect', () => {
+	let requestAnimationFramePreviewValue;
+
+	beforeAll(() => {
+		requestAnimationFramePreviewValue = window.requestAnimationFrame;
+		window.requestAnimationFrame = callback => setTimeout(callback, 32);
+	});
+
+	afterAll(() => {
+		window.requestAnimationFrame = requestAnimationFramePreviewValue;
+	});
+
 	common(SearchableSelect, {
 		exemptFunctionProps: ['optionFilter', 'richChildRenderer'],
 	});

--- a/src/components/SingleSelect/SingleSelect.spec.jsx
+++ b/src/components/SingleSelect/SingleSelect.spec.jsx
@@ -10,6 +10,17 @@ import { DropMenuDumb as DropMenu } from '../DropMenu/DropMenu';
 const { Placeholder, Option, OptionGroup } = SingleSelect;
 
 describe('SingleSelect', () => {
+	let requestAnimationFramePreviewValue;
+
+	beforeAll(() => {
+		requestAnimationFramePreviewValue = window.requestAnimationFrame;
+		window.requestAnimationFrame = callback => setTimeout(callback, 32);
+	});
+
+	afterAll(() => {
+		window.requestAnimationFrame = requestAnimationFramePreviewValue;
+	});
+
 	common(SingleSelect);
 
 	describe('render', () => {

--- a/src/components/ToolTip/ToolTip.spec.jsx
+++ b/src/components/ToolTip/ToolTip.spec.jsx
@@ -12,6 +12,17 @@ import { MOSTLY_STABLE_DELAY } from '../../../tests/constants';
 const { Target, Title, Body } = ToolTip;
 
 describe('ToolTip', () => {
+	let requestAnimationFramePreviewValue;
+
+	beforeAll(() => {
+		requestAnimationFramePreviewValue = window.requestAnimationFrame;
+		window.requestAnimationFrame = callback => setTimeout(callback, 32);
+	});
+
+	afterAll(() => {
+		window.requestAnimationFrame = requestAnimationFramePreviewValue;
+	});
+
 	common(ToolTip);
 
 	describe('render', () => {


### PR DESCRIPTION
 - Adds new prop `useSlidePanel` to DateSelect for finer control of performance
 - reduces number of re-renders and state changes in ContextMenu
 - ContextMenu FlyOut now uses requestAnimationFrame to synchronize alignments

## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
