### PR TITLE
Fix bugs in DateSelect

### DIFF
--- a/src/components/DateSelect/DateSelect.jsx
+++ b/src/components/DateSelect/DateSelect.jsx
@@ -250,7 +250,7 @@ const DateSelect = createClass({
 	renderCalendarMonth({
 		key,
 		offset,
-		slideOffset,
+		calendarPosition,
 		initialMonth,
 		cursor,
 		isRangeSameDay,
@@ -269,7 +269,7 @@ const DateSelect = createClass({
 			<CalendarMonth
 				key={key}
 				className={cx('&-CalendarMonth')}
-				monthOffset={offset + slideOffset}
+				monthOffset={offset + calendarPosition}
 				initialMonth={initialMonth}
 				cursor={cursor}
 				from={isRangeSameDay ? null : from}
@@ -351,7 +351,7 @@ const DateSelect = createClass({
 										{this.renderCalendarMonth({
 											key: slideOffset,
 											offset,
-											slideOffset,
+											calendarPosition: slideOffset - offset,
 											initialMonth: this.initialMonth,
 											cursor,
 											isRangeSameDay,
@@ -370,14 +370,16 @@ const DateSelect = createClass({
 								)}
 							</InfiniteSlidePanel.Slide>
 						</InfiniteSlidePanel>
-					: <div className={cx('&-slidePanel')}>
-							<div className={cx('&-slide')}>
-								<div className={cx('&-slide-content')}>
-									{_.times(monthsShown, slideOffset =>
-										this.renderCalendarMonth({
-											key: slideOffset,
+					: <div className={cx('&-slidePanel', '&-slidePanel-simple')}>
+							{_.times(monthsShown, calendarIndex => (
+								<div
+									className={cx('&-slide', '&-slide-simple')}
+									key={calendarIndex}
+								>
+									<div className={cx('&-slide-content')}>
+										{this.renderCalendarMonth({
 											offset,
-											slideOffset,
+											calendarPosition: calendarIndex,
 											initialMonth: this.initialMonth,
 											cursor,
 											isRangeSameDay,
@@ -391,10 +393,10 @@ const DateSelect = createClass({
 											onDayMouseEnter: this.handleDayMouseEnter,
 											onDayMouseLeave: this.handleDayMouseLeave,
 											calendarMonthProps: calendarMonth.props,
-										})
-									)}
+										})}
+									</div>
 								</div>
-							</div>
+							))}
 						</div>}
 				<div>
 					<ChevronThinIcon

--- a/src/components/DateSelect/DateSelect.less
+++ b/src/components/DateSelect/DateSelect.less
@@ -6,19 +6,28 @@
 	align-items: center;
 	font-size: @size-font;
 
-	&-slidePanel {
-		flex: 1;
-		height: 100%;
-	}
-
 	.lucid-DateSelect-chevron {
 		user-select: none;
 	}
 
-	.lucid-DateSelect-slide {
+	&-slidePanel {
+		flex: 1;
+		height: 100%;
+
+		&-simple {
+			overflow: hidden;
+			display: flex;
+		}
+	}
+
+	& &-slide {
 		position: relative;
 		display: flex;
 		align-items: stretch;
+
+		&-simple {
+			flex: 1;
+		}
 
 		.lucid-DateSelect-show-divider& {
 			&::after {
@@ -31,7 +40,8 @@
 				background-color: @color-gray-10;
 			}
 
-			&.lucid-InfiniteSlidePanel-Slide-in-frame {
+			&.lucid-InfiniteSlidePanel-Slide-in-frame,
+			&.lucid-DateSelect-slide-simple {
 				&::after {
 					right: -1px;
 				}

--- a/src/components/DateSelect/__snapshots__/DateSelect.spec.jsx.snap
+++ b/src/components/DateSelect/__snapshots__/DateSelect.spec.jsx.snap
@@ -290,10 +290,10 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
 
 exports[`DateSelect common tests [common] example testing should match snapshot(s) for 8.disable-slide-panel 1`] = `
 <section
-  className="lucid-DateSelect"
+  className="lucid-DateSelect lucid-DateSelect-show-divider"
   style={
     Object {
-      "minWidth": 249,
+      "minWidth": 434,
     }
   }
 >
@@ -307,10 +307,10 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     />
   </div>
   <div
-    className="lucid-DateSelect-slidePanel"
+    className="lucid-DateSelect-slidePanel lucid-DateSelect-slidePanel-simple"
   >
     <div
-      className="lucid-DateSelect-slide"
+      className="lucid-DateSelect-slide lucid-DateSelect-slide-simple"
     >
       <div
         className="lucid-DateSelect-slide-content"
@@ -322,6 +322,29 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
           from={null}
           initialMonth={2016-02-17T22:25:23.000Z}
           monthOffset={0}
+          onDayClick={[Function]}
+          onDayMouseEnter={[Function]}
+          onDayMouseLeave={[Function]}
+          selectMode="day"
+          selectedDays={null}
+          shouldComponentUpdate={true}
+          to={null}
+        />
+      </div>
+    </div>
+    <div
+      className="lucid-DateSelect-slide lucid-DateSelect-slide-simple"
+    >
+      <div
+        className="lucid-DateSelect-slide-content"
+      >
+        <CalendarMonth
+          className="lucid-DateSelect-CalendarMonth"
+          cursor={null}
+          disabledDays={null}
+          from={null}
+          initialMonth={2016-02-17T22:25:23.000Z}
+          monthOffset={1}
           onDayClick={[Function]}
           onDayMouseEnter={[Function]}
           onDayMouseLeave={[Function]}

--- a/src/components/DateSelect/examples/8.disable-slide-panel.jsx
+++ b/src/components/DateSelect/examples/8.disable-slide-panel.jsx
@@ -19,13 +19,14 @@ export default createClass({
 		const { selectedDate } = this.state;
 
 		return (
-			<section style={{ maxWidth: 400 }}>
+			<section style={{ maxWidth: 800 }}>
 
 				<DateSelect
+					useSlidePanel={false}
 					selectedDays={selectedDate}
 					onSelectDate={this.handleSelectDate}
-					monthsShown={1}
-					useSlidePanel={false}
+					monthsShown={2}
+					showDivider
 				/>
 
 				selected date:


### PR DESCRIPTION
 - fixed bug in month offset logic that caused it to skip months
 - fixed style bugs when rendering dividers `useSlidePanel` set to `false`

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
