### PR TITLE
update CheckboxLabeled, RadioGroup example styling

### DIFF
--- a/src/components/CheckboxLabeled/examples/label-as-child.jsx
+++ b/src/components/CheckboxLabeled/examples/label-as-child.jsx
@@ -9,17 +9,15 @@ const style = {
 export default createClass({
 	render() {
 		return (
-			<section>
-				<section>
-					<CheckboxLabeled style={style}>
-						<CheckboxLabeled.Label>Just text</CheckboxLabeled.Label>
-					</CheckboxLabeled>
-					<CheckboxLabeled style={style}>
-						<CheckboxLabeled.Label>
-							<span>HTML element</span>
-						</CheckboxLabeled.Label>
-					</CheckboxLabeled>
-				</section>
+			<section style={{ display: 'inline-flex', flexDirection: 'column' }}>
+				<CheckboxLabeled style={style}>
+					<CheckboxLabeled.Label>Just text</CheckboxLabeled.Label>
+				</CheckboxLabeled>
+				<CheckboxLabeled style={style}>
+					<CheckboxLabeled.Label>
+						<span>HTML element</span>
+					</CheckboxLabeled.Label>
+				</CheckboxLabeled>
 			</section>
 		);
 	},

--- a/src/components/CheckboxLabeled/examples/label-as-prop.jsx
+++ b/src/components/CheckboxLabeled/examples/label-as-prop.jsx
@@ -9,27 +9,25 @@ const style = {
 export default createClass({
 	render() {
 		return (
-			<section>
-				<section>
-					<CheckboxLabeled Label="Just text" style={style} />
-					<CheckboxLabeled Label={<span>HTML element</span>} style={style} />
-					<CheckboxLabeled
-						Label={[
-							'Text in an array',
-							'Only the first value in the array is used',
-							'The rest of these should be ignored',
-						]}
-						style={style}
-					/>
-					<CheckboxLabeled
-						Label={[
-							<span>HTML element in an array</span>,
-							<span>Again only the first value in the array is used</span>,
-							<span>The rest should not be rendered</span>,
-						]}
-						style={style}
-					/>
-				</section>
+			<section style={{ display: 'inline-flex', flexDirection: 'column' }}>
+				<CheckboxLabeled Label="Just text" style={style} />
+				<CheckboxLabeled Label={<span>HTML element</span>} style={style} />
+				<CheckboxLabeled
+					Label={[
+						'Text in an array',
+						'Only the first value in the array is used',
+						'The rest of these should be ignored',
+					]}
+					style={style}
+				/>
+				<CheckboxLabeled
+					Label={[
+						<span>HTML element in an array</span>,
+						<span>Again only the first value in the array is used</span>,
+						<span>The rest should not be rendered</span>,
+					]}
+					style={style}
+				/>
 			</section>
 		);
 	},

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
@@ -368,7 +368,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for select
   className="lucid-RadioGroup"
   style={
     Object {
-      "display": "flex",
+      "display": "inline-flex",
       "flexDirection": "column",
     }
   }
@@ -513,7 +513,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for select
   className="lucid-RadioGroup"
   style={
     Object {
-      "display": "flex",
+      "display": "inline-flex",
       "flexDirection": "column",
     }
   }

--- a/src/components/RadioGroup/examples/selected-index-as-prop.jsx
+++ b/src/components/RadioGroup/examples/selected-index-as-prop.jsx
@@ -13,7 +13,7 @@ export default createClass({
 				name="name"
 				selectedIndex={3}
 				style={{
-					display: 'flex',
+					display: 'inline-flex',
 					flexDirection: 'column',
 				}}
 			>

--- a/src/components/RadioGroup/examples/selected-index-from-child.jsx
+++ b/src/components/RadioGroup/examples/selected-index-from-child.jsx
@@ -13,7 +13,7 @@ export default createClass({
 				name="name"
 				selectedIndex={3}
 				style={{
-					display: 'flex',
+					display: 'inline-flex',
 					flexDirection: 'column',
 				}}
 			>


### PR DESCRIPTION
fixes #797 

## PR Checklist

- Manually tested across supported browsers
  - ~~[ ] Chrome~~
  - ~~[ ] Firefox~~
  - ~~[ ] Safari~~
  - ~~[ ] Edge (Win 10)~~
- ~~[ ] Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~[ ] One core team UX approval~~
