### PR TITLE
RFC: #797 Reduce clickable area of CheckboxLabeled

### DIFF
--- a/src/components/CheckboxLabeled/CheckboxLabeled.jsx
+++ b/src/components/CheckboxLabeled/CheckboxLabeled.jsx
@@ -80,30 +80,33 @@ const CheckboxLabeled = createClass({
 		);
 
 		return (
-			<label
-				className={cx(
-					'&',
-					{
-						'&-is-disabled': isDisabled,
-						'&-is-selected': isIndeterminate || isSelected,
-					},
-					className
-				)}
-				style={style}
-			>
-				<Checkbox
-					className={cx('&-Checkbox', className)}
-					isDisabled={isDisabled}
-					isIndeterminate={isIndeterminate}
-					isSelected={isSelected}
-					onSelect={onSelect}
-					{...omitProps(passThroughs, CheckboxLabeled, [], false)}
-				/>
-				<div
-					{...labelChildProps}
-					className={cx('&-label', _.get(labelChildProps, 'className', null))}
-				/>
-			</label>
+			<div className={cx('&-wrapper')}>
+				<label
+					className={cx(
+						'&',
+						{
+							'&-is-disabled': isDisabled,
+							'&-is-selected': isIndeterminate || isSelected,
+						},
+						className
+					)}
+					style={style}
+				>
+					<Checkbox
+						className={cx('&-Checkbox', className)}
+						isDisabled={isDisabled}
+						isIndeterminate={isIndeterminate}
+						isSelected={isSelected}
+						onSelect={onSelect}
+						{...omitProps(passThroughs, CheckboxLabeled, [], false)}
+					/>
+					<div
+						{...labelChildProps}
+						className={cx('&-label', _.get(labelChildProps, 'className', null))}
+						onClick={_.noop}
+					/>
+				</label>
+			</div>
 		);
 	},
 });

--- a/src/components/CheckboxLabeled/CheckboxLabeled.less
+++ b/src/components/CheckboxLabeled/CheckboxLabeled.less
@@ -1,6 +1,10 @@
 @import (reference) '../../styles/variables.less';
 @import (reference) '../../styles/mixins.less';
 
+.lucid-CheckboxLabeled-wrapper {
+	display: flex;
+}
+
 .lucid-CheckboxLabeled {
 	align-items: flex-start;
 	color: @color-darkGray;


### PR DESCRIPTION
Don't merge, this PR is for just for feedback.

A simple solution is to wrap the existing <label> element so that the label doesn't get stretched to the width of the container. Thoughts?