### PR TITLE
Set `propName: 'Panel'` on the Panel component.

### DIFF
--- a/src/components/Panel/Panel.jsx
+++ b/src/components/Panel/Panel.jsx
@@ -16,6 +16,8 @@ const { bool, node, object, string } = PropTypes;
 const Panel = createClass({
 	displayName: 'Panel',
 
+	propName: 'Panel',
+
 	components: {
 		/**
 		 * Content displayed at the top of the panel.


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
