### PR TITLE
IconSelect: fix hover glow when selected

### DIFF
--- a/src/components/IconSelect/IconSelect.less
+++ b/src/components/IconSelect/IconSelect.less
@@ -22,7 +22,7 @@
 	box-sizing: border-box;
 	position: relative;
 	align-items: center;
-	padding: 12px 6px 11px 6px;
+	padding: 12px 6px 11px;
 	width: 120px;
 	overflow: hidden;
 
@@ -35,11 +35,10 @@
 		border: 1px solid @color-gray;
 		border-radius: 4px;
 		transition: all 0.1s linear;
-		margin-right: 18px;
 		width: 100%;
 		height: 100%;
 		box-sizing: border-box;
-		margin: 0;
+		margin: 0 18px 0 0;
 	}
 
 	// On Hover, Active, Indeterminate, or Selected
@@ -58,12 +57,16 @@
 			fill: @color-primary;
 		}
 
+		.lucid-Checkbox-visualization-container {
+			border-color: @color-primary;
+		}
+	}
+
+	// On Hover
+	&:not(.lucid-IconSelect-Item-is-disabled):hover {
 		.lucid-Checkbox-visualization-glow {
 			opacity: 0.3;
 			transform: scale(1.375);
-		}
-		.lucid-Checkbox-visualization-container {
-			border-color: @color-primary;
 		}
 	}
 
@@ -116,6 +119,7 @@
 .lucid-IconSelect-Item-multi {
 	height: 103px;
 }
+
 .lucid-IconSelect-Item-checkbox {
 	&.lucid-CheckboxLabeled {
 		display: flex;

--- a/src/components/IconSelect/IconSelect.spec.js
+++ b/src/components/IconSelect/IconSelect.spec.js
@@ -19,7 +19,9 @@ const items = [
 ];
 
 describe('IconSelect', () => {
-	common(IconSelect);
+	common(IconSelect, {
+		getDefaultProps: () => ({ items: [] }),
+	});
 
 	it('prop children', () => {
 		const wrapper = shallow(


### PR DESCRIPTION
fixes #881

http://docspot.devnxs.net/projects/lucid/881-icon-select-hover-glow/#/components/IconSelect

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval