### PR TITLE
Tabs: don't overwrite className of child Tab

### DIFF
--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -29,6 +29,11 @@ const Tab = createClass({
 
 	propTypes: {
 		/**
+		 * Class names that are appended to the defaults.
+		 */
+		className: string,
+
+		/**
 		 * The index of this `Tab` within the list of `Tabs`.
 		 */
 		index: number,
@@ -95,19 +100,24 @@ const Tab = createClass({
 			isSelected,
 			Title,
 			isNavigation,
+			className,
 			...passThroughs
 		} = this.props;
 
 		return (
 			<li
-				className={cx('&-Tab', {
-					'&-Tab-is-active': isSelected,
-					'&-Tab-is-disabled': isDisabled,
-					'&-Tab-is-active-and-open': isOpen && isSelected,
-					'&-Tab-is-progressive': isProgressive && !isLastTab,
-				})}
+				className={cx(
+					'&-Tab',
+					{
+						'&-Tab-is-active': isSelected,
+						'&-Tab-is-disabled': isDisabled,
+						'&-Tab-is-active-and-open': isOpen && isSelected,
+						'&-Tab-is-progressive': isProgressive && !isLastTab,
+					},
+					className
+				)}
 				onClick={this.handleClick}
-				{..._.omit(passThroughs, 'index')}
+				{...omitProps(passThroughs, Tab)}
 			>
 				<span className={cx('&-Tab-content')}>{Title}</span>
 				{isProgressive &&

--- a/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -9,6 +9,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 01-title-as-
   >
     <Tabs.Tab
       Title="One"
+      className="one"
       index={0}
       isLastTab={false}
       isNavigation={false}

--- a/src/components/Tabs/examples/01-title-as-prop.jsx
+++ b/src/components/Tabs/examples/01-title-as-prop.jsx
@@ -7,7 +7,7 @@ export default createClass({
 		return (
 			<div>
 				<Tabs>
-					<Tabs.Tab Title="One">One content</Tabs.Tab>
+					<Tabs.Tab Title="One" className="one">One content</Tabs.Tab>
 					<Tabs.Tab Title="Two" isDisabled={true}>Two content</Tabs.Tab>
 					<Tabs.Tab Title="Three">Three content</Tabs.Tab>
 					<Tabs.Tab Title="Five">Four content</Tabs.Tab>


### PR DESCRIPTION
fixes #887

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~[ ] One core team UX approval~~
