### PR TITLE
Revert exposing defaultProps in buildHybridComonent

### DIFF
--- a/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
@@ -265,12 +265,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
       Object {
         "children": Array [
           "Simon",
-          <RadioGroup
-            isDisabled={false}
-            name="lucid-RadioGroup-2"
-            onSelect={[Function]}
-            selectedIndex={0}
-          >
+          <RadioGroup>
             <RadioButton
               isDisabled={false}
               isSelected={false}
@@ -307,12 +302,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
   >
     <RadioGroup.Label>
       Simon
-      <RadioGroup
-        isDisabled={false}
-        name="lucid-RadioGroup-2"
-        onSelect={[Function]}
-        selectedIndex={0}
-      >
+      <RadioGroup>
         <RadioButton
           isDisabled={false}
           isSelected={false}
@@ -337,41 +327,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
   <RadioButtonLabeled
     Label={
       Object {
-        "children": <SingleSelect
-          DropMenu={
-            Object {
-              "ContextMenu": Object {
-                "alignment": "start",
-                "direction": "down",
-                "directonOffset": 0,
-                "getAlignmentOffset": [Function],
-                "isExpanded": true,
-                "minWidthOffset": 0,
-                "onClickOut": null,
-                "portalId": null,
-              },
-              "alignment": "start",
-              "direction": "down",
-              "flyOutStyle": Object {
-                "maxHeight": "18em",
-              },
-              "focusedIndex": null,
-              "isDisabled": false,
-              "isExpanded": false,
-              "onCollapse": [Function],
-              "onExpand": [Function],
-              "onFocusNext": [Function],
-              "onFocusOption": [Function],
-              "onFocusPrev": [Function],
-              "onSelect": [Function],
-              "selectedIndices": Array [],
-            }
-          }
-          hasReset={true}
-          isDisabled={false}
-          isSelectionHighlighted={true}
-          selectedIndex={null}
-        >
+        "children": <SingleSelect>
           <SingleSelect.Option>
             One
           </SingleSelect.Option>
@@ -394,41 +350,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
     }
   >
     <RadioGroup.Label>
-      <SingleSelect
-        DropMenu={
-          Object {
-            "ContextMenu": Object {
-              "alignment": "start",
-              "direction": "down",
-              "directonOffset": 0,
-              "getAlignmentOffset": [Function],
-              "isExpanded": true,
-              "minWidthOffset": 0,
-              "onClickOut": null,
-              "portalId": null,
-            },
-            "alignment": "start",
-            "direction": "down",
-            "flyOutStyle": Object {
-              "maxHeight": "18em",
-            },
-            "focusedIndex": null,
-            "isDisabled": false,
-            "isExpanded": false,
-            "onCollapse": [Function],
-            "onExpand": [Function],
-            "onFocusNext": [Function],
-            "onFocusOption": [Function],
-            "onFocusPrev": [Function],
-            "onSelect": [Function],
-            "selectedIndices": Array [],
-          }
-        }
-        hasReset={true}
-        isDisabled={false}
-        isSelectionHighlighted={true}
-        selectedIndex={null}
-      >
+      <SingleSelect>
         <SingleSelect.Option>
           One
         </SingleSelect.Option>

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
@@ -670,14 +670,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 09.nested
     isPrimary={true}
   >
     <Sidebar
-      isAnimated={true}
-      isExpanded={true}
-      isResizeDisabled={false}
-      onResize={[Function]}
-      onResizing={[Function]}
-      onToggle={[Function]}
       position="right"
-      width={250}
     >
       <Sidebar.Bar
         hasGutters={true}
@@ -1960,18 +1953,7 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 10.nested
     className="lucid-Sidebar-Primary"
     isPrimary={true}
   >
-    <Submarine
-      height={250}
-      isAnimated={true}
-      isExpanded={true}
-      isHidden={false}
-      isResizeDisabled={false}
-      isTitleShownCollapsed={false}
-      onResize={[Function]}
-      onResizing={[Function]}
-      onToggle={[Function]}
-      position="bottom"
-    >
+    <Submarine>
       <Submarine.Bar>
         Air plant blog pitchfork gastropub shabby chic wolf sriracha salvia, hella af. Taxidermy gastropub marfa fap, selvage af four dollar toast stumptown biodiesel post-ironic keffiyeh scenester cliche. Fashion axe listicle hexagon man bun pour-over migas. Schlitz you probably haven't heard of them la croix skateboard, literally small batch sartorial flexitarian messenger bag offal deep v kitsch chicharrones hammock. Keffiyeh knausgaard listicle, edison bulb lumbersexual flannel normcore ennui. YOLO la croix craft beer, pickled pitchfork intelligentsia PBR&B. Shabby chic raw denim cornhole raclette selfies messenger bag. Dreamcatcher jean shorts hoodie, subway tile viral franzen microdosing readymade photo booth farm-to-table echo park salvia lyft vegan chicharrones. Semiotics master cleanse meggings typewriter small batch. Four dollar toast green juice 90's, tattooed jianbing taxidermy gluten-free. Cronut la croix skateboard, sartorial sustainable asymmetrical mustache pinterest af semiotics lyft man bun fam truffaut. You probably haven't heard of them PBR&B bushwick hell of four dollar toast umami, put a bird on it church-key tattooed chillwave neutra live-edge twee. Chartreuse selvage gluten-free blue bottle. Ethical skateboard keffiyeh lumbersexual hell of, plaid bushwick iceland live-edge cornhole. Letterpress occupy man braid narwhal small batch, selfies pabst sustainable organic fashion axe pinterest flannel drinking vinegar. Meh tilde tattooed, readymade gastropub semiotics salvia williamsburg lomo truffaut direct trade gluten-free. Artisan neutra tilde microdosing, photo booth raw denim lo-fi celiac irony yr dreamcatcher taxidermy normcore. Stumptown bespoke offal, swag tilde chambray subway tile try-hard post-ironic. VHS literally keffiyeh, health goth 3 wolf moon chartreuse franzen trust fund locavore +1. Tousled lo-fi art party, craft beer knausgaard portland kombucha church-key 3 wolf moon heirloom taxidermy blue bottle narwhal. Migas portland sriracha, hot chicken green juice yr bushwick master cleanse PBR&B unicorn DIY waistcoat kombucha YOLO air plant. Four dollar toast air plant skateboard meditation. Waistcoat keffiyeh fingerstache vape. Stumptown heirloom pabst tote bag lo-fi microdosing, everyday carry knausgaard. Selfies readymade wolf, paleo pinterest chartreuse glossier pour-over irony literally cronut lyft stumptown iceland. Twee vice fixie +1, poutine flannel freegan put a bird on it ethical chicharrones. Scenester chartreuse swag sartorial, hella raclette art party. Pickled everyday carry quinoa gentrify.
       </Submarine.Bar>

--- a/src/components/Submarine/__snapshots__/Submarine.spec.jsx.snap
+++ b/src/components/Submarine/__snapshots__/Submarine.spec.jsx.snap
@@ -510,15 +510,6 @@ exports[`Submarine [common] example testing should match snapshot(s) for 9.neste
     isPrimary={true}
   >
     <Submarine
-      height={250}
-      isAnimated={true}
-      isExpanded={true}
-      isHidden={false}
-      isResizeDisabled={false}
-      isTitleShownCollapsed={false}
-      onResize={[Function]}
-      onResizing={[Function]}
-      onToggle={[Function]}
       position="bottom"
     >
       <Submarine.Bar>

--- a/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -290,14 +290,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 04-complex-t
           "Two",
           <br />,
           "Line Two",
-          <SearchField
-            debounceLevel={500}
-            isDisabled={false}
-            onChange={[Function]}
-            onChangeDebounced={[Function]}
-            onSubmit={[Function]}
-            value=""
-          />,
+          <SearchField />,
         ]
       }
       index={1}
@@ -313,23 +306,13 @@ exports[`Tabs [common] example testing should match snapshot(s) for 04-complex-t
         Two
         <br />
         Line Two
-        <SearchField
-          debounceLevel={500}
-          isDisabled={false}
-          onChange={[Function]}
-          onChangeDebounced={[Function]}
-          onSubmit={[Function]}
-          value=""
-        />
+        <SearchField />
       </Tabs.Title>
       Two content
     </Tabs.Tab>
     <Tabs.Tab
       Title={
         <RadioGroup
-          isDisabled={false}
-          name="lucid-RadioGroup-2"
-          onSelect={[Function]}
           selectedIndex={1}
         >
           <RadioButton
@@ -372,9 +355,6 @@ exports[`Tabs [common] example testing should match snapshot(s) for 04-complex-t
     >
       <Tabs.Title>
         <RadioGroup
-          isDisabled={false}
-          name="lucid-RadioGroup-2"
-          onSelect={[Function]}
           selectedIndex={1}
         >
           <RadioButton

--- a/src/components/VerticalListMenu/__snapshots__/VerticalListMenu.spec.jsx.snap
+++ b/src/components/VerticalListMenu/__snapshots__/VerticalListMenu.spec.jsx.snap
@@ -121,10 +121,8 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
       rootType="div"
     >
       <VerticalListMenu
-        expandedIndices={Array []}
         key=".1"
         onSelect={[Function]}
-        onToggle={[Function]}
         selectedIndices={Array []}
       >
         <VerticalListMenu.Item>
@@ -135,9 +133,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
         >
           Level two with VerticalListMenu and lots of text. Lorem quos natus mollitia nihil quasi! Necessitatibus corporis aliquam quam laborum nesciunt quaerat. Nostrum distinctio officiis adipisci nulla unde repellat. Soluta eaque ex obcaecati molestiae provident aspernatur sit! Expedita et.
           <VerticalListMenu
-            expandedIndices={Array []}
             onSelect={[Function]}
-            onToggle={[Function]}
             selectedIndices={Array []}
           >
             <VerticalListMenu.Item
@@ -421,9 +417,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
   >
     Level one with VerticalListMenu
     <VerticalListMenu
-      expandedIndices={Array []}
       onSelect={[Function]}
-      onToggle={[Function]}
       selectedIndices={Array []}
     >
       <VerticalListMenu.Item>
@@ -434,9 +428,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
       >
         Level two with VerticalListMenu and lots of text. Lorem quos natus mollitia nihil quasi! Necessitatibus corporis aliquam quam laborum nesciunt quaerat. Nostrum distinctio officiis adipisci nulla unde repellat. Soluta eaque ex obcaecati molestiae provident aspernatur sit! Expedita et.
         <VerticalListMenu
-          expandedIndices={Array []}
           onSelect={[Function]}
-          onToggle={[Function]}
           selectedIndices={Array []}
         >
           <VerticalListMenu.Item
@@ -744,10 +736,8 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
       rootType="div"
     >
       <VerticalListMenu
-        expandedIndices={Array []}
         key=".1"
         onSelect={[Function]}
-        onToggle={[Function]}
         selectedIndices={Array []}
       >
         <VerticalListMenu.Item>
@@ -782,10 +772,8 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
       rootType="div"
     >
       <VerticalListMenu
-        expandedIndices={Array []}
         key=".1"
         onSelect={[Function]}
-        onToggle={[Function]}
         selectedIndices={Array []}
       >
         <VerticalListMenu.Item>
@@ -796,9 +784,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
         >
           Level two with closed VerticalListMenu
           <VerticalListMenu
-            expandedIndices={Array []}
             onSelect={[Function]}
-            onToggle={[Function]}
             selectedIndices={Array []}
           >
             <VerticalListMenu.Item>
@@ -841,9 +827,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
   >
     Level one with VerticalListMenu
     <VerticalListMenu
-      expandedIndices={Array []}
       onSelect={[Function]}
-      onToggle={[Function]}
       selectedIndices={Array []}
     >
       <VerticalListMenu.Item>
@@ -859,9 +843,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
   >
     Level one with VerticalListMenu
     <VerticalListMenu
-      expandedIndices={Array []}
       onSelect={[Function]}
-      onToggle={[Function]}
       selectedIndices={Array []}
     >
       <VerticalListMenu.Item>
@@ -872,9 +854,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
       >
         Level two with closed VerticalListMenu
         <VerticalListMenu
-          expandedIndices={Array []}
           onSelect={[Function]}
-          onToggle={[Function]}
           selectedIndices={Array []}
         >
           <VerticalListMenu.Item>
@@ -954,11 +934,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
       rootType="div"
     >
       <VerticalListMenu
-        expandedIndices={Array []}
         key=".1"
-        onSelect={[Function]}
-        onToggle={[Function]}
-        selectedIndices={Array []}
       >
         <VerticalListMenu.Item
           key="0"
@@ -1241,12 +1217,7 @@ exports[`VerticalListMenu [common] example testing should match snapshot(s) for 
     hasExpander={true}
   >
     Level one with VerticalListMenu
-    <VerticalListMenu
-      expandedIndices={Array []}
-      onSelect={[Function]}
-      onToggle={[Function]}
-      selectedIndices={Array []}
-    >
+    <VerticalListMenu>
       <VerticalListMenu.Item
         key="0"
       >

--- a/src/docs/index.jsx
+++ b/src/docs/index.jsx
@@ -220,7 +220,8 @@ const Component = createClass({
 	render() {
 		const { componentName, componentRef } = this.props;
 		const childComponents = _.toPairs(_.pickBy(componentRef, isReactComponent));
-		const defaultProps = componentRef.defaultProps;
+		const defaultProps =
+			componentRef.defaultProps || componentRef.peekDefaultProps;
 
 		const componentProps = _.flow(
 			x => _.get(x, 'propTypes', {}),
@@ -378,16 +379,13 @@ const Component = createClass({
 															x => x[0]
 														),
 														([propName, propTypeResolver]) => {
+															const defaultProps =
+																childComponent.defaultProps ||
+																childComponent.peekDefaultProps;
 															const propDetails = _.assign(
 																{},
-																_.has(childComponent, [
-																	'defaultProps',
-																	propName,
-																]) && {
-																	default: _.get(childComponent, [
-																		'defaultProps',
-																		propName,
-																	]),
+																_.has(defaultProps, propName) && {
+																	default: _.get(defaultProps, propName),
 																},
 																_.get(propTypeResolver, 'peek')
 															);

--- a/src/util/state-management.js
+++ b/src/util/state-management.js
@@ -171,9 +171,6 @@ export function safeMerge(objValue, srcValue) {
 	}
 }
 
-const omitDefaults = (props = {}, defaultProps = {}) =>
-	_.omitBy(props, (value, key) => _.isEqual(props[key], defaultProps[key]));
-
 export function buildHybridComponent(
 	baseComponent,
 	{
@@ -205,19 +202,17 @@ export function buildHybridComponent(
 		propTypes,
 		statics: {
 			_isLucidHybridComponent: true,
+			peekDefaultProps: defaultProps,
 			...statics,
 		},
 		displayName,
-		getDefaultProps() {
-			return defaultProps;
-		},
 		getInitialState() {
 			const { initialState } = this.props; //initial state overrides
 			return _.mergeWith(
 				{},
-				omitFunctionPropsDeep(defaultProps),
+				omitFunctionPropsDeep(baseComponent.getDefaultProps()),
 				initialState,
-				omitFunctionPropsDeep(omitDefaults(this.props, defaultProps)),
+				omitFunctionPropsDeep(this.props),
 				safeMerge
 			);
 		},
@@ -228,7 +223,7 @@ export function buildHybridComponent(
 					_.mergeWith(
 						{},
 						omitFunctionPropsDeep(synchronousState),
-						omitFunctionPropsDeep(omitDefaults(this.props, defaultProps)),
+						omitFunctionPropsDeep(this.props),
 						safeMerge
 					),
 				setState: state => {
@@ -241,19 +236,13 @@ export function buildHybridComponent(
 			if (replaceEvents) {
 				return React.createElement(
 					baseComponent,
-					selector(
-						this.boundContext.getPropReplaceReducers(
-							omitDefaults(this.props, defaultProps)
-						)
-					),
+					selector(this.boundContext.getPropReplaceReducers(this.props)),
 					this.props.children
 				);
 			}
 			return React.createElement(
 				baseComponent,
-				selector(
-					this.boundContext.getProps(omitDefaults(this.props, defaultProps))
-				),
+				selector(this.boundContext.getProps(this.props)),
 				this.props.children
 			);
 		},


### PR DESCRIPTION
Reverted changes to exposed defaultProps in buildHybridComonent stateful wrapper. This was causing props which were passed in explicitly, but had the same value as the default prop to be ignored. For doc generation, a static property `peekDefaultProps` was exposed to inspect default values.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
