### PR TITLE
Fix initial state bug

### DIFF
--- a/src/util/state-management.js
+++ b/src/util/state-management.js
@@ -212,7 +212,6 @@ export function buildHybridComponent(
 				{},
 				omitFunctionPropsDeep(baseComponent.getDefaultProps()),
 				initialState,
-				omitFunctionPropsDeep(this.props),
 				safeMerge
 			);
 		},


### PR DESCRIPTION
Ensure that initial state of hybrids is not populated by passed props other than `initialState`

## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
