### PR TITLE
Add fine grained tick control

### DIFF
--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -35,7 +35,6 @@ const {
 	string,
 	bool,
 	oneOfType,
-	array,
 } = PropTypes;
 
 const LineChart = createClass({

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -35,6 +35,7 @@ const {
 	string,
 	bool,
 	oneOfType,
+	array,
 } = PropTypes;
 
 const LineChart = createClass({
@@ -168,6 +169,13 @@ const LineChart = createClass({
 		xAxisTickCount: number`
 			There are some cases where you need to only show a "sampling" of ticks on
 			the x axis. This number will control that.
+		`,
+
+		xAxisTicks: array`
+			In some cases xAxisTickCount is not enough and you want to specify
+			exactly where the tick marks should appear on the x axis. This prop takes
+			an array of dates (currently only dates are supported for the x axis).
+			This prop will override the \`xAxisTickCount\` prop.
 		`,
 
 		xAxisTitle: string`
@@ -327,6 +335,7 @@ const LineChart = createClass({
 
 			xAxisField: 'x',
 			xAxisTickCount: null,
+			xAxisTicks: undefined, // intentionally undefined so that `Axis` can default it correctly
 			xAxisTitle: null,
 			xAxisTitleColor: '#000',
 			// E.g. "Mon 06/06/2016 15:46:19"
@@ -393,6 +402,7 @@ const LineChart = createClass({
 
 			xAxisField,
 			xAxisTickCount,
+			xAxisTicks,
 			xAxisTitle,
 			xAxisTitleColor,
 			xAxisFormatter = formatDate,
@@ -655,6 +665,7 @@ const LineChart = createClass({
 						outerTickSize={0}
 						tickFormat={xFinalFormatter}
 						tickCount={xAxisTickCount}
+						ticks={xAxisTicks}
 						ref="xAxis"
 					/>
 

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -171,7 +171,7 @@ const LineChart = createClass({
 			the x axis. This number will control that.
 		`,
 
-		xAxisTicks: array`
+		xAxisTicks: arrayOf(instanceOf(Date))`
 			In some cases xAxisTickCount is not enough and you want to specify
 			exactly where the tick marks should appear on the x axis. This prop takes
 			an array of dates (currently only dates are supported for the x axis).

--- a/src/components/LineChart/__snapshots__/LineChart.spec.jsx.snap
+++ b/src/components/LineChart/__snapshots__/LineChart.spec.jsx.snap
@@ -2801,3 +2801,146 @@ exports[`LineChart [common] example testing should match snapshot(s) for 15.load
   </svg>
 </EmptyStateWrapper>
 `;
+
+exports[`LineChart [common] example testing should match snapshot(s) for 16.fine-grained-ticks 1`] = `
+<svg
+  className="lucid-LineChart"
+  height={400}
+  width={1000}
+>
+  <g
+    transform="translate(80, 10)"
+  />
+  <g
+    transform="translate(80, 335)"
+  >
+    <Axis
+      innerTickSize={6}
+      orient="bottom"
+      outerTickSize={0}
+      scale={[Function]}
+      tickCount={null}
+      tickFormat={[Function]}
+      tickPadding={3}
+      ticks={
+        Array [
+          2018-01-01T08:00:00.000Z,
+          2018-01-02T08:00:00.000Z,
+          2018-01-03T08:00:00.000Z,
+        ]
+      }
+    />
+  </g>
+  <g
+    transform="translate(80, 10)"
+  >
+    <Axis
+      innerTickSize={6}
+      orient="left"
+      outerTickSize={6}
+      scale={[Function]}
+      tickCount={null}
+      tickFormat={[Function]}
+      tickPadding={3}
+    />
+  </g>
+  <g
+    transform="translate(80, 10)"
+  >
+    <Lines
+      colorOffset={0}
+      data={
+        Array [
+          Object {
+            "x": 2018-01-01T08:00:00.000Z,
+            "y": 1,
+          },
+          Object {
+            "x": 2018-01-02T08:00:00.000Z,
+            "y": 2,
+          },
+          Object {
+            "x": 2018-01-03T08:00:00.000Z,
+            "y": 3,
+          },
+        ]
+      }
+      isStacked={false}
+      palette={
+        Array [
+          "color-chart-0",
+          "color-chart-1",
+          "color-chart-2",
+          "color-chart-3",
+          "color-chart-4",
+          "color-chart-5",
+        ]
+      }
+      xField="x"
+      xScale={[Function]}
+      yFields={
+        Array [
+          "y",
+        ]
+      }
+      yScale={[Function]}
+      yStackedMax={3}
+    />
+  </g>
+  <g
+    transform="translate(80, 10)"
+  >
+    <Points
+      colorOffset={0}
+      data={
+        Array [
+          Object {
+            "x": 2018-01-01T08:00:00.000Z,
+            "y": 1,
+          },
+          Object {
+            "x": 2018-01-02T08:00:00.000Z,
+            "y": 2,
+          },
+          Object {
+            "x": 2018-01-03T08:00:00.000Z,
+            "y": 3,
+          },
+        ]
+      }
+      hasStroke={true}
+      isStacked={false}
+      palette={
+        Array [
+          "color-chart-0",
+          "color-chart-1",
+          "color-chart-2",
+          "color-chart-3",
+          "color-chart-4",
+          "color-chart-5",
+        ]
+      }
+      xField="x"
+      xScale={[Function]}
+      yFields={
+        Array [
+          "y",
+        ]
+      }
+      yScale={[Function]}
+      yStackedMax={3}
+    />
+  </g>
+  <g
+    transform="translate(80, 10)"
+  >
+    <rect
+      className="lucid-LineChart-invisible"
+      height={325}
+      onMouseMove={[Function]}
+      onMouseOut={[Function]}
+      width={840}
+    />
+  </g>
+</svg>
+`;

--- a/src/components/LineChart/examples/16.fine-grained-ticks.jsx
+++ b/src/components/LineChart/examples/16.fine-grained-ticks.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { LineChart } from '../../../index';
+import _ from 'lodash';
+
+const data = [
+	{ x: new Date('2018-01-01T00:00:00-0800'), y: 1 },
+	{ x: new Date('2018-01-02T00:00:00-0800'), y: 2 },
+	{ x: new Date('2018-01-03T00:00:00-0800'), y: 3 },
+];
+
+export default createClass({
+	render() {
+		return (
+			<LineChart
+				data={data}
+				xAxisTicks={_.map(data, 'x')}
+				xAxisFormatter={date => date.toLocaleDateString()}
+			/>
+		);
+	},
+});


### PR DESCRIPTION
There have been some use cases where people need finer grain control
over the x axis tick marks on the line chart. This PR should enable
that.

## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~~One core team UX approval~~
