### PR TITLE
Unmount Portal at DOM node before removing it

### DIFF
--- a/src/components/Portal/Portal.jsx
+++ b/src/components/Portal/Portal.jsx
@@ -48,6 +48,7 @@ const Portal = createClass({
 		this.componentDidUpdate();
 	},
 	componentWillUnmount() {
+		ReactDOM.unmountComponentAtNode(this.portalElement);
 		window.document.body.removeChild(this.portalElement);
 	},
 	componentDidUpdate() {


### PR DESCRIPTION
fixes #494 

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
