### PR TITLE
fix secondary button size in `SplitButton`

### DIFF
--- a/src/components/SplitButton/SplitButton.jsx
+++ b/src/components/SplitButton/SplitButton.jsx
@@ -180,6 +180,7 @@ const SplitButton = createClass({
 						/>
 						<Button
 							className={cx('&-Button-drop')}
+							size={size}
 							hasOnlyIcon
 							isActive={isExpanded}
 							kind={kind}

--- a/src/components/SplitButton/__snapshots__/SplitButton.spec.jsx.snap
+++ b/src/components/SplitButton/__snapshots__/SplitButton.spec.jsx.snap
@@ -848,6 +848,285 @@ exports[`SplitButton [common] example testing should match snapshot(s) for 04.up
 </DropMenu>
 `;
 
+exports[`SplitButton [common] example testing should match snapshot(s) for 4.sizes 1`] = `
+<DropMenu
+  ContextMenu={
+    Object {
+      "alignment": "start",
+      "direction": "down",
+      "directonOffset": 0,
+      "getAlignmentOffset": [Function],
+      "isExpanded": true,
+      "minWidthOffset": 0,
+      "onClickOut": null,
+      "portalId": null,
+    }
+  }
+  alignment="start"
+  className="lucid-SplitButton"
+  direction="down"
+  flyOutStyle={
+    Object {
+      "maxHeight": "18em",
+    }
+  }
+  focusedIndex={null}
+  isDisabled={false}
+  isExpanded={false}
+  onCollapse={[Function]}
+  onExpand={[Function]}
+  onFocusNext={[Function]}
+  onFocusOption={[Function]}
+  onFocusPrev={[Function]}
+  onSelect={[Function]}
+  selectedIndices={Array []}
+  style={
+    Object {
+      "height": 100,
+      "marginRight": "20px",
+    }
+  }
+>
+  <DropMenu.Control>
+    <ButtonGroup
+      className={null}
+      onSelect={[Function]}
+      selectedIndices={Array []}
+    >
+      <Button
+        className="lucid-SplitButton-Button-primary"
+        hasOnlyIcon={false}
+        isActive={false}
+        isDisabled={false}
+        onClick={[Function]}
+        size="large"
+        type="button"
+      >
+        Large
+      </Button>
+      <Button
+        className="lucid-SplitButton-Button-drop"
+        hasOnlyIcon={true}
+        isActive={false}
+        isDisabled={false}
+        onClick={[Function]}
+        size="large"
+        type="button"
+      >
+        <CaretIcon
+          className="lucid-SplitButton-CaretIcon"
+          direction="down"
+          size={8}
+          viewBox="0 3 16 8"
+        />
+      </Button>
+    </ButtonGroup>
+  </DropMenu.Control>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="0"
+  >
+    One
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="1"
+  >
+    Two
+  </DropMenu.Option>
+</DropMenu>
+`;
+
+exports[`SplitButton [common] example testing should match snapshot(s) for 4.sizes 2`] = `
+<DropMenu
+  ContextMenu={
+    Object {
+      "alignment": "start",
+      "direction": "down",
+      "directonOffset": 0,
+      "getAlignmentOffset": [Function],
+      "isExpanded": true,
+      "minWidthOffset": 0,
+      "onClickOut": null,
+      "portalId": null,
+    }
+  }
+  alignment="start"
+  className="lucid-SplitButton"
+  direction="down"
+  flyOutStyle={
+    Object {
+      "maxHeight": "18em",
+    }
+  }
+  focusedIndex={null}
+  isDisabled={false}
+  isExpanded={false}
+  onCollapse={[Function]}
+  onExpand={[Function]}
+  onFocusNext={[Function]}
+  onFocusOption={[Function]}
+  onFocusPrev={[Function]}
+  onSelect={[Function]}
+  selectedIndices={Array []}
+  style={
+    Object {
+      "height": 100,
+      "marginRight": "20px",
+    }
+  }
+>
+  <DropMenu.Control>
+    <ButtonGroup
+      className={null}
+      onSelect={[Function]}
+      selectedIndices={Array []}
+    >
+      <Button
+        className="lucid-SplitButton-Button-primary"
+        hasOnlyIcon={false}
+        isActive={false}
+        isDisabled={false}
+        onClick={[Function]}
+        size="small"
+        type="button"
+      >
+        Small
+      </Button>
+      <Button
+        className="lucid-SplitButton-Button-drop"
+        hasOnlyIcon={true}
+        isActive={false}
+        isDisabled={false}
+        onClick={[Function]}
+        size="small"
+        type="button"
+      >
+        <CaretIcon
+          className="lucid-SplitButton-CaretIcon"
+          direction="down"
+          size={8}
+          viewBox="0 3 16 8"
+        />
+      </Button>
+    </ButtonGroup>
+  </DropMenu.Control>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="0"
+  >
+    One
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="1"
+  >
+    Two
+  </DropMenu.Option>
+</DropMenu>
+`;
+
+exports[`SplitButton [common] example testing should match snapshot(s) for 4.sizes 3`] = `
+<DropMenu
+  ContextMenu={
+    Object {
+      "alignment": "start",
+      "direction": "down",
+      "directonOffset": 0,
+      "getAlignmentOffset": [Function],
+      "isExpanded": true,
+      "minWidthOffset": 0,
+      "onClickOut": null,
+      "portalId": null,
+    }
+  }
+  alignment="start"
+  className="lucid-SplitButton"
+  direction="down"
+  flyOutStyle={
+    Object {
+      "maxHeight": "18em",
+    }
+  }
+  focusedIndex={null}
+  isDisabled={false}
+  isExpanded={false}
+  onCollapse={[Function]}
+  onExpand={[Function]}
+  onFocusNext={[Function]}
+  onFocusOption={[Function]}
+  onFocusPrev={[Function]}
+  onSelect={[Function]}
+  selectedIndices={Array []}
+  style={
+    Object {
+      "height": 100,
+      "marginRight": "20px",
+    }
+  }
+>
+  <DropMenu.Control>
+    <ButtonGroup
+      className={null}
+      onSelect={[Function]}
+      selectedIndices={Array []}
+    >
+      <Button
+        className="lucid-SplitButton-Button-primary"
+        hasOnlyIcon={false}
+        isActive={false}
+        isDisabled={false}
+        onClick={[Function]}
+        size="short"
+        type="button"
+      >
+        Short
+      </Button>
+      <Button
+        className="lucid-SplitButton-Button-drop"
+        hasOnlyIcon={true}
+        isActive={false}
+        isDisabled={false}
+        onClick={[Function]}
+        size="short"
+        type="button"
+      >
+        <CaretIcon
+          className="lucid-SplitButton-CaretIcon"
+          direction="down"
+          size={8}
+          viewBox="0 3 16 8"
+        />
+      </Button>
+    </ButtonGroup>
+  </DropMenu.Control>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="0"
+  >
+    One
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="1"
+  >
+    Two
+  </DropMenu.Option>
+</DropMenu>
+`;
+
 exports[`SplitButton click handlers primary button should trigger \`handleClick\` 1`] = `
 Object {
   "event": Object {

--- a/src/components/SplitButton/examples/4.sizes.jsx
+++ b/src/components/SplitButton/examples/4.sizes.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SplitButton } from '../../../index';
+
+const style = { marginRight: '20px', height: 100 };
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<SplitButton size="large" style={style}>
+					<SplitButton.Button>Large</SplitButton.Button>
+					<SplitButton.Button>One</SplitButton.Button>
+					<SplitButton.Button>Two</SplitButton.Button>
+				</SplitButton>
+				<SplitButton size="small" style={style}>
+					<SplitButton.Button>Small</SplitButton.Button>
+					<SplitButton.Button>One</SplitButton.Button>
+					<SplitButton.Button>Two</SplitButton.Button>
+				</SplitButton>
+				<SplitButton size="short" style={style}>
+					<SplitButton.Button>Short</SplitButton.Button>
+					<SplitButton.Button>One</SplitButton.Button>
+					<SplitButton.Button>Two</SplitButton.Button>
+				</SplitButton>
+			</div>
+		);
+	},
+});


### PR DESCRIPTION
fixes #902

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval
