### PR TITLE
Add child components to docs

### DIFF
--- a/.storybook/lucid-docs-addon/ChildComponents.js
+++ b/.storybook/lucid-docs-addon/ChildComponents.js
@@ -43,7 +43,6 @@ const compile = marksy({
 
 const styles = {
 	divider: {
-		//backgroundColor: 'rgb(247,247,247)',
 		backgroundColor: 'rgb(236,236,236)',
 		height: 1,
 		border: 'none',
@@ -51,16 +50,11 @@ const styles = {
 	},
 	childComponent: {
 		backgroundColor: 'rgb(247,247,247)',
-		//border: '1px solid #ccc',
 		margin: '10px 0px 0px 10px',
 		padding: 6,
 	},
 	name: {
 		fontWeight: 'bold',
-		//fontSize: 'larger',
-	},
-	header: {
-		//fontWeight: 100,
 	},
 	headerText: {
 		backgroundColor: 'white',
@@ -107,18 +101,13 @@ const ChildComponents = ({ childComponents }) => {
 	return (
 		<section>
 			<hr style={styles.divider} />
-			<div style={styles.header}>
+			<div>
 				<span style={styles.headerText}>Child Components</span>
 			</div>
 			{!_.isEmpty(childComponents) &&
 				_.map(childComponents, (childComponent, key) => (
 					<ChildComponent key={key} {...childComponent} />
 				))}
-			{/*<pre>
-				{JSON.stringify(childComponents, null, 2)}
-			</pre>*/}
-			{/*TODO remove the bottom <hr>*/}
-			{/*<hr style={{...styles.divider, marginBottom: 18}} />*/}
 		</section>
 	);
 };

--- a/.storybook/lucid-docs-addon/ChildComponents.js
+++ b/.storybook/lucid-docs-addon/ChildComponents.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import _ from 'lodash';
+import marksy from 'marksy/components';
+import PropTypes from './PropTypes';
+import { stripIndent } from '../../src/docs/util';
+
+import SyntaxHighlighter, {
+	registerLanguage,
+} from 'react-syntax-highlighter/prism-light';
+import jsx from 'react-syntax-highlighter/languages/prism/jsx';
+import json from 'react-syntax-highlighter/languages/prism/json';
+import coy from 'react-syntax-highlighter/styles/prism/coy';
+
+const coyCustom = {
+	...coy,
+	'code[class*="language-"]': {
+		...coy['code[class*="language-"]'],
+		tabSize: '2',
+	},
+	'pre[class*="language-"]': {
+		...coy['pre[class*="language-"]'],
+		backgroundColor: '',
+		fontSize: 12,
+	},
+};
+
+registerLanguage('jsx', jsx);
+registerLanguage('json', json);
+
+const compile = marksy({
+	createElement: React.createElement,
+	highlight: (language, code) =>
+		ReactDOMServer.renderToStaticMarkup(
+			<SyntaxHighlighter language={language || 'jsx'} style={coyCustom}>
+				{code}
+			</SyntaxHighlighter>
+		),
+	elements: {
+		p: props => <p {...props} style={{ margin: '4px 0' }} />,
+	},
+});
+
+const styles = {
+	divider: {
+		//backgroundColor: 'rgb(247,247,247)',
+		backgroundColor: 'rgb(236,236,236)',
+		height: 1,
+		border: 'none',
+		margin: '18px 0px -11px',
+	},
+	childComponent: {
+		backgroundColor: 'rgb(247,247,247)',
+		//border: '1px solid #ccc',
+		margin: '10px 0px 0px 10px',
+		padding: 6,
+	},
+	name: {
+		fontWeight: 'bold',
+		//fontSize: 'larger',
+	},
+	header: {
+		//fontWeight: 100,
+	},
+	headerText: {
+		backgroundColor: 'white',
+		paddingLeft: 4,
+		paddingRight: 4,
+		marginLeft: 6,
+		fontWeight: 'bold',
+		fontSize: 'smaller',
+		color: '#999',
+	},
+	displayName: {
+		marginLeft: '.5em',
+		fontSize: 'smaller',
+		fontWeight: 'normal',
+	},
+};
+
+const ChildComponent = ({
+	name,
+	displayName,
+	path,
+	description,
+	props,
+	childComponents,
+	isPrivate,
+}) => {
+	const childComponentName = _.isEmpty(path) ? name : path.join('.');
+	return (
+		<section style={styles.childComponent}>
+			<div style={styles.name}>
+				{childComponentName}
+				{!isPrivate &&
+					childComponentName !== displayName && (
+						<span style={styles.displayName}>(see {displayName})</span>
+					)}
+			</div>
+			<div>{compile(description).tree}</div>
+			<PropTypes showIndex={false} props={props} />
+		</section>
+	);
+};
+
+const ChildComponents = ({ childComponents }) => {
+	return (
+		<section>
+			<hr style={styles.divider} />
+			<div style={styles.header}>
+				<span style={styles.headerText}>Child Components</span>
+			</div>
+			{!_.isEmpty(childComponents) &&
+				_.map(childComponents, (childComponent, key) => (
+					<ChildComponent key={key} {...childComponent} />
+				))}
+			{/*<pre>
+				{JSON.stringify(childComponents, null, 2)}
+			</pre>*/}
+			{/*TODO remove the bottom <hr>*/}
+			{/*<hr style={{...styles.divider, marginBottom: 18}} />*/}
+		</section>
+	);
+};
+
+export default ChildComponents;

--- a/.storybook/lucid-docs-addon/PropTypes.js
+++ b/.storybook/lucid-docs-addon/PropTypes.js
@@ -120,7 +120,7 @@ const PropType = ({ oneline, type, ...propData }) => {
 					oneline={oneline}
 					style={{ fontFamily: 'monospace', ...PropType.style.section }}
 				>
-					{JSON.stringify(propData.oneOfData, null, 2)}
+					{JSON.stringify(propData.dynamicData, null, 2)}
 				</Block>
 			</span>
 		);
@@ -131,7 +131,7 @@ const PropType = ({ oneline, type, ...propData }) => {
 			<span style={PropType.style.root}>
 				{type}:
 				<Block oneline={oneline} style={PropType.style.section}>
-					<PropType {...propData.arrayOfData} />
+					<PropType {...propData.dynamicData} />
 				</Block>
 			</span>
 		);
@@ -141,7 +141,7 @@ const PropType = ({ oneline, type, ...propData }) => {
 		return (
 			<span style={PropType.style.root}>
 				{type}:
-				{_.map(propData.oneOfTypeData, (propTypeData, key) => (
+				{_.map(propData.dynamicData, (propTypeData, key) => (
 					<Block oneline={oneline} key={key} style={PropType.style.section}>
 						<PropType {...propTypeData} />
 					</Block>
@@ -153,7 +153,7 @@ const PropType = ({ oneline, type, ...propData }) => {
 	if (type === 'instanceOf') {
 		return (
 			<span style={PropType.style.root}>
-				{type}: <span>{propData.instanceOfData}</span>
+				{type}: <span>{propData.dynamicData}</span>
 			</span>
 		);
 	}
@@ -163,7 +163,7 @@ const PropType = ({ oneline, type, ...propData }) => {
 			<span style={PropType.style.root}>
 				{type}:
 				<Block oneline={oneline} style={PropType.style.section}>
-					<PropType {...propData.objectOfData} />
+					<PropType {...propData.dynamicData} />
 				</Block>
 			</span>
 		);
@@ -175,7 +175,7 @@ const PropType = ({ oneline, type, ...propData }) => {
 				{type}:
 				<Block oneline={oneline} style={PropType.style.section}>
 					{'{'}
-					{_.map(propData.shapeData, (propTypeData, key) => (
+					{_.map(propData.dynamicData, (propTypeData, key) => (
 						<div key={key} style={PropType.style.section}>
 							{key}:
 							<span style={PropType.style.section}>

--- a/.storybook/lucid-docs-addon/PropTypes.js
+++ b/.storybook/lucid-docs-addon/PropTypes.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import marksy from 'marksy/components';
-import { Table, Td, Th } from '@storybook/components';
 import { stripIndent } from '../../src/docs/util';
 
 import SyntaxHighlighter, {
@@ -40,13 +39,6 @@ const compile = marksy({
 		p: props => <p {...props} style={{ margin: '4px 0' }} />,
 	},
 });
-
-const getDefaultPropValue = (componentRef, property) => {
-	const defaultValue = _.get(componentRef, ['defaultProps', property]);
-	return _.isUndefined(defaultValue)
-		? _.get(componentRef, ['peekDefaultProps', property])
-		: defaultValue;
-};
 
 const style = {
 	a: {
@@ -92,7 +84,6 @@ const style = {
 	},
 	propSection: {
 		margin: '10px 0 10px 0',
-		backgroundColor: 'white',
 		padding: 8,
 	},
 	defaultValueLabel: {
@@ -114,7 +105,6 @@ const style = {
 	top: {
 		fontSize: 'smaller',
 		fontWeight: '200',
-		display: 'none',
 	},
 };
 
@@ -212,41 +202,39 @@ PropType.style = {
 	},
 };
 
-const PropsList = ({ componentRef, props }) => {
-	if (componentRef) {
-		return <section />;
-	}
-
+const PropsList = ({ showIndex, showTopLinks, props }) => {
 	const sortedProps = _.sortBy(props, 'isRequired');
 
 	return (
 		<section>
-			<a name="top" />
-			<ul style={style.ul}>
-				{_.map(
-					sortedProps,
-					({ name, type, isRequired, defaultValue, text }) => (
-						<li key={name} style={style.li}>
-							<a
-								style={{ ...style.a, ...style.propName, ...style.propLink }}
-								href={`#${name}`}
-							>
-								<span style={style.hashSymbol}>#</span>
-								{name}
-							</a>
-							&nbsp;
-							<span style={style.propType}>{type}</span>
-							{isRequired && <span style={style.isRequired}>Required</span>}
-						</li>
-					)
-				)}
-			</ul>
-			<hr style={style.divider} />
+			{showIndex && [
+				showTopLinks ? <a name="top" /> : null,
+				<ul key="propsIndex" style={style.ul}>
+					{_.map(
+						sortedProps,
+						({ name, type, isRequired, defaultValue, text }) => (
+							<li key={name} style={style.li}>
+								<a
+									style={{ ...style.a, ...style.propName, ...style.propLink }}
+									href={`#${name}`}
+								>
+									<span style={style.hashSymbol}>#</span>
+									{name}
+								</a>
+								&nbsp;
+								<span style={style.propType}>{type}</span>
+								{isRequired && <span style={style.isRequired}>Required</span>}
+							</li>
+						)
+					)}
+				</ul>,
+				<hr key="propsIndexDivider" style={style.divider} />,
+			]}
 			{_.map(
 				sortedProps,
 				({ name, type, isRequired, defaultValue, text, ...propData }) => (
 					<span key={name}>
-						<a name={name} />
+						{showIndex && <a name={name} />}
 						<div style={style.propSection}>
 							<h3 style={style.propHeader}>
 								<span style={style.propName}>{name}</span>
@@ -266,21 +254,30 @@ const PropsList = ({ componentRef, props }) => {
 										style={coy}
 										customStyle={{
 											fontSize: 12,
+											backgroundColor: 'none',
 										}}
 									>
 										{JSON.stringify(defaultValue, null, 2)}
 									</SyntaxHighlighter>
 								</div>
 							)}
-							<a style={{ ...style.a, ...style.top }} href="#top">
-								top
-							</a>
+							{showIndex &&
+								showTopLinks && (
+									<a style={{ ...style.a, ...style.top }} href="#top">
+										top
+									</a>
+								)}
 						</div>
 					</span>
 				)
 			)}
 		</section>
 	);
+};
+
+PropsList.defaultProps = {
+	showIndex: true,
+	showTopLinks: false,
 };
 
 export default PropsList;

--- a/.storybook/lucid-docs-addon/index.js
+++ b/.storybook/lucid-docs-addon/index.js
@@ -22,52 +22,42 @@ const getDefaultPropValue = (componentRef, property) => {
 
 const getPropTypeData = resolverFn => {
 	const type = _.get(resolverFn, ['peek', 'type']);
+	let dynamicData;
 
-	let oneOfData;
 	if (type === 'oneOf') {
-		oneOfData = _.get(resolverFn, ['peek', 'args', 0]);
+		dynamicData = _.get(resolverFn, ['peek', 'args', 0]);
 	}
 
-	let arrayOfData;
 	if (type === 'arrayOf') {
 		const arrayOfResolverFn = _.get(resolverFn, ['peek', 'args', 0]);
-		arrayOfData = getPropTypeData(arrayOfResolverFn);
+		dynamicData = getPropTypeData(arrayOfResolverFn);
 	}
 
-	let oneOfTypeData;
 	if (type === 'oneOfType') {
 		const oneOfTypeResolverFns = _.get(resolverFn, ['peek', 'args', 0]);
-		oneOfTypeData = _.map(oneOfTypeResolverFns, getPropTypeData);
+		dynamicData = _.map(oneOfTypeResolverFns, getPropTypeData);
 	}
 
-	let instanceOfData;
 	if (type === 'instanceOf') {
 		const instanceOfClass = _.get(resolverFn, ['peek', 'args', 0]);
-		instanceOfData = instanceOfClass.name;
+		dynamicData = instanceOfClass.name;
 	}
 
-	let objectOfData;
 	if (type === 'objectOf') {
 		const objectOfResolverFn = _.get(resolverFn, ['peek', 'args', 0]);
-		objectOfData = getPropTypeData(objectOfResolverFn);
+		dynamicData = getPropTypeData(objectOfResolverFn);
 	}
 
-	let shapeData;
 	if (type === 'shape') {
 		const shapeObject = _.get(resolverFn, ['peek', 'args', 0]);
-		shapeData = _.mapValues(shapeObject, getPropTypeData);
+		dynamicData = _.mapValues(shapeObject, getPropTypeData);
 	}
 
 	return {
 		...resolverFn.peek,
 		type,
 		text: stripIndent(_.get(resolverFn, ['peek', 'text'])).trim(),
-		oneOfData,
-		arrayOfData,
-		oneOfTypeData,
-		instanceOfData,
-		objectOfData,
-		shapeData,
+		dynamicData,
 	};
 };
 

--- a/docs/examples/Accordion.stories.js
+++ b/docs/examples/Accordion.stories.js
@@ -11,6 +11,7 @@ storiesOf('Accordion', module).add(
 		component: Accordion,
 		example: OnSelectExample,
 		code: onSelectCode,
+		path: ['Accordion'],
 	})
 );
 

--- a/docs/examples/Accordion.stories.js
+++ b/docs/examples/Accordion.stories.js
@@ -12,6 +12,7 @@ storiesOf('Accordion', module).add(
 		example: OnSelectExample,
 		code: onSelectCode,
 		path: ['Accordion'],
+		options: { showAddonPanel: true },
 	})
 );
 

--- a/docs/index.stories.js
+++ b/docs/index.stories.js
@@ -202,6 +202,7 @@ _.forEach(
 				component,
 				code: firstExample.source,
 				example: FirstExampleComponent,
+				path: [name],
 				options: { showAddonPanel: true },
 			})
 		);
@@ -212,7 +213,7 @@ const loadedComponents = require('./load-components');
 
 _.forEach(
 	loadedComponents,
-	({ name, component, examplesContext, examplesContextRaw }) => {
+	({ name: componentName, component, examplesContext, examplesContextRaw }) => {
 		if (component._isPrivate || (component.peek && component.peek.isPrivate)) {
 			return;
 		}
@@ -229,10 +230,11 @@ _.forEach(
 						component,
 						code: source,
 						example: Example,
+						path: [componentName],
 						options: { showAddonPanel: true },
 					})
 				),
-			storiesOf(name, module)
+			storiesOf(componentName, module)
 		);
 	}
 );

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -137,7 +137,7 @@ const Sidebar = createClass({
 		}),
 
 		Primary: createClass({
-			displayName: 'SplitVertical.Primary',
+			displayName: 'Sidebar.Primary',
 			statics: {
 				peek: {
 					description: `

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.jsx.snap
@@ -671,9 +671,9 @@ exports[`Sidebar [common] example testing should match snapshot(s) for 09.nested
       >
         Id mumblecore blue bottle vegan, fingerstache commodo health goth man bun bitters. Ad ennui authentic, offal humblebrag paleo minim vero hammock kickstarter reprehenderit gastropub.
       </Sidebar.Bar>
-      <SplitVertical.Primary>
+      <Sidebar.Primary>
         Dreamcatcher jean shorts veniam paleo humblebrag, nihil venmo consequat. Tempor kickstarter fingerstache veniam austin, assumenda lomo eu YOLO small batch 3 wolf moon. Chia offal cliche, thundercats try-hard before they sold out tofu freegan ethical scenester polaroid quis next level jean shorts. Sed hoodie ullamco, XOXO laboris yuccie farm-to-table narwhal jean shorts odio affogato irure. Marfa echo park mixtape pinterest accusamus, ullamco normcore deep v hammock. Odio cronut authentic id sunt, knausgaard YOLO. Roof party mollit kickstarter sustainable sriracha.
-      </SplitVertical.Primary>
+      </Sidebar.Primary>
     </Sidebar>
   </SplitVertical.RightPane>
 </SplitVertical>

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -87,8 +87,8 @@ const TextField = createClass({
 			the user is typing and the component gets a new \`value\` prop.  Any time
 			the user hits a key, it starts a timer that prevents state changes from
 			flowing in to the component until the timer has elapsed.  This was
-			heavily inspired by the [lazy-input][li] component.  [li]:
-			https://www.npmjs.com/package/lazy-input
+			heavily inspired by the
+			[lazy-input](https:/docs.npmjs.com/package/lazy-input) component.
 		`,
 	},
 


### PR DESCRIPTION
Added Child components to docs in the 'Props' panel.

See http://docspot.devnxs.net/projects/lucid/docs-child-components/?selectedKind=Accordion&selectedStory=basic&full=0&addons=1&stories=1&panelRight=1&addonPanel=lucid-docs-panel-props

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
