### PR TITLE
Selector option formatting

### DIFF
--- a/.storybook/lucid-docs-addon/index.js
+++ b/.storybook/lucid-docs-addon/index.js
@@ -117,7 +117,8 @@ export const withDescription = componentRef => {
 				<div>
 					<h1>{kind}</h1>
 					<section>
-						{compile(stripIndent(componentRef.peek.description)).tree}
+						{_.has(componentRef, 'peek.description') &&
+							compile(stripIndent(componentRef.peek.description)).tree}
 					</section>
 					<h2>{story}</h2>
 					<StoryComponent {...{ kind, story }} />

--- a/docs/examples/SearchableMultiSelect.stories.js
+++ b/docs/examples/SearchableMultiSelect.stories.js
@@ -1,0 +1,17 @@
+import { storiesOf } from '@storybook/react';
+import { exampleStory } from '../../.storybook/lucid-docs-addon';
+
+import SearchableMultiSelect from '../../src/components/SearchableMultiSelect/SearchableMultiSelect';
+import WithFomattedOptionsExample from './SearchableMultiSelect/WithFormattedOptions';
+import withFomattedOptionsExampleCode from '!!raw-loader!./SearchableMultiSelect/WithFormattedOptions';
+
+storiesOf('SearchableMultiSelect', module).add(
+	'with formatted options',
+	exampleStory({
+		component: SearchableMultiSelect,
+		example: WithFomattedOptionsExample,
+		code: withFomattedOptionsExampleCode,
+		path: ['SearchableMultiSelect'],
+		options: { showAddonPanel: true },
+	})
+);

--- a/docs/examples/SearchableMultiSelect/WithFormattedOptions.js
+++ b/docs/examples/SearchableMultiSelect/WithFormattedOptions.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { SearchableMultiSelect, Underline } from '../../../src/index.js';
+
+const OptionCols = ({ col1, col2, textMatch }) => (
+	<div style={{ display: 'flex' }}>
+		<div style={{ width: 100 }}>
+			<Underline match={textMatch}>{col1}</Underline>
+		</div>
+		<div>
+			<Underline match={textMatch}>{col2}</Underline>
+		</div>
+	</div>
+);
+
+const optionFilter = (searchText, { filterText }) => {
+	if (filterText) {
+		return new RegExp(_.escapeRegExp(searchText), 'i').test(filterText);
+	}
+	return true;
+};
+
+export default class extends React.Component {
+	render() {
+		return (
+			<SearchableMultiSelect optionFilter={optionFilter}>
+				<SearchableMultiSelect.OptionGroup Selected="">
+					<div style={{ marginLeft: 27 }}>
+						<OptionCols col1="ID" col2="NAME" />
+					</div>
+
+					<SearchableMultiSelect.Option filterText="Foo" Selected="Foo (1234)">
+						{({ searchText }) => (
+							<OptionCols col1="1234" col2="Foo" textMatch={searchText} />
+						)}
+					</SearchableMultiSelect.Option>
+
+					<SearchableMultiSelect.Option filterText="Bar" Selected="Bar (2345)">
+						{({ searchText }) => (
+							<OptionCols col1="2345" col2="Bar" textMatch={searchText} />
+						)}
+					</SearchableMultiSelect.Option>
+
+					<SearchableMultiSelect.Option filterText="Baz" Selected="Baz (3456)">
+						{({ searchText }) => (
+							<OptionCols col1="3456" col2="Baz" textMatch={searchText} />
+						)}
+					</SearchableMultiSelect.Option>
+				</SearchableMultiSelect.OptionGroup>
+			</SearchableMultiSelect>
+		);
+	}
+}

--- a/docs/examples/SearchableSelect.stories.js
+++ b/docs/examples/SearchableSelect.stories.js
@@ -1,0 +1,17 @@
+import { storiesOf } from '@storybook/react';
+import { exampleStory } from '../../.storybook/lucid-docs-addon';
+
+import SearchableSelect from '../../src/components/SearchableSelect/SearchableSelect';
+import WithFomattedOptionsExample from './SearchableSelect/WithFormattedOptions';
+import withFomattedOptionsExampleCode from '!!raw-loader!./SearchableSelect/WithFormattedOptions';
+
+storiesOf('SearchableSelect', module).add(
+	'with formatted options',
+	exampleStory({
+		component: SearchableSelect,
+		example: WithFomattedOptionsExample,
+		code: withFomattedOptionsExampleCode,
+		path: ['SearchableSelect'],
+		options: { showAddonPanel: true },
+	})
+);

--- a/docs/examples/SearchableSelect/WithFormattedOptions.js
+++ b/docs/examples/SearchableSelect/WithFormattedOptions.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { SearchableSelect, Underline } from '../../../src/index.js';
+
+const OptionCols = ({ col1, col2, textMatch }) => (
+	<div style={{ display: 'flex' }}>
+		<div style={{ width: 100 }}>
+			<Underline match={textMatch}>{col1}</Underline>
+		</div>
+		<div>
+			<Underline match={textMatch}>{col2}</Underline>
+		</div>
+	</div>
+);
+
+const optionFilter = (searchText, { filterText }) => {
+	if (filterText) {
+		return new RegExp(_.escapeRegExp(searchText), 'i').test(filterText);
+	}
+	return true;
+};
+
+export default class extends React.Component {
+	render() {
+		return (
+			<SearchableSelect optionFilter={optionFilter}>
+				<SearchableSelect.OptionGroup>
+					<OptionCols col1="ID" col2="NAME" />
+
+					<SearchableSelect.Option filterText="Foo" Selected="Foo (1234)">
+						{({ searchText }) => (
+							<OptionCols col1="1234" col2="Foo" textMatch={searchText} />
+						)}
+					</SearchableSelect.Option>
+
+					<SearchableSelect.Option filterText="Bar" Selected="Bar (2345)">
+						{({ searchText }) => (
+							<OptionCols col1="2345" col2="Bar" textMatch={searchText} />
+						)}
+					</SearchableSelect.Option>
+
+					<SearchableSelect.Option filterText="Baz" Selected="Baz (3456)">
+						{({ searchText }) => (
+							<OptionCols col1="3456" col2="Baz" textMatch={searchText} />
+						)}
+					</SearchableSelect.Option>
+				</SearchableSelect.OptionGroup>
+			</SearchableSelect>
+		);
+	}
+}

--- a/docs/examples/SingleSelect.stories.js
+++ b/docs/examples/SingleSelect.stories.js
@@ -1,0 +1,17 @@
+import { storiesOf } from '@storybook/react';
+import { exampleStory } from '../../.storybook/lucid-docs-addon';
+
+import SingleSelect from '../../src/components/SingleSelect/SingleSelect';
+import WithFomattedOptionsExample from './SingleSelect/WithFormattedOptions';
+import withFomattedOptionsExampleCode from '!!raw-loader!./SingleSelect/WithFormattedOptions';
+
+storiesOf('SingleSelect', module).add(
+	'with formatted options',
+	exampleStory({
+		component: SingleSelect,
+		example: WithFomattedOptionsExample,
+		code: withFomattedOptionsExampleCode,
+		path: ['SingleSelect'],
+		options: { showAddonPanel: true },
+	})
+);

--- a/docs/examples/SingleSelect/WithFormattedOptions.js
+++ b/docs/examples/SingleSelect/WithFormattedOptions.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { SingleSelect } from '../../../src/index.js';
+
+const OptionCols = ({ col1, col2 }) => (
+	<div style={{ display: 'flex' }}>
+		<div style={{ width: 100 }}>{col1}</div>
+		<div>{col2}</div>
+	</div>
+);
+
+export default class extends React.Component {
+	render() {
+		return (
+			<SingleSelect>
+				<SingleSelect.OptionGroup>
+					<OptionCols col1="ID" col2="NAME" />
+
+					<SingleSelect.Option Selected="Foo (1234)">
+						<OptionCols col1="1234" col2="Foo" />
+					</SingleSelect.Option>
+
+					<SingleSelect.Option Selected="Bar (2345)">
+						<OptionCols col1="2345" col2="Bar" />
+					</SingleSelect.Option>
+
+					<SingleSelect.Option Selected="Baz (3456)">
+						<OptionCols col1="3456" col2="Baz" />
+					</SingleSelect.Option>
+				</SingleSelect.OptionGroup>
+			</SingleSelect>
+		);
+	}
+}

--- a/docs/examples/Underline.stories.js
+++ b/docs/examples/Underline.stories.js
@@ -1,0 +1,35 @@
+import { storiesOf } from '@storybook/react';
+import { exampleStory } from '../../.storybook/lucid-docs-addon';
+
+import Underline from '../../src/components/Underline/Underline';
+import WithDefaultsExample from './Underline/WithDefaults';
+import withDefaultsCode from '!!raw-loader!./Underline/WithDefaults';
+
+storiesOf('Underline', module).add(
+	'with defaults',
+	exampleStory({
+		component: Underline,
+		example: WithDefaultsExample,
+		code: withDefaultsCode,
+		path: ['Underline'],
+		options: { showAddonPanel: true },
+	})
+);
+
+/*
+ * This is the same as calling the `exampleStory` function above:
+
+import { withDescription, withProps, withCode } from '../../.storybook/lucid-docs-addon';
+
+storiesOf('Underline', module)
+	.add('with defaults',
+		withDescription(Underline)(
+			withProps(Underline)(
+				withCode(withDefaultsCode)(
+					WithDefaultsExample
+				)
+			)
+		)
+	);
+
+*/

--- a/docs/examples/Underline.stories.js
+++ b/docs/examples/Underline.stories.js
@@ -4,32 +4,39 @@ import { exampleStory } from '../../.storybook/lucid-docs-addon';
 import Underline from '../../src/components/Underline/Underline';
 import WithDefaultsExample from './Underline/WithDefaults';
 import withDefaultsCode from '!!raw-loader!./Underline/WithDefaults';
-
-storiesOf('Underline', module).add(
-	'with defaults',
-	exampleStory({
-		component: Underline,
-		example: WithDefaultsExample,
-		code: withDefaultsCode,
-		path: ['Underline'],
-		options: { showAddonPanel: true },
-	})
-);
-
-/*
- * This is the same as calling the `exampleStory` function above:
-
-import { withDescription, withProps, withCode } from '../../.storybook/lucid-docs-addon';
+import WithStringMatchExample from './Underline/WithStringMatch';
+import withStringMatchCode from '!!raw-loader!./Underline/WithStringMatch';
+import WithRegexMatchExample from './Underline/WithRegexMatch';
+import withRegexMatchCode from '!!raw-loader!./Underline/WithRegexMatch';
 
 storiesOf('Underline', module)
-	.add('with defaults',
-		withDescription(Underline)(
-			withProps(Underline)(
-				withCode(withDefaultsCode)(
-					WithDefaultsExample
-				)
-			)
-		)
+	.add(
+		'with defaults',
+		exampleStory({
+			component: Underline,
+			example: WithDefaultsExample,
+			code: withDefaultsCode,
+			path: ['Underline'],
+			options: { showAddonPanel: true },
+		})
+	)
+	.add(
+		'with string match',
+		exampleStory({
+			component: Underline,
+			example: WithStringMatchExample,
+			code: withStringMatchCode,
+			path: ['Underline'],
+			options: { showAddonPanel: true },
+		})
+	)
+	.add(
+		'with regex match',
+		exampleStory({
+			component: Underline,
+			example: WithRegexMatchExample,
+			code: withRegexMatchCode,
+			path: ['Underline'],
+			options: { showAddonPanel: true },
+		})
 	);
-
-*/

--- a/docs/examples/Underline/WithDefaults.js
+++ b/docs/examples/Underline/WithDefaults.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Underline } from '../../../src/index.js';
+
+export default class extends React.Component {
+	render() {
+		return <Underline />;
+	}
+}

--- a/docs/examples/Underline/WithRegexMatch.js
+++ b/docs/examples/Underline/WithRegexMatch.js
@@ -3,6 +3,6 @@ import { Underline } from '../../../src/index.js';
 
 export default class extends React.Component {
 	render() {
-		return <Underline>foo bar baz</Underline>;
+		return <Underline match={/foo?/i}>foo bar baz</Underline>;
 	}
 }

--- a/docs/examples/Underline/WithStringMatch.js
+++ b/docs/examples/Underline/WithStringMatch.js
@@ -3,6 +3,6 @@ import { Underline } from '../../../src/index.js';
 
 export default class extends React.Component {
 	render() {
-		return <Underline>foo bar baz</Underline>;
+		return <Underline match="bar">foo bar baz</Underline>;
 	}
 }

--- a/src/components/DropMenu/DropMenu.jsx
+++ b/src/components/DropMenu/DropMenu.jsx
@@ -283,7 +283,7 @@ const DropMenu = createClass({
 			statics: {
 				peek: {
 					description: `
-						Props that are passed through to the underling ContextMenu.
+						Props that are passed through to the underlying ContextMenu.
 					`,
 				},
 			},

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.jsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.jsx
@@ -67,7 +67,14 @@ const SearchableMultiSelect = createClass({
 				},
 			},
 			propName: 'Option',
-			propTypes: DropMenu.Option.propTypes,
+			propTypes: {
+				filterText: string`
+					Text used to filter options when searching. By default, this is the
+					text rendered in the Option, but it can be customized further with
+					this prop.
+				`,
+				...DropMenu.Option.propTypes,
+			},
 			components: {
 				Selected: createClass({
 					displayName: 'SearchableMultiSelect.Option.Selected',

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.jsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.jsx
@@ -69,6 +69,18 @@ const SearchableMultiSelect = createClass({
 			propName: 'Option',
 			propTypes: DropMenu.Option.propTypes,
 			components: {
+				Selected: createClass({
+					displayName: 'SearchableMultiSelect.Option.Selected',
+					statics: {
+						peek: {
+							description: `
+								Customizes the rendering of the Option label when it is
+								selected and is displayed .
+							`,
+						},
+					},
+					propName: 'Selected',
+				}),
 				Selection: createClass({
 					displayName: 'SearchableMultiSelect.Option.Selection',
 					propName: 'Selection',
@@ -100,6 +112,20 @@ const SearchableMultiSelect = createClass({
 			},
 			propName: 'OptionGroup',
 			propTypes: DropMenu.OptionGroup.propTypes,
+			components: {
+				Selected: createClass({
+					displayName: 'SearchableMultiSelect.OptionGroup.Selected',
+					statics: {
+						peek: {
+							description: `
+								Customizes the rendering of the OptionGroup label when it is
+								selected and is displayed.
+							`,
+						},
+					},
+					propName: 'Selected',
+				}),
+			},
 		}),
 
 		SelectionLabel: createClass({
@@ -368,7 +394,7 @@ const SearchableMultiSelect = createClass({
 		return (
 			<DropMenu.Option
 				key={'SearchableMultiSelectOption' + optionIndex}
-				{..._.omit(optionProps, 'children')}
+				{..._.omit(optionProps, ['children', 'Selected', 'filterText'])}
 				isHidden={!optionFilter(searchText, optionProps)}
 				isDisabled={optionProps.isDisabled || isLoading}
 			>
@@ -380,7 +406,9 @@ const SearchableMultiSelect = createClass({
 					<CheckboxLabeled.Label>
 						{_.isString(optionProps.children)
 							? this.renderUnderlinedChildren(optionProps.children, searchText)
-							: optionProps.children}
+							: _.isFunction(optionProps.children)
+								? React.createElement(optionProps.children, { searchText })
+								: optionProps.children}
 					</CheckboxLabeled.Label>
 				</CheckboxLabeled>
 			</DropMenu.Option>
@@ -435,7 +463,7 @@ const SearchableMultiSelect = createClass({
 			_.map(optionGroups, (optionGroupProps, optionGroupIndex) => (
 				<DropMenu.OptionGroup
 					key={'SearchableMultiSelectOptionGroup' + optionGroupIndex}
-					{..._.omit(optionGroupProps, 'children')}
+					{..._.omit(optionGroupProps, 'children', 'Selected')}
 				>
 					{optionGroupProps.children}
 					{_.map(optionGroupDataLookup[optionGroupIndex], this.renderOption)}
@@ -577,6 +605,13 @@ const SearchableMultiSelect = createClass({
 									({ optionIndex }) => _.includes(selectedIndices, optionIndex)
 								);
 								if (!_.isEmpty(selectedGroupedOptions)) {
+									const selectedOptionGroupChildren = _.get(
+										getFirst(
+											optionGroups[optionGroupIndex],
+											SearchableMultiSelect.OptionGroup.Selected
+										),
+										'props.children'
+									);
 									return (
 										<Selection
 											className={cx('&-Selection-group')}
@@ -587,12 +622,14 @@ const SearchableMultiSelect = createClass({
 											kind="container"
 										>
 											<Selection.Label>
-												{_.first(
-													rejectTypes(
-														optionGroups[optionGroupIndex].children,
-														SearchableMultiSelect.Option
-													)
-												)}
+												{!_.isNil(selectedOptionGroupChildren)
+													? selectedOptionGroupChildren
+													: _.first(
+															rejectTypes(
+																optionGroups[optionGroupIndex].children,
+																SearchableMultiSelect.Option
+															)
+														)}
 											</Selection.Label>
 											{_.map(
 												selectedGroupedOptions,
@@ -613,7 +650,16 @@ const SearchableMultiSelect = createClass({
 															onRemove={this.handleSelectionRemove}
 														>
 															<Selection.Label>
-																{optionProps.children}
+																{_.get(
+																	getFirst(
+																		optionProps,
+																		SearchableMultiSelect.Option.Selected
+																	),
+																	'props.children'
+																) ||
+																	(_.isFunction(optionProps.children)
+																		? React.createElement(optionProps.children)
+																		: optionProps.children)}
 															</Selection.Label>
 														</Selection>
 													);
@@ -644,7 +690,18 @@ const SearchableMultiSelect = createClass({
 										responsiveMode={responsiveMode}
 										onRemove={this.handleSelectionRemove}
 									>
-										<Selection.Label>{optionProps.children}</Selection.Label>
+										<Selection.Label>
+											{_.get(
+												getFirst(
+													optionProps,
+													SearchableMultiSelect.Option.Selected
+												),
+												'props.children'
+											) ||
+												(_.isFunction(optionProps.children)
+													? React.createElement(optionProps.children)
+													: optionProps.children)}
+										</Selection.Label>
 									</Selection>
 								);
 							}

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.jsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.jsx
@@ -5,7 +5,7 @@ import { common } from '../../util/generic-tests';
 import { SearchableMultiSelectDumb as SearchableMultiSelect } from './SearchableMultiSelect';
 import { DropMenuDumb as DropMenu } from '../DropMenu/DropMenu';
 
-const { Option } = SearchableMultiSelect;
+const { Option, OptionGroup } = SearchableMultiSelect;
 
 describe('SearchableMultiSelect', () => {
 	common(SearchableMultiSelect, {
@@ -232,6 +232,105 @@ describe('SearchableMultiSelect', () => {
 
 				expect(onSelect).toHaveBeenCalledWith([1]);
 			});
+		});
+	});
+
+	describe('custom formatting', () => {
+		it('should render Option.Selected in the SelectedItems area', () => {
+			expect(
+				shallow(
+					<SearchableMultiSelect selectedIndices={[1, 2]}>
+						<Option name="OptionA" Selected="option a">
+							<div style={{ display: 'flex' }}>
+								<div style={{ width: 100 }}>id</div>
+								<div>option a</div>
+							</div>
+						</Option>
+						<Option name="OptionB" Selected="option b">
+							<div style={{ display: 'flex' }}>
+								<div style={{ width: 100 }}>id</div>
+								<div>option b</div>
+							</div>
+						</Option>
+						<Option name="OptionC" Selected="option c">
+							<div style={{ display: 'flex' }}>
+								<div style={{ width: 100 }}>id</div>
+								<div>option c</div>
+							</div>
+						</Option>
+					</SearchableMultiSelect>
+				)
+			).toMatchSnapshot();
+		});
+
+		it('should render OptionGroup.Selected in the SelectedItems area', () => {
+			expect(
+				shallow(
+					<SearchableMultiSelect selectedIndices={[1, 2]}>
+						<OptionGroup Selected="Selected Foo">
+							Foo bar baz
+							<Option name="OptionA" Selected="option a">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option a</div>
+								</div>
+							</Option>
+							<Option name="OptionB" Selected="option b">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option b</div>
+								</div>
+							</Option>
+							<Option name="OptionC" Selected="option c">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option c</div>
+								</div>
+							</Option>
+						</OptionGroup>
+					</SearchableMultiSelect>
+				)
+			).toMatchSnapshot();
+		});
+
+		it('should render Option child function by passing in {searchText}, setting filterText on each option and using a custom optionFilter', () => {
+			const optionFilter = (searchText, { filterText }) => {
+				if (filterText) {
+					return new RegExp(_.escapeRegExp(searchText), 'i').test(filterText);
+				}
+				return true;
+			};
+
+			expect(
+				shallow(
+					<SearchableMultiSelect optionFilter={optionFilter} searchText="tion">
+						<Option name="OptionA" Selected="option a" filterText="option a">
+							{({ searchText }) => (
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>{searchText}</div>
+									<div>option a</div>
+								</div>
+							)}
+						</Option>
+						<Option name="OptionB" Selected="option b" filterText="option b">
+							{({ searchText }) => (
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>{searchText}</div>
+									<div>option b</div>
+								</div>
+							)}
+						</Option>
+						<Option name="OptionC" Selected="option c" filterText="option c">
+							{({ searchText }) => (
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>{searchText}</div>
+									<div>option c</div>
+								</div>
+							)}
+						</Option>
+					</SearchableMultiSelect>
+				)
+			).toMatchSnapshot();
 		});
 	});
 });

--- a/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.jsx.snap
+++ b/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.jsx.snap
@@ -2715,3 +2715,669 @@ exports[`SearchableMultiSelect [common] example testing should match snapshot(s)
   </DropMenu>
 </div>
 `;
+
+exports[`SearchableMultiSelect custom formatting should render Option child function by passing in {searchText}, setting filterText on each option and using a custom optionFilter 1`] = `
+<div
+  className="lucid-SearchableMultiSelect"
+>
+  <DropMenu
+    ContextMenu={
+      Object {
+        "alignmentOffset": -13,
+        "directonOffset": -1,
+        "minWidthOffset": -28,
+      }
+    }
+    alignment="start"
+    className="lucid-SearchableMultiSelect-DropMenu"
+    direction="down"
+    flyOutStyle={
+      Object {
+        "maxHeight": "18em",
+      }
+    }
+    focusedIndex={null}
+    isDisabled={false}
+    isExpanded={false}
+    onCollapse={[Function]}
+    onExpand={[Function]}
+    onFocusNext={[Function]}
+    onFocusOption={[Function]}
+    onFocusPrev={[Function]}
+    onSelect={[Function]}
+    optionContainerStyle={Object {}}
+    selectedIndices={null}
+  >
+    <DropMenu.Control>
+      <SearchField
+        className="lucid-SearchableMultiSelect-search"
+        debounceLevel={500}
+        isDisabled={false}
+        onChange={[Function]}
+        onChangeDebounced={[Function]}
+        onSubmit={[Function]}
+        value="tion"
+      />
+    </DropMenu.Control>
+    <DropMenu.FixedOption
+      className="lucid-SearchableMultiSelect-Option-select-all"
+      isDisabled={false}
+      isHidden={true}
+      isWrapped={true}
+      key="SearchableMultiSelectOption-select-all"
+    >
+      <CheckboxLabeled
+        Label="Select All"
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={false}
+        isSelected={false}
+        onSelect={[Function]}
+      />
+    </DropMenu.FixedOption>
+    <DropMenu.Option
+      isDisabled={false}
+      isHidden={false}
+      isWrapped={true}
+      key="SearchableMultiSelectOption0"
+      name="OptionA"
+    >
+      <CheckboxLabeled
+        callbackId={0}
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={false}
+        isSelected={false}
+        onSelect={[Function]}
+      >
+        <CheckboxLabeled.Label>
+          <Component
+            searchText="tion"
+          />
+        </CheckboxLabeled.Label>
+      </CheckboxLabeled>
+    </DropMenu.Option>
+    <DropMenu.Option
+      isDisabled={false}
+      isHidden={false}
+      isWrapped={true}
+      key="SearchableMultiSelectOption1"
+      name="OptionB"
+    >
+      <CheckboxLabeled
+        callbackId={1}
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={false}
+        isSelected={false}
+        onSelect={[Function]}
+      >
+        <CheckboxLabeled.Label>
+          <Component
+            searchText="tion"
+          />
+        </CheckboxLabeled.Label>
+      </CheckboxLabeled>
+    </DropMenu.Option>
+    <DropMenu.Option
+      isDisabled={false}
+      isHidden={false}
+      isWrapped={true}
+      key="SearchableMultiSelectOption2"
+      name="OptionC"
+    >
+      <CheckboxLabeled
+        callbackId={2}
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={false}
+        isSelected={false}
+        onSelect={[Function]}
+      >
+        <CheckboxLabeled.Label>
+          <Component
+            searchText="tion"
+          />
+        </CheckboxLabeled.Label>
+      </CheckboxLabeled>
+    </DropMenu.Option>
+  </DropMenu>
+</div>
+`;
+
+exports[`SearchableMultiSelect custom formatting should render Option.Selected in the SelectedItems area 1`] = `
+<div
+  className="lucid-SearchableMultiSelect"
+>
+  <DropMenu
+    ContextMenu={
+      Object {
+        "alignmentOffset": -13,
+        "directonOffset": -1,
+        "minWidthOffset": -28,
+      }
+    }
+    alignment="start"
+    className="lucid-SearchableMultiSelect-DropMenu"
+    direction="down"
+    flyOutStyle={
+      Object {
+        "maxHeight": "18em",
+      }
+    }
+    focusedIndex={null}
+    isDisabled={false}
+    isExpanded={false}
+    onCollapse={[Function]}
+    onExpand={[Function]}
+    onFocusNext={[Function]}
+    onFocusOption={[Function]}
+    onFocusPrev={[Function]}
+    onSelect={[Function]}
+    optionContainerStyle={Object {}}
+    selectedIndices={null}
+  >
+    <DropMenu.Control>
+      <SearchField
+        className="lucid-SearchableMultiSelect-search"
+        debounceLevel={500}
+        isDisabled={false}
+        onChange={[Function]}
+        onChangeDebounced={[Function]}
+        onSubmit={[Function]}
+        value=""
+      />
+    </DropMenu.Control>
+    <DropMenu.FixedOption
+      className="lucid-SearchableMultiSelect-Option-select-all"
+      isDisabled={false}
+      isHidden={true}
+      isWrapped={true}
+      key="SearchableMultiSelectOption-select-all"
+    >
+      <CheckboxLabeled
+        Label="Select All"
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={true}
+        isSelected={false}
+        onSelect={[Function]}
+      />
+    </DropMenu.FixedOption>
+    <DropMenu.Option
+      isDisabled={false}
+      isHidden={false}
+      isWrapped={true}
+      key="SearchableMultiSelectOption0"
+      name="OptionA"
+    >
+      <CheckboxLabeled
+        callbackId={0}
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={false}
+        isSelected={false}
+        onSelect={[Function]}
+      >
+        <CheckboxLabeled.Label>
+          <div
+            style={
+              Object {
+                "display": "flex",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": 100,
+                }
+              }
+            >
+              id
+            </div>
+            <div>
+              option a
+            </div>
+          </div>
+        </CheckboxLabeled.Label>
+      </CheckboxLabeled>
+    </DropMenu.Option>
+    <DropMenu.Option
+      isDisabled={false}
+      isHidden={false}
+      isWrapped={true}
+      key="SearchableMultiSelectOption1"
+      name="OptionB"
+    >
+      <CheckboxLabeled
+        callbackId={1}
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={false}
+        isSelected={true}
+        onSelect={[Function]}
+      >
+        <CheckboxLabeled.Label>
+          <div
+            style={
+              Object {
+                "display": "flex",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": 100,
+                }
+              }
+            >
+              id
+            </div>
+            <div>
+              option b
+            </div>
+          </div>
+        </CheckboxLabeled.Label>
+      </CheckboxLabeled>
+    </DropMenu.Option>
+    <DropMenu.Option
+      isDisabled={false}
+      isHidden={false}
+      isWrapped={true}
+      key="SearchableMultiSelectOption2"
+      name="OptionC"
+    >
+      <CheckboxLabeled
+        callbackId={2}
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={false}
+        isSelected={true}
+        onSelect={[Function]}
+      >
+        <CheckboxLabeled.Label>
+          <div
+            style={
+              Object {
+                "display": "flex",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "width": 100,
+                }
+              }
+            >
+              id
+            </div>
+            <div>
+              option c
+            </div>
+          </div>
+        </CheckboxLabeled.Label>
+      </CheckboxLabeled>
+    </DropMenu.Option>
+  </DropMenu>
+  <Selection
+    className="lucid-SearchableMultiSelect-Selection-section"
+    hasBackground={true}
+    isBold={true}
+    isRemovable={true}
+    kind="container"
+    onRemove={[Function]}
+    responsiveMode="large"
+  >
+    <Selection.Label>
+      Selected
+    </Selection.Label>
+    <Selection
+      callbackId={1}
+      hasBackground={false}
+      isBold={false}
+      isRemovable={true}
+      key="1"
+      kind="default"
+      onRemove={[Function]}
+      responsiveMode="large"
+    >
+      <Selection.Label>
+        option b
+      </Selection.Label>
+    </Selection>
+    <Selection
+      callbackId={2}
+      hasBackground={false}
+      isBold={false}
+      isRemovable={true}
+      key="2"
+      kind="default"
+      onRemove={[Function]}
+      responsiveMode="large"
+    >
+      <Selection.Label>
+        option c
+      </Selection.Label>
+    </Selection>
+  </Selection>
+</div>
+`;
+
+exports[`SearchableMultiSelect custom formatting should render OptionGroup.Selected in the SelectedItems area 1`] = `
+<div
+  className="lucid-SearchableMultiSelect"
+>
+  <DropMenu
+    ContextMenu={
+      Object {
+        "alignmentOffset": -13,
+        "directonOffset": -1,
+        "minWidthOffset": -28,
+      }
+    }
+    alignment="start"
+    className="lucid-SearchableMultiSelect-DropMenu"
+    direction="down"
+    flyOutStyle={
+      Object {
+        "maxHeight": "18em",
+      }
+    }
+    focusedIndex={null}
+    isDisabled={false}
+    isExpanded={false}
+    onCollapse={[Function]}
+    onExpand={[Function]}
+    onFocusNext={[Function]}
+    onFocusOption={[Function]}
+    onFocusPrev={[Function]}
+    onSelect={[Function]}
+    optionContainerStyle={Object {}}
+    selectedIndices={null}
+  >
+    <DropMenu.Control>
+      <SearchField
+        className="lucid-SearchableMultiSelect-search"
+        debounceLevel={500}
+        isDisabled={false}
+        onChange={[Function]}
+        onChangeDebounced={[Function]}
+        onSubmit={[Function]}
+        value=""
+      />
+    </DropMenu.Control>
+    <DropMenu.FixedOption
+      className="lucid-SearchableMultiSelect-Option-select-all"
+      isDisabled={false}
+      isHidden={true}
+      isWrapped={true}
+      key="SearchableMultiSelectOption-select-all"
+    >
+      <CheckboxLabeled
+        Label="Select All"
+        className="lucid-SearchableMultiSelect-CheckboxLabeled"
+        isDisabled={false}
+        isIndeterminate={true}
+        isSelected={false}
+        onSelect={[Function]}
+      />
+    </DropMenu.FixedOption>
+    <DropMenu.OptionGroup
+      isHidden={false}
+      key="SearchableMultiSelectOptionGroup0"
+    >
+      Foo bar baz
+      <SearchableMultiSelect.Option
+        Selected="option a"
+        name="OptionA"
+      >
+        <div
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 100,
+              }
+            }
+          >
+            id
+          </div>
+          <div>
+            option a
+          </div>
+        </div>
+      </SearchableMultiSelect.Option>
+      <SearchableMultiSelect.Option
+        Selected="option b"
+        name="OptionB"
+      >
+        <div
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 100,
+              }
+            }
+          >
+            id
+          </div>
+          <div>
+            option b
+          </div>
+        </div>
+      </SearchableMultiSelect.Option>
+      <SearchableMultiSelect.Option
+        Selected="option c"
+        name="OptionC"
+      >
+        <div
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "width": 100,
+              }
+            }
+          >
+            id
+          </div>
+          <div>
+            option c
+          </div>
+        </div>
+      </SearchableMultiSelect.Option>
+      <DropMenu.Option
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+        key="SearchableMultiSelectOption0"
+        name="OptionA"
+      >
+        <CheckboxLabeled
+          callbackId={0}
+          className="lucid-SearchableMultiSelect-CheckboxLabeled"
+          isDisabled={false}
+          isIndeterminate={false}
+          isSelected={false}
+          onSelect={[Function]}
+        >
+          <CheckboxLabeled.Label>
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+              >
+                id
+              </div>
+              <div>
+                option a
+              </div>
+            </div>
+          </CheckboxLabeled.Label>
+        </CheckboxLabeled>
+      </DropMenu.Option>
+      <DropMenu.Option
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+        key="SearchableMultiSelectOption1"
+        name="OptionB"
+      >
+        <CheckboxLabeled
+          callbackId={1}
+          className="lucid-SearchableMultiSelect-CheckboxLabeled"
+          isDisabled={false}
+          isIndeterminate={false}
+          isSelected={true}
+          onSelect={[Function]}
+        >
+          <CheckboxLabeled.Label>
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+              >
+                id
+              </div>
+              <div>
+                option b
+              </div>
+            </div>
+          </CheckboxLabeled.Label>
+        </CheckboxLabeled>
+      </DropMenu.Option>
+      <DropMenu.Option
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+        key="SearchableMultiSelectOption2"
+        name="OptionC"
+      >
+        <CheckboxLabeled
+          callbackId={2}
+          className="lucid-SearchableMultiSelect-CheckboxLabeled"
+          isDisabled={false}
+          isIndeterminate={false}
+          isSelected={true}
+          onSelect={[Function]}
+        >
+          <CheckboxLabeled.Label>
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+              >
+                id
+              </div>
+              <div>
+                option c
+              </div>
+            </div>
+          </CheckboxLabeled.Label>
+        </CheckboxLabeled>
+      </DropMenu.Option>
+    </DropMenu.OptionGroup>
+  </DropMenu>
+  <Selection
+    className="lucid-SearchableMultiSelect-Selection-section"
+    hasBackground={true}
+    isBold={true}
+    isRemovable={true}
+    kind="container"
+    onRemove={[Function]}
+    responsiveMode="large"
+  >
+    <Selection.Label>
+      Selected
+    </Selection.Label>
+    <Selection
+      className="lucid-SearchableMultiSelect-Selection-group"
+      hasBackground={false}
+      isBold={true}
+      isRemovable={false}
+      key="optionGroup-0"
+      kind="container"
+      onRemove={[Function]}
+      responsiveMode="large"
+    >
+      <Selection.Label>
+        Selected Foo
+      </Selection.Label>
+      <Selection
+        callbackId={1}
+        hasBackground={false}
+        isBold={false}
+        isRemovable={true}
+        key="1"
+        kind="default"
+        onRemove={[Function]}
+        responsiveMode="large"
+      >
+        <Selection.Label>
+          option b
+        </Selection.Label>
+      </Selection>
+      <Selection
+        callbackId={2}
+        hasBackground={false}
+        isBold={false}
+        isRemovable={true}
+        key="2"
+        kind="default"
+        onRemove={[Function]}
+        responsiveMode="large"
+      >
+        <Selection.Label>
+          option c
+        </Selection.Label>
+      </Selection>
+    </Selection>
+  </Selection>
+</div>
+`;

--- a/src/components/SearchableSelect/SearchableSelect.jsx
+++ b/src/components/SearchableSelect/SearchableSelect.jsx
@@ -64,7 +64,27 @@ const SearchableSelect = createClass({
 				},
 			},
 			propName: 'Option',
-			propTypes: DropMenu.Option.propTypes,
+			propTypes: {
+				Selected: any`
+					Customizes the rendering of the Option when it is selected and is
+					displayed instead of the Placeholder.
+				`,
+				...DropMenu.Option.propTypes,
+			},
+			components: {
+				Selected: createClass({
+					displayName: 'SearchableSelect.Option.Selected',
+					statics: {
+						peek: {
+							description: `
+								Customizes the rendering of the Option when it is selected
+								and is displayed instead of the Placeholder.
+							`,
+						},
+					},
+					propName: 'Selected',
+				}),
+			},
 		}),
 		OptionGroup: createClass({
 			displayName: 'SearchableSelect.OptionGroup',
@@ -263,7 +283,9 @@ const SearchableSelect = createClass({
 				>
 					{_.isString(optionProps.children)
 						? this.renderUnderlinedChildren(optionProps.children, searchText)
-						: optionProps.children}
+						: _.isFunction(optionProps.children)
+							? React.createElement(optionProps.children, { searchText })
+							: optionProps.children}
 				</DropMenu.Option>
 			);
 		}
@@ -271,9 +293,13 @@ const SearchableSelect = createClass({
 		return (
 			<DropMenu.Option
 				key={'SearchableSelectOption' + optionIndex}
-				{...optionProps}
+				{..._.omit(optionProps, ['children'])}
 				isDisabled={optionProps.isDisabled || isLoading}
-			/>
+			>
+				{_.isFunction(optionProps.children)
+					? React.createElement(optionProps.children, { searchText })
+					: optionProps.children}
+			</DropMenu.Option>
 		);
 	},
 
@@ -404,7 +430,17 @@ const SearchableSelect = createClass({
 							)}
 						>
 							{isItemSelected
-								? flattenedOptionsData[selectedIndex].optionProps.children
+								? _.get(
+										getFirst(
+											flattenedOptionsData[selectedIndex].optionProps,
+											SearchableSelect.Option.Selected
+										),
+										'props.children'
+									) ||
+									(Children =>
+										_.isFunction(Children) ? <Children /> : Children)(
+										flattenedOptionsData[selectedIndex].optionProps.children
+									)
 								: placeholder}
 						</span>
 						<CaretIcon direction={isExpanded ? direction : 'down'} size={8} />

--- a/src/components/SearchableSelect/SearchableSelect.jsx
+++ b/src/components/SearchableSelect/SearchableSelect.jsx
@@ -69,6 +69,11 @@ const SearchableSelect = createClass({
 					Customizes the rendering of the Option when it is selected and is
 					displayed instead of the Placeholder.
 				`,
+				filterText: string`
+					Text used to filter options when searching. By default, this is the
+					text rendered in the Option, but it can be customized further with
+					this prop.
+				`,
 				...DropMenu.Option.propTypes,
 			},
 			components: {
@@ -277,7 +282,7 @@ const SearchableSelect = createClass({
 			return (
 				<DropMenu.Option
 					isDisabled={isLoading}
-					{..._.omit(optionProps, ['children'])}
+					{..._.omit(optionProps, ['children', 'Selected', 'filterText'])}
 					isHidden={!optionFilter(searchText, optionProps)}
 					key={'SearchableSelectOption' + optionIndex}
 				>
@@ -293,7 +298,7 @@ const SearchableSelect = createClass({
 		return (
 			<DropMenu.Option
 				key={'SearchableSelectOption' + optionIndex}
-				{..._.omit(optionProps, ['children'])}
+				{..._.omit(optionProps, ['children', 'Selected', 'filterText'])}
 				isDisabled={optionProps.isDisabled || isLoading}
 			>
 				{_.isFunction(optionProps.children)

--- a/src/components/SearchableSelect/SearchableSelect.spec.jsx
+++ b/src/components/SearchableSelect/SearchableSelect.spec.jsx
@@ -500,6 +500,75 @@ describe('SearchableSelect', () => {
 					})
 				);
 			});
+
+			it('should render Option.Selected in the Placeholder area', () => {
+				expect(
+					shallow(
+						<SearchableSelect selectedIndex={1}>
+							<Placeholder>select one</Placeholder>
+							<Option name="OptionA" Selected="option a">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option a</div>
+								</div>
+							</Option>
+							<Option name="OptionB" Selected="option b">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option b</div>
+								</div>
+							</Option>
+							<Option name="OptionC" Selected="option c">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option c</div>
+								</div>
+							</Option>
+						</SearchableSelect>
+					)
+				).toMatchSnapshot();
+			});
+
+			it('should render Option child function by passing in {searchText}, setting filterText on each option and using a custom optionFilter', () => {
+				const optionFilter = (searchText, { filterText }) => {
+					if (filterText) {
+						return new RegExp(_.escapeRegExp(searchText), 'i').test(filterText);
+					}
+					return true;
+				};
+
+				expect(
+					shallow(
+						<SearchableSelect optionFilter={optionFilter} searchText="tion">
+							<Placeholder>select one</Placeholder>
+							<Option name="OptionA" Selected="option a" filterText="option a">
+								{({ searchText }) => (
+									<div style={{ display: 'flex' }}>
+										<div style={{ width: 100 }}>{searchText}</div>
+										<div>option a</div>
+									</div>
+								)}
+							</Option>
+							<Option name="OptionB" Selected="option b" filterText="option b">
+								{({ searchText }) => (
+									<div style={{ display: 'flex' }}>
+										<div style={{ width: 100 }}>{searchText}</div>
+										<div>option b</div>
+									</div>
+								)}
+							</Option>
+							<Option name="OptionC" Selected="option c" filterText="option c">
+								{({ searchText }) => (
+									<div style={{ display: 'flex' }}>
+										<div style={{ width: 100 }}>{searchText}</div>
+										<div>option c</div>
+									</div>
+								)}
+							</Option>
+						</SearchableSelect>
+					)
+				).toMatchSnapshot();
+			});
 		});
 
 		describe('OptionGroup', () => {

--- a/src/components/SearchableSelect/__snapshots__/SearchableSelect.spec.jsx.snap
+++ b/src/components/SearchableSelect/__snapshots__/SearchableSelect.spec.jsx.snap
@@ -1451,3 +1451,259 @@ exports[`SearchableSelect [common] example testing should match snapshot(s) for 
   </DropMenu.Option>
 </DropMenu>
 `;
+
+exports[`SearchableSelect child elements Option should render Option child function by passing in {searchText}, setting filterText on each option and using a custom optionFilter 1`] = `
+<DropMenu
+  ContextMenu={
+    Object {
+      "alignment": "start",
+      "direction": "down",
+      "directonOffset": 0,
+      "getAlignmentOffset": [Function],
+      "isExpanded": true,
+      "minWidthOffset": 0,
+      "onClickOut": null,
+      "portalId": null,
+    }
+  }
+  alignment="start"
+  className="lucid-SearchableSelect"
+  direction="down"
+  flyOutStyle={
+    Object {
+      "maxHeight": "18em",
+    }
+  }
+  focusedIndex={null}
+  isDisabled={false}
+  isExpanded={false}
+  onCollapse={[Function]}
+  onExpand={[Function]}
+  onFocusNext={[Function]}
+  onFocusOption={[Function]}
+  onFocusPrev={[Function]}
+  onSelect={[Function]}
+  optionContainerStyle={Object {}}
+  selectedIndices={Array []}
+>
+  <DropMenu.Control>
+    <div
+      className="lucid-SearchableSelect-Control"
+      tabIndex={0}
+    >
+      <span
+        className="lucid-SearchableSelect-Control-content"
+      >
+        select one
+      </span>
+      <CaretIcon
+        direction="down"
+        size={8}
+        viewBox="0 3 16 8"
+      />
+    </div>
+  </DropMenu.Control>
+  <DropMenu.Header
+    className="lucid-SearchableSelect-Search-container"
+  >
+    <SearchField
+      debounceLevel={500}
+      isDisabled={false}
+      onChange={[Function]}
+      onChangeDebounced={[Function]}
+      onSubmit={[Function]}
+      value="tion"
+    />
+  </DropMenu.Header>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SearchableSelectOption0"
+    name="OptionA"
+  >
+    <Component
+      searchText="tion"
+    />
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SearchableSelectOption1"
+    name="OptionB"
+  >
+    <Component
+      searchText="tion"
+    />
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SearchableSelectOption2"
+    name="OptionC"
+  >
+    <Component
+      searchText="tion"
+    />
+  </DropMenu.Option>
+</DropMenu>
+`;
+
+exports[`SearchableSelect child elements Option should render Option.Selected in the Placeholder area 1`] = `
+<DropMenu
+  ContextMenu={
+    Object {
+      "alignment": "start",
+      "direction": "down",
+      "directonOffset": 0,
+      "getAlignmentOffset": [Function],
+      "isExpanded": true,
+      "minWidthOffset": 0,
+      "onClickOut": null,
+      "portalId": null,
+    }
+  }
+  alignment="start"
+  className="lucid-SearchableSelect"
+  direction="down"
+  flyOutStyle={
+    Object {
+      "maxHeight": "18em",
+    }
+  }
+  focusedIndex={null}
+  isDisabled={false}
+  isExpanded={false}
+  onCollapse={[Function]}
+  onExpand={[Function]}
+  onFocusNext={[Function]}
+  onFocusOption={[Function]}
+  onFocusPrev={[Function]}
+  onSelect={[Function]}
+  optionContainerStyle={Object {}}
+  selectedIndices={
+    Array [
+      1,
+    ]
+  }
+>
+  <DropMenu.Control>
+    <div
+      className="lucid-SearchableSelect-Control lucid-SearchableSelect-Control-is-highlighted lucid-SearchableSelect-Control-is-selected"
+      tabIndex={0}
+    >
+      <span
+        className="lucid-SearchableSelect-Control-content"
+      >
+        option b
+      </span>
+      <CaretIcon
+        direction="down"
+        size={8}
+        viewBox="0 3 16 8"
+      />
+    </div>
+  </DropMenu.Control>
+  <DropMenu.Header
+    className="lucid-SearchableSelect-Search-container"
+  >
+    <SearchField
+      debounceLevel={500}
+      isDisabled={false}
+      onChange={[Function]}
+      onChangeDebounced={[Function]}
+      onSubmit={[Function]}
+      value=""
+    />
+  </DropMenu.Header>
+  <DropMenu.NullOption>
+    select one
+  </DropMenu.NullOption>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SearchableSelectOption0"
+    name="OptionA"
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": 100,
+          }
+        }
+      >
+        id
+      </div>
+      <div>
+        option a
+      </div>
+    </div>
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SearchableSelectOption1"
+    name="OptionB"
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": 100,
+          }
+        }
+      >
+        id
+      </div>
+      <div>
+        option b
+      </div>
+    </div>
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SearchableSelectOption2"
+    name="OptionC"
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": 100,
+          }
+        }
+      >
+        id
+      </div>
+      <div>
+        option c
+      </div>
+    </div>
+  </DropMenu.Option>
+</DropMenu>
+`;

--- a/src/components/SingleSelect/SingleSelect.jsx
+++ b/src/components/SingleSelect/SingleSelect.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'react-peek/prop-types';
 import _ from 'lodash';
 import { lucidClassNames } from '../../util/style-helpers';
-import { createClass, findTypes } from '../../util/component-types';
+import { createClass, findTypes, getFirst } from '../../util/component-types';
 import { buildHybridComponent } from '../../util/state-management';
 import * as reducers from './SingleSelect.reducers';
 import { DropMenuDumb as DropMenu } from '../DropMenu/DropMenu';
@@ -61,7 +61,27 @@ const SingleSelect = createClass({
 				},
 			},
 			propName: 'Option',
-			propTypes: DropMenu.Option.propTypes,
+			propTypes: {
+				Selected: any`
+					Customizes the rendering of the Option when it is selected and is
+					displayed instead of the Placeholder.
+				`,
+				...DropMenu.Option.propTypes,
+			},
+			components: {
+				Selected: createClass({
+					displayName: 'SingleSelect.Option.Selected',
+					statics: {
+						peek: {
+							description: `
+								Customizes the rendering of the Option when it is selected
+								and is displayed instead of the Placeholder.
+							`,
+						},
+					},
+					propName: 'Selected',
+				}),
+			},
 		}),
 		OptionGroup: createClass({
 			displayName: 'SingleSelect.OptionGroup',
@@ -241,7 +261,13 @@ const SingleSelect = createClass({
 							)}
 						>
 							{isItemSelected
-								? flattenedOptionsData[selectedIndex].optionProps.children
+								? _.get(
+										getFirst(
+											flattenedOptionsData[selectedIndex].optionProps,
+											SingleSelect.Option.Selected
+										),
+										'props.children'
+									) || flattenedOptionsData[selectedIndex].optionProps.children
 								: placeholder}
 						</span>
 						<CaretIcon direction={isExpanded ? direction : 'down'} size={8} />
@@ -264,7 +290,7 @@ const SingleSelect = createClass({
 							({ optionProps, optionIndex }) => (
 								<DropMenu.Option
 									key={'SingleSelectOption' + optionIndex}
-									{...optionProps}
+									{..._.omit(optionProps, 'Selected')}
 								/>
 							)
 						)}
@@ -274,7 +300,7 @@ const SingleSelect = createClass({
 					_.map(ungroupedOptionData, ({ optionProps, optionIndex }) => (
 						<DropMenu.Option
 							key={'SingleSelectOption' + optionIndex}
-							{...optionProps}
+							{..._.omit(optionProps, 'Selected')}
 						/>
 					))
 				)}

--- a/src/components/SingleSelect/SingleSelect.spec.jsx
+++ b/src/components/SingleSelect/SingleSelect.spec.jsx
@@ -379,6 +379,34 @@ describe('SingleSelect', () => {
 					})
 				);
 			});
+
+			it('should render Option.Selected in the Placeholder area', () => {
+				expect(
+					shallow(
+						<SingleSelect selectedIndex={1}>
+							<Placeholder>select one</Placeholder>
+							<Option name="OptionA" Selected="option a">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option a</div>
+								</div>
+							</Option>
+							<Option name="OptionB" Selected="option b">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option b</div>
+								</div>
+							</Option>
+							<Option name="OptionC" Selected="option c">
+								<div style={{ display: 'flex' }}>
+									<div style={{ width: 100 }}>id</div>
+									<div>option c</div>
+								</div>
+							</Option>
+						</SingleSelect>
+					)
+				).toMatchSnapshot();
+			});
 		});
 
 		describe('OptionGroup', () => {

--- a/src/components/SingleSelect/__snapshots__/SingleSelect.spec.jsx.snap
+++ b/src/components/SingleSelect/__snapshots__/SingleSelect.spec.jsx.snap
@@ -2100,3 +2100,147 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 11.s
   </DropMenu.Option>
 </DropMenu>
 `;
+
+exports[`SingleSelect child elements Option should render Option.Selected in the Placeholder area 1`] = `
+<DropMenu
+  ContextMenu={
+    Object {
+      "alignment": "start",
+      "direction": "down",
+      "directonOffset": 0,
+      "getAlignmentOffset": [Function],
+      "isExpanded": true,
+      "minWidthOffset": 0,
+      "onClickOut": null,
+      "portalId": null,
+    }
+  }
+  alignment="start"
+  className="lucid-SingleSelect"
+  direction="down"
+  flyOutStyle={
+    Object {
+      "maxHeight": "18em",
+    }
+  }
+  focusedIndex={null}
+  isDisabled={false}
+  isExpanded={false}
+  onCollapse={[Function]}
+  onExpand={[Function]}
+  onFocusNext={[Function]}
+  onFocusOption={[Function]}
+  onFocusPrev={[Function]}
+  onSelect={[Function]}
+  selectedIndices={
+    Array [
+      1,
+    ]
+  }
+>
+  <DropMenu.Control>
+    <div
+      className="lucid-SingleSelect-Control lucid-SingleSelect-Control-is-highlighted lucid-SingleSelect-Control-is-selected"
+      tabIndex={0}
+    >
+      <span
+        className="lucid-SingleSelect-Control-content"
+      >
+        option b
+      </span>
+      <CaretIcon
+        direction="down"
+        size={8}
+        viewBox="0 3 16 8"
+      />
+    </div>
+  </DropMenu.Control>
+  <DropMenu.NullOption>
+    select one
+  </DropMenu.NullOption>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SingleSelectOption0"
+    name="OptionA"
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": 100,
+          }
+        }
+      >
+        id
+      </div>
+      <div>
+        option a
+      </div>
+    </div>
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SingleSelectOption1"
+    name="OptionB"
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": 100,
+          }
+        }
+      >
+        id
+      </div>
+      <div>
+        option b
+      </div>
+    </div>
+  </DropMenu.Option>
+  <DropMenu.Option
+    isDisabled={false}
+    isHidden={false}
+    isWrapped={true}
+    key="SingleSelectOption2"
+    name="OptionC"
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": 100,
+          }
+        }
+      >
+        id
+      </div>
+      <div>
+        option c
+      </div>
+    </div>
+  </DropMenu.Option>
+</DropMenu>
+`;

--- a/src/components/Underline/Underline.jsx
+++ b/src/components/Underline/Underline.jsx
@@ -10,7 +10,7 @@ const { node, string, instanceOf, oneOfType } = PropTypes;
 
 const matchAllRegexp = /^.*$/;
 
-const Underline = ({ className, children, match }) => {
+const Underline = ({ className, children, match, ...passThroughs }) => {
 	if (!_.isRegExp(match)) {
 		if (_.isString(match)) {
 			match = new RegExp(_.escapeRegExp(match), 'i');
@@ -21,7 +21,7 @@ const Underline = ({ className, children, match }) => {
 
 	if (!_.isString(children)) {
 		return (
-			<span className={cx('&', className)}>
+			<span className={cx('&', className)} {...passThroughs}>
 				<span
 					style={
 						match === matchAllRegexp ? { textDecoration: 'underline' } : null
@@ -36,7 +36,7 @@ const Underline = ({ className, children, match }) => {
 	const [pre, matchText, post] = partitionText(children, match);
 
 	return (
-		<span className="lucid-Underline">
+		<span className={cx('&', className)} {...passThroughs}>
 			{[
 				pre && <span key="pre">{pre}</span>,
 				matchText && (
@@ -50,6 +50,8 @@ const Underline = ({ className, children, match }) => {
 	);
 };
 
+Underline.displayName = 'Underline';
+
 Underline.peek = {
 	description: `
 		Underlines a portion of text that matches a given pattern
@@ -61,8 +63,13 @@ Underline.propTypes = {
 	className: string`
 		Appended to the component-specific class names set on the root element.
 	`,
-	children: node,
-	match: oneOfType([string, instanceOf(RegExp)]),
+	children: node`
+		Text to be partially or fully underlined. If non-text is passed as
+		children, it will not attempt to match the given pattern.
+	`,
+	match: oneOfType([string, instanceOf(RegExp)])`
+		The first match of the given pattern has the underline style applied to it.
+	`,
 };
 
 export default Underline;

--- a/src/components/Underline/Underline.jsx
+++ b/src/components/Underline/Underline.jsx
@@ -1,0 +1,68 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'react-peek/prop-types';
+import { partitionText } from '../../util/text-manipulation';
+import { lucidClassNames } from '../../util/style-helpers.js';
+
+const cx = lucidClassNames.bind('&-Underline');
+
+const { node, string, instanceOf, oneOfType } = PropTypes;
+
+const matchAllRegexp = /^.*$/;
+
+const Underline = ({ className, children, match }) => {
+	if (!_.isRegExp(match)) {
+		if (_.isString(match)) {
+			match = new RegExp(_.escapeRegExp(match), 'i');
+		} else {
+			match = matchAllRegexp;
+		}
+	}
+
+	if (!_.isString(children)) {
+		return (
+			<span className={cx('&', className)}>
+				<span
+					style={
+						match === matchAllRegexp ? { textDecoration: 'underline' } : null
+					}
+				>
+					{children}
+				</span>
+			</span>
+		);
+	}
+
+	const [pre, matchText, post] = partitionText(children, match);
+
+	return (
+		<span className="lucid-Underline">
+			{[
+				pre && <span key="pre">{pre}</span>,
+				matchText && (
+					<span key="match" style={{ textDecoration: 'underline' }}>
+						{matchText}
+					</span>
+				),
+				post && <span key="post">{post}</span>,
+			]}
+		</span>
+	);
+};
+
+Underline.peek = {
+	description: `
+		Underlines a portion of text that matches a given pattern
+	`,
+	categories: ['controls', 'selectors'],
+};
+
+Underline.propTypes = {
+	className: string`
+		Appended to the component-specific class names set on the root element.
+	`,
+	children: node,
+	match: oneOfType([string, instanceOf(RegExp)]),
+};
+
+export default Underline;

--- a/src/components/Underline/Underline.spec.jsx
+++ b/src/components/Underline/Underline.spec.jsx
@@ -6,4 +6,36 @@ import Underline from './Underline';
 
 describe('Underline', () => {
 	common(Underline);
+
+	it('should match snapshot for default props', () => {
+		expect(
+			shallow(<Underline />, {
+				disableLifecycleMethods: true,
+			})
+		).toMatchSnapshot();
+	});
+
+	it('should match snapshot for default props with children', () => {
+		expect(
+			shallow(<Underline>foo bar baz</Underline>, {
+				disableLifecycleMethods: true,
+			})
+		).toMatchSnapshot();
+	});
+
+	it('should match snapshot for string match with children', () => {
+		expect(
+			shallow(<Underline match="bar">foo bar baz</Underline>, {
+				disableLifecycleMethods: true,
+			})
+		).toMatchSnapshot();
+	});
+
+	it('should match snapshot for regex match with children', () => {
+		expect(
+			shallow(<Underline match={/foo?/i}>foo bar baz</Underline>, {
+				disableLifecycleMethods: true,
+			})
+		).toMatchSnapshot();
+	});
 });

--- a/src/components/Underline/Underline.spec.jsx
+++ b/src/components/Underline/Underline.spec.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { common } from '../../util/generic-tests';
+import Underline from './Underline';
+
+describe('Underline', () => {
+	common(Underline);
+});

--- a/src/components/Underline/__snapshots__/Underline.spec.jsx.snap
+++ b/src/components/Underline/__snapshots__/Underline.spec.jsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Underline should match snapshot for default props 1`] = `
+<span
+  className="lucid-Underline"
+>
+  <span
+    style={
+      Object {
+        "textDecoration": "underline",
+      }
+    }
+  />
+</span>
+`;
+
+exports[`Underline should match snapshot for default props with children 1`] = `
+<span
+  className="lucid-Underline"
+>
+  <span
+    key="match"
+    style={
+      Object {
+        "textDecoration": "underline",
+      }
+    }
+  >
+    foo bar baz
+  </span>
+</span>
+`;
+
+exports[`Underline should match snapshot for regex match with children 1`] = `
+<span
+  className="lucid-Underline"
+>
+  <span
+    key="match"
+    style={
+      Object {
+        "textDecoration": "underline",
+      }
+    }
+  >
+    foo
+  </span>
+  <span
+    key="post"
+  >
+     bar baz
+  </span>
+</span>
+`;
+
+exports[`Underline should match snapshot for string match with children 1`] = `
+<span
+  className="lucid-Underline"
+>
+  <span
+    key="pre"
+  >
+    foo 
+  </span>
+  <span
+    key="match"
+    style={
+      Object {
+        "textDecoration": "underline",
+      }
+    }
+  >
+    bar
+  </span>
+  <span
+    key="post"
+  >
+     baz
+  </span>
+</span>
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ import Tag from './components/Tag/Tag';
 import TextIcon from './components/Icon/TextIcon/TextIcon';
 import TextField from './components/TextField/TextField';
 import TextFieldValidated from './components/TextFieldValidated/TextFieldValidated';
-import Underline from './components/Icon/Underline/Underline';
+import Underline from './components/Underline/Underline';
 import UnlinkedIcon from './components/Icon/UnlinkedIcon/UnlinkedIcon';
 import UnlockedIcon from './components/Icon/UnlockedIcon/UnlockedIcon';
 import UploadIcon from './components/Icon/UploadIcon/UploadIcon';

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,7 @@ import Tag from './components/Tag/Tag';
 import TextIcon from './components/Icon/TextIcon/TextIcon';
 import TextField from './components/TextField/TextField';
 import TextFieldValidated from './components/TextFieldValidated/TextFieldValidated';
+import Underline from './components/Icon/Underline/Underline';
 import UnlinkedIcon from './components/Icon/UnlinkedIcon/UnlinkedIcon';
 import UnlockedIcon from './components/Icon/UnlockedIcon/UnlockedIcon';
 import UploadIcon from './components/Icon/UploadIcon/UploadIcon';
@@ -338,6 +339,7 @@ export {
 	TextFieldValidated,
 	ToolTip,
 	ToolTipDumb,
+	Underline,
 	UnlinkedIcon,
 	UnlockedIcon,
 	UploadIcon,

--- a/src/util/generic-tests.jsx
+++ b/src/util/generic-tests.jsx
@@ -128,13 +128,10 @@ export function common(
 		});
 
 		describe('child components', () => {
-			const childComponents = _.omit(Component.definition.statics, [
-				'_isPrivate',
-				'definition',
-				'propName',
-				'reducers',
-				'selectors',
-			]);
+			// Child components are all function types which start with a capital letter
+			const childComponents = _.pickBy(Component, (value, key) => {
+				return /^[A-Z]/.test(key) && _.isFunction(value);
+			});
 
 			describe('propNames in propTypes', () => {
 				_.flow(

--- a/src/util/text-manipulation.js
+++ b/src/util/text-manipulation.js
@@ -1,7 +1,21 @@
 import _ from 'lodash';
+import React from 'react';
 
 export function partitionText(text, pattern, length) {
-	const index = text.search(pattern);
+	let index;
+
+	if (length) {
+		index = text.search(pattern);
+	} else {
+		const result = pattern.exec(text);
+		if (result) {
+			length = result[0].length;
+			index = result.index;
+		} else {
+			length = 0;
+			index = -1;
+		}
+	}
 
 	if (index === -1) {
 		return ['', '', text];
@@ -25,7 +39,7 @@ export function getCombinedChildText(node) {
 		return node.children;
 	}
 
-	return node.children
+	return React.Children.toArray(node.children)
 		.filter(child => !_.isString(child))
 		.map(child => getCombinedChildText(child.props))
 		.reduce(

--- a/src/util/text-manipulation.spec.js
+++ b/src/util/text-manipulation.spec.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import assert from 'assert';
 import _ from 'lodash';
 
@@ -38,12 +39,14 @@ describe('text-manipulation', () => {
 
 	describe('#getCombinedChildText', () => {
 		it("should return '' if the passed in node has no children", () => {
-			assert.equal(getCombinedChildText({}), '');
+			const element = <div />;
+			assert.equal(getCombinedChildText(element.props), '');
 		});
 
 		it("should return the node's `children` if it is a string", () => {
 			const children = 'child';
-			assert.equal(getCombinedChildText({ children }), 'child');
+			const element = <div>child</div>;
+			assert.equal(getCombinedChildText(element.props), 'child');
 		});
 
 		it('should recursively combine children', () => {
@@ -60,7 +63,16 @@ describe('text-manipulation', () => {
 					},
 				],
 			};
-			assert.equal(getCombinedChildText(node), '123');
+			const element = (
+				<div>
+					1
+					<div>
+						<div>2</div>
+						<div>3</div>
+					</div>
+				</div>
+			);
+			assert.equal(getCombinedChildText(element.props), '123');
 		});
 	});
 

--- a/src/util/text-manipulation.spec.js
+++ b/src/util/text-manipulation.spec.js
@@ -44,25 +44,11 @@ describe('text-manipulation', () => {
 		});
 
 		it("should return the node's `children` if it is a string", () => {
-			const children = 'child';
 			const element = <div>child</div>;
 			assert.equal(getCombinedChildText(element.props), 'child');
 		});
 
 		it('should recursively combine children', () => {
-			const node = {
-				children: [
-					{ props: { children: '1' } },
-					{
-						props: {
-							children: [
-								{ props: { children: '2' } },
-								{ props: { children: '3' } },
-							],
-						},
-					},
-				],
-			};
 			const element = (
 				<div>
 					1


### PR DESCRIPTION
Added more formatting options to `SingleSelect`, `SearchableSelect`, and `SearchableMultiSelect`:
- Added new component `Underline` that will underline child text that matches a given text pattern
- `Option` accepts a `Selected` prop/child that is rendered when the option is selected
- `Option` children accepts a function/component as children which is passed the current `searchText` as a prop

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval
