### PR TITLE
Fix SearchableSelect & SearchableMultiSelect option formatting examples

### DIFF
--- a/docs/examples/SearchableMultiSelect/WithFormattedOptions.js
+++ b/docs/examples/SearchableMultiSelect/WithFormattedOptions.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import { SearchableMultiSelect, Underline } from '../../../src/index.js';
 
 const OptionCols = ({ col1, col2, textMatch }) => (

--- a/docs/examples/SearchableSelect/WithFormattedOptions.js
+++ b/docs/examples/SearchableSelect/WithFormattedOptions.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import { SearchableSelect, Underline } from '../../../src/index.js';
 
 const OptionCols = ({ col1, col2, textMatch }) => (


### PR DESCRIPTION
Fix option formatting examples for SearchableSelect and SearchableMultiSelect missing the lodash dependency

## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
