### PR TITLE
ensure onRowClick is called when a row is clicked

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -182,11 +182,7 @@ const DataTable = createClass({
 
 	handleRowClick(rowIndex, event) {
 		const { data, onRowClick } = this.props;
-
-		const targetTagName = event.target.tagName.toLowerCase();
-		if (targetTagName === 'td' || targetTagName === 'tr') {
-			onRowClick(data[rowIndex], rowIndex, { props: this.props, event });
-		}
+		onRowClick(data[rowIndex], rowIndex, { props: this.props, event });
 	},
 
 	handleSort(field, event) {


### PR DESCRIPTION
currently if a cell has any element such as `<div>hello</div>`, the
`onRowClick` will not get called. This probably should be up to the
consumer to stop propagation of the event if they don't want it
triggered.

here's a codepen to test it out https://codepen.io/jhsu/pen/gzoJvM?editors=0011