### PR TITLE
Portal: pass store context to children

### DIFF
--- a/src/components/Portal/Portal.jsx
+++ b/src/components/Portal/Portal.jsx
@@ -8,6 +8,25 @@ const cx = lucidClassNames.bind('&-Portal');
 
 const { any, node, string } = PropTypes;
 
+// This component passes the `context` prop with { store } from react-redux
+// Provider on to the childContext
+const WithStoreContext = createClass({
+	displayName: 'WithContext',
+	propTypes: {
+		context: any,
+		children: node,
+	},
+	childContextTypes: {
+		store: any,
+	},
+	getChildContext() {
+		return this.props.context;
+	},
+	render() {
+		return this.props.children;
+	},
+});
+
 const Portal = createClass({
 	displayName: 'Portal',
 
@@ -34,6 +53,9 @@ const Portal = createClass({
 			The \`id\` of the portal element that is appended to \`document.body\`.
 		`,
 	},
+	contextTypes: {
+		store: any, // access `store` from the context object
+	},
 	render: () => null,
 	componentDidMount() {
 		const { portalId } = this.props;
@@ -53,12 +75,14 @@ const Portal = createClass({
 	},
 	componentDidUpdate() {
 		ReactDOM.render(
-			<div
-				{...omitProps(this.props, Portal)}
-				className={cx('&', this.props.className)}
-			>
-				{this.props.children}
-			</div>,
+			<WithStoreContext context={this.context}>
+				<div
+					{...omitProps(this.props, Portal)}
+					className={cx('&', this.props.className)}
+				>
+					{this.props.children}
+				</div>
+			</WithStoreContext>,
 			this.portalElement
 		);
 	},


### PR DESCRIPTION
In Portal, pass along the `store` context property to rendered Portal children

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval
