### PR TITLE
fixes #741 by adding onSelect handler to Icon

### DIFF
--- a/src/components/Icon/AddURLIcon/__snapshots__/AddURLIcon.spec.jsx.snap
+++ b/src/components/Icon/AddURLIcon/__snapshots__/AddURLIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`AddURLIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-AddURLIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`AddURLIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-AddURLIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/AnalyzeDataIcon/__snapshots__/AnalyzeDataIcon.spec.jsx.snap
+++ b/src/components/Icon/AnalyzeDataIcon/__snapshots__/AnalyzeDataIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`AnalyzeDataIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-AnalyzeDataIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -88,6 +89,7 @@ exports[`AnalyzeDataIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-AnalyzeDataIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/ArrowIcon/__snapshots__/ArrowIcon.spec.jsx.snap
+++ b/src/components/Icon/ArrowIcon/__snapshots__/ArrowIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-up"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -35,6 +37,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -50,6 +53,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -65,6 +69,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-right"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -80,6 +85,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-up"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -95,6 +101,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-down"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -110,6 +117,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-left"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -125,6 +133,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-right"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -284,6 +293,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -299,6 +309,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-up"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -314,6 +325,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -329,6 +341,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -344,6 +357,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-right"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -359,6 +373,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-up"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -374,6 +389,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-down"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -389,6 +405,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-left"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -404,6 +421,7 @@ exports[`ArrowIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ArrowIcon lucid-ArrowIcon-is-right"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/AsteriskIcon/__snapshots__/AsteriskIcon.spec.jsx.snap
+++ b/src/components/Icon/AsteriskIcon/__snapshots__/AsteriskIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`AsteriskIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-AsteriskIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={18}
   viewBox="0 0 18 18"
@@ -20,6 +21,7 @@ exports[`AsteriskIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-AsteriskIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={18}
   viewBox="0 0 18 18"
@@ -67,6 +69,7 @@ exports[`AsteriskIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-AsteriskIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={18}
   viewBox="0 0 18 18"
@@ -82,6 +85,7 @@ exports[`AsteriskIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-AsteriskIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={18}
   viewBox="0 0 18 18"

--- a/src/components/Icon/AttachIcon/__snapshots__/AttachIcon.spec.js.snap
+++ b/src/components/Icon/AttachIcon/__snapshots__/AttachIcon.spec.js.snap
@@ -5,6 +5,7 @@ exports[`AttachIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-AttachIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="102.8 0 54.4 60"
@@ -36,6 +37,7 @@ exports[`AttachIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-AttachIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="102.8 0 54.4 60"

--- a/src/components/Icon/AudioIcon/__snapshots__/AudioIcon.spec.jsx.snap
+++ b/src/components/Icon/AudioIcon/__snapshots__/AudioIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`AudioIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-AudioIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -46,6 +47,7 @@ exports[`AudioIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-AudioIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/BeakerIcon/__snapshots__/BeakerIcon.spec.jsx.snap
+++ b/src/components/Icon/BeakerIcon/__snapshots__/BeakerIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`BeakerIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-BeakerIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -44,6 +45,7 @@ exports[`BeakerIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-BeakerIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/BellIcon/__snapshots__/BellIcon.spec.jsx.snap
+++ b/src/components/Icon/BellIcon/__snapshots__/BellIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`BellIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-BellIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`BellIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-BellIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/BookIcon/__snapshots__/BookIcon.spec.jsx.snap
+++ b/src/components/Icon/BookIcon/__snapshots__/BookIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`BookIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-BookIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -42,6 +43,7 @@ exports[`BookIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-BookIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/CalendarIcon/__snapshots__/CalendarIcon.spec.jsx.snap
+++ b/src/components/Icon/CalendarIcon/__snapshots__/CalendarIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`CalendarIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-CalendarIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -44,6 +45,7 @@ exports[`CalendarIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-CalendarIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/CaretIcon/__snapshots__/CaretIcon.spec.jsx.snap
+++ b/src/components/Icon/CaretIcon/__snapshots__/CaretIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -20,6 +21,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-up"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -35,6 +37,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -50,6 +53,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -65,6 +69,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-right"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -80,6 +85,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-up"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -95,6 +101,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-down"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -110,6 +117,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-left"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -125,6 +133,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-right"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 3 16 8"
@@ -284,6 +293,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -299,6 +309,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-up"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -314,6 +325,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -329,6 +341,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -344,6 +357,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-right"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -359,6 +373,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-up"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -374,6 +389,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-down"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -389,6 +405,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-left"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"
@@ -404,6 +421,7 @@ exports[`CaretIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CaretIcon lucid-CaretIcon-is-right"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 3 16 8"

--- a/src/components/Icon/ChatIcon/__snapshots__/ChatIcon.spec.jsx.snap
+++ b/src/components/Icon/ChatIcon/__snapshots__/ChatIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ChatIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-ChatIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`ChatIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-ChatIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/CheckIcon/__snapshots__/CheckIcon.spec.jsx.snap
+++ b/src/components/Icon/CheckIcon/__snapshots__/CheckIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`CheckIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CheckIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`CheckIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CheckIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -67,6 +69,7 @@ exports[`CheckIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CheckIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -82,6 +85,7 @@ exports[`CheckIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CheckIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/ChevronIcon/__snapshots__/ChevronIcon.spec.jsx.snap
+++ b/src/components/Icon/ChevronIcon/__snapshots__/ChevronIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-up"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -35,6 +37,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -50,6 +53,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -65,6 +69,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-right"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -80,6 +85,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-up"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -95,6 +101,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-down"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -110,6 +117,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-left"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -125,6 +133,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-right"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -284,6 +293,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -299,6 +309,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-up"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -314,6 +325,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-down"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -329,6 +341,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-left"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -344,6 +357,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-right"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -359,6 +373,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-up"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -374,6 +389,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-down"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -389,6 +405,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-left"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -404,6 +421,7 @@ exports[`ChevronIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronIcon lucid-ChevronIcon-is-right"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/ChevronThinIcon/__snapshots__/ChevronThinIcon.spec.jsx.snap
+++ b/src/components/Icon/ChevronThinIcon/__snapshots__/ChevronThinIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ChevronThinIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronThinIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`ChevronThinIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronThinIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -35,6 +37,7 @@ exports[`ChevronThinIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronThinIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -98,6 +101,7 @@ exports[`ChevronThinIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronThinIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -113,6 +117,7 @@ exports[`ChevronThinIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronThinIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -128,6 +133,7 @@ exports[`ChevronThinIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-ChevronThinIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/ClockIcon/__snapshots__/ClockIcon.spec.jsx.snap
+++ b/src/components/Icon/ClockIcon/__snapshots__/ClockIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ClockIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ClockIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -42,6 +43,7 @@ exports[`ClockIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ClockIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/CrossIcon/__snapshots__/CrossIcon.spec.jsx.snap
+++ b/src/components/Icon/CrossIcon/__snapshots__/CrossIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`CrossIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CrossIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`CrossIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CrossIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -67,6 +69,7 @@ exports[`CrossIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CrossIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -82,6 +85,7 @@ exports[`CrossIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CrossIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/CrownIcon/__snapshots__/CrownIcon.spec.js.snap
+++ b/src/components/Icon/CrownIcon/__snapshots__/CrownIcon.spec.js.snap
@@ -5,6 +5,7 @@ exports[`CrownIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-CrownIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="99.9 7.5 60.1 45"
@@ -36,6 +37,7 @@ exports[`CrownIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-CrownIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="99.9 7.5 60.1 45"

--- a/src/components/Icon/DangerIcon/__snapshots__/DangerIcon.spec.jsx.snap
+++ b/src/components/Icon/DangerIcon/__snapshots__/DangerIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`DangerIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-DangerIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -50,6 +51,7 @@ exports[`DangerIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-DangerIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/DangerLightIcon/__snapshots__/DangerLightIcon.spec.jsx.snap
+++ b/src/components/Icon/DangerLightIcon/__snapshots__/DangerLightIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`DangerLightIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-DangerLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -46,6 +47,7 @@ exports[`DangerLightIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-DangerLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/DataViewIcon/__snapshots__/DataViewIcon.spec.jsx.snap
+++ b/src/components/Icon/DataViewIcon/__snapshots__/DataViewIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`DataViewIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-DataViewIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`DataViewIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-DataViewIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/DeleteIcon/__snapshots__/DeleteIcon.spec.js.snap
+++ b/src/components/Icon/DeleteIcon/__snapshots__/DeleteIcon.spec.js.snap
@@ -5,6 +5,7 @@ exports[`DeleteIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-DeleteIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="103.75 0 52.5 60"
@@ -36,6 +37,7 @@ exports[`DeleteIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-DeleteIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="103.75 0 52.5 60"

--- a/src/components/Icon/DownloadIcon/__snapshots__/DownloadIcon.spec.jsx.snap
+++ b/src/components/Icon/DownloadIcon/__snapshots__/DownloadIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`DownloadIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-DownloadIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`DownloadIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-DownloadIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/DownloadTableDataIcon/__snapshots__/DownloadTableDataIcon.spec.jsx.snap
+++ b/src/components/Icon/DownloadTableDataIcon/__snapshots__/DownloadTableDataIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`DownloadTableDataIcon [common] example testing should match snapshot(s)
   aspectRatio="xMidYMid meet"
   className="lucid-DownloadTableDataIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -44,6 +45,7 @@ exports[`DownloadTableDataIcon [common] example testing should match snapshot(s)
   aspectRatio="xMidYMid meet"
   className="lucid-DownloadTableDataIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/DuplicateIcon/__snapshots__/DuplicateIcon.spec.jsx.snap
+++ b/src/components/Icon/DuplicateIcon/__snapshots__/DuplicateIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`DuplicateIcon [common] example testing should match snapshot(s) for 1.d
   aspectRatio="xMidYMid meet"
   className="lucid-DuplicateIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`DuplicateIcon [common] example testing should match snapshot(s) for 3.d
   aspectRatio="xMidYMid meet"
   className="lucid-DuplicateIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/EditIcon/__snapshots__/EditIcon.spec.jsx.snap
+++ b/src/components/Icon/EditIcon/__snapshots__/EditIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`EditIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-EditIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`EditIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-EditIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -67,6 +69,7 @@ exports[`EditIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-EditIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -82,6 +85,7 @@ exports[`EditIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-EditIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/EditPageIcon/__snapshots__/EditPageIcon.spec.jsx.snap
+++ b/src/components/Icon/EditPageIcon/__snapshots__/EditPageIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`EditPageIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-EditPageIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`EditPageIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-EditPageIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/EligibilityIcon/__snapshots__/EligibilityIcon.spec.jsx.snap
+++ b/src/components/Icon/EligibilityIcon/__snapshots__/EligibilityIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -27,6 +28,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -49,6 +51,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -71,6 +74,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -93,6 +97,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -115,6 +120,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -137,6 +143,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -159,6 +166,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -181,6 +189,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -410,6 +419,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -432,6 +442,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -454,6 +465,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -476,6 +488,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -498,6 +511,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -520,6 +534,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -542,6 +557,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -564,6 +580,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -586,6 +603,7 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-EligibilityIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/EnvelopeIcon/__snapshots__/EnvelopeIcon.spec.jsx.snap
+++ b/src/components/Icon/EnvelopeIcon/__snapshots__/EnvelopeIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`EnvelopeIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-EnvelopeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`EnvelopeIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-EnvelopeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/EqualsIcon/__snapshots__/EqualsIcon.spec.jsx.snap
+++ b/src/components/Icon/EqualsIcon/__snapshots__/EqualsIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`EqualsIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-EqualsIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`EqualsIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-EqualsIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/FileIcon/__snapshots__/FileIcon.spec.jsx.snap
+++ b/src/components/Icon/FileIcon/__snapshots__/FileIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`FileIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-FileIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`FileIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-FileIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/FilterIcon/__snapshots__/FilterIcon.spec.jsx.snap
+++ b/src/components/Icon/FilterIcon/__snapshots__/FilterIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`FilterIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-FilterIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`FilterIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-FilterIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/FolderIcon/__snapshots__/FolderIcon.spec.jsx.snap
+++ b/src/components/Icon/FolderIcon/__snapshots__/FolderIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`FolderIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-FolderIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`FolderIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-FolderIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -67,6 +69,7 @@ exports[`FolderIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-FolderIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -82,6 +85,7 @@ exports[`FolderIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-FolderIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/FourSquaresIcon/__snapshots__/FourSquaresIcon.spec.jsx.snap
+++ b/src/components/Icon/FourSquaresIcon/__snapshots__/FourSquaresIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`FourSquaresIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-FourSquaresIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`FourSquaresIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-FourSquaresIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/HelpIcon/__snapshots__/HelpIcon.spec.jsx.snap
+++ b/src/components/Icon/HelpIcon/__snapshots__/HelpIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`HelpIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-HelpIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`HelpIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-HelpIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/HomeIcon/__snapshots__/HomeIcon.spec.jsx.snap
+++ b/src/components/Icon/HomeIcon/__snapshots__/HomeIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`HomeIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-HomeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`HomeIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-HomeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
+import ReactDOM from 'react-dom';
 import { lucidClassNames } from '../../util/style-helpers';
 import { createClass, omitProps } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-Icon');
 
-const { any, string, number, object, bool } = PropTypes;
+const { any, string, number, object, bool, func } = PropTypes;
 
 const Icon = createClass({
 	displayName: 'Icon',
@@ -60,6 +61,11 @@ const Icon = createClass({
 			isClickable to be false.
 		`,
 
+		onClick: func`
+			Called when user clicks the \`Icon\`. Signature:
+			\`({event, props}) => {}\`
+		`,
+
 		children: any`
 			Any valid React children.
 		`,
@@ -72,7 +78,18 @@ const Icon = createClass({
 			viewBox: '0 0 16 16',
 			isBadge: false,
 			isDisabled: false,
+			isClickable: false,
 		};
+	},
+
+	onSelect(event) {
+		const { isClickable, isDisabled, onClick } = this.props;
+		const domNode = ReactDOM.findDOMNode(this);
+
+		if (!isDisabled && isClickable) {
+			domNode.focus();
+			onClick({ event, props: this.props });
+		}
 	},
 
 	render() {
@@ -118,6 +135,7 @@ const Icon = createClass({
 					},
 					className
 				)}
+				onClick={this.handleSelect}
 			>
 				{children}
 			</svg>

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -61,7 +61,11 @@ const Icon = createClass({
 			isClickable to be false.
 		`,
 
-		onClick: func`
+		onSelect: func`
+			Called if user already has \`onClick\` in place.
+		`,
+
+		handleClick: func`
 			Called when user clicks the \`Icon\`. Signature:
 			\`({event, props}) => {}\`
 		`,
@@ -82,13 +86,13 @@ const Icon = createClass({
 		};
 	},
 
-	onSelect(event) {
-		const { isClickable, isDisabled, onClick } = this.props;
+	handleClick(event) {
+		const { onClick } = this.props;
 		const domNode = ReactDOM.findDOMNode(this);
 
-		if (!isDisabled && isClickable) {
+		if (onClick) {
 			domNode.focus();
-			onClick({ event, props: this.props });
+			onSelect({ event, props: this.props });
 		}
 	},
 
@@ -135,7 +139,7 @@ const Icon = createClass({
 					},
 					className
 				)}
-				onClick={this.handleSelect}
+				onClick={this.handleClick}
 			>
 				{children}
 			</svg>

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -62,11 +62,7 @@ const Icon = createClass({
 		`,
 
 		onSelect: func`
-			Called if user already has \`onClick\` in place.
-		`,
-
-		handleClick: func`
-			Called when user clicks the \`Icon\`. Signature:
+			Called when the user clicks the \`Icon\`. Signature:
 			\`({event, props}) => {}\`
 		`,
 
@@ -87,10 +83,14 @@ const Icon = createClass({
 	},
 
 	handleClick(event) {
-		const { onClick } = this.props;
+		const { onClick, isDisabled, isClickable, onSelect } = this.props;
 		const domNode = ReactDOM.findDOMNode(this);
 
 		if (onClick) {
+			onClick(event);
+		}
+
+		if (onSelect && isClickable && !isDisabled) {
 			domNode.focus();
 			onSelect({ event, props: this.props });
 		}

--- a/src/components/Icon/ImageIcon/__snapshots__/ImageIcon.spec.jsx.snap
+++ b/src/components/Icon/ImageIcon/__snapshots__/ImageIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ImageIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-ImageIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`ImageIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-ImageIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/InfoIcon/__snapshots__/InfoIcon.spec.jsx.snap
+++ b/src/components/Icon/InfoIcon/__snapshots__/InfoIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`InfoIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-InfoIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -70,6 +71,7 @@ exports[`InfoIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-InfoIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/InfoLightIcon/__snapshots__/InfoLightIcon.spec.jsx.snap
+++ b/src/components/Icon/InfoLightIcon/__snapshots__/InfoLightIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`InfoLightIcon [common] example testing should match snapshot(s) for 1.d
   aspectRatio="xMidYMid meet"
   className="lucid-InfoLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -46,6 +47,7 @@ exports[`InfoLightIcon [common] example testing should match snapshot(s) for 3.d
   aspectRatio="xMidYMid meet"
   className="lucid-InfoLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/LinkedIcon/__snapshots__/LinkedIcon.spec.jsx.snap
+++ b/src/components/Icon/LinkedIcon/__snapshots__/LinkedIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`LinkedIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-LinkedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -42,6 +43,7 @@ exports[`LinkedIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-LinkedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/LoadingIcon/__snapshots__/LoadingIcon.spec.jsx.snap
+++ b/src/components/Icon/LoadingIcon/__snapshots__/LoadingIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`LoadingIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-LoadingIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   style={
@@ -46,6 +47,7 @@ exports[`LoadingIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-LoadingIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   style={
@@ -87,6 +89,7 @@ exports[`LoadingIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-LoadingIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   style={
@@ -254,6 +257,7 @@ exports[`LoadingIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-LoadingIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   style={
@@ -295,6 +299,7 @@ exports[`LoadingIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-LoadingIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   style={
@@ -336,6 +341,7 @@ exports[`LoadingIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-LoadingIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   style={

--- a/src/components/Icon/LockedIcon/__snapshots__/LockedIcon.spec.jsx.snap
+++ b/src/components/Icon/LockedIcon/__snapshots__/LockedIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`LockedIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-LockedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`LockedIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-LockedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/MaximizeIcon/__snapshots__/MaximizeIcon.spec.jsx.snap
+++ b/src/components/Icon/MaximizeIcon/__snapshots__/MaximizeIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`MaximizeIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-MaximizeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`MaximizeIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-MaximizeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/MinimizeIcon/__snapshots__/MinimizeIcon.spec.jsx.snap
+++ b/src/components/Icon/MinimizeIcon/__snapshots__/MinimizeIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`MinimizeIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-MinimizeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`MinimizeIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-MinimizeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/MinusCircleIcon/__snapshots__/MinusCircleIcon.spec.jsx.snap
+++ b/src/components/Icon/MinusCircleIcon/__snapshots__/MinusCircleIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`MinusCircleIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-MinusCircleIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -56,6 +57,7 @@ exports[`MinusCircleIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-MinusCircleIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/MinusCircleLightIcon/__snapshots__/MinusCircleLightIcon.spec.jsx.snap
+++ b/src/components/Icon/MinusCircleLightIcon/__snapshots__/MinusCircleLightIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`MinusCircleLightIcon [common] example testing should match snapshot(s) 
   aspectRatio="xMidYMid meet"
   className="lucid-MinusCircleLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -46,6 +47,7 @@ exports[`MinusCircleLightIcon [common] example testing should match snapshot(s) 
   aspectRatio="xMidYMid meet"
   className="lucid-MinusCircleLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/MinusIcon/__snapshots__/MinusIcon.spec.jsx.snap
+++ b/src/components/Icon/MinusIcon/__snapshots__/MinusIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`MinusIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-MinusIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`MinusIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-MinusIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -67,6 +69,7 @@ exports[`MinusIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-MinusIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -82,6 +85,7 @@ exports[`MinusIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-MinusIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/NewWindowIcon/__snapshots__/NewWindowIcon.spec.jsx.snap
+++ b/src/components/Icon/NewWindowIcon/__snapshots__/NewWindowIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`NewWindowIcon [common] example testing should match snapshot(s) for 1.d
   aspectRatio="xMidYMid meet"
   className="lucid-NewWindowIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`NewWindowIcon [common] example testing should match snapshot(s) for 3.d
   aspectRatio="xMidYMid meet"
   className="lucid-NewWindowIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/OutwardArrowsIcon/__snapshots__/OutwardArrowsIcon.spec.js.snap
+++ b/src/components/Icon/OutwardArrowsIcon/__snapshots__/OutwardArrowsIcon.spec.js.snap
@@ -5,6 +5,7 @@ exports[`OutwardArrowsIcon [common] example testing should match snapshot(s) for
   aspectRatio="xMidYMid meet"
   className="lucid-OutwardArrowsIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`OutwardArrowsIcon [common] example testing should match snapshot(s) for
   aspectRatio="xMidYMid meet"
   className="lucid-OutwardArrowsIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -35,6 +37,7 @@ exports[`OutwardArrowsIcon [common] example testing should match snapshot(s) for
   aspectRatio="xMidYMid meet"
   className="lucid-OutwardArrowsIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/PlusIcon/__snapshots__/PlusIcon.spec.jsx.snap
+++ b/src/components/Icon/PlusIcon/__snapshots__/PlusIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`PlusIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-PlusIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -23,6 +24,7 @@ exports[`PlusIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-PlusIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -79,6 +81,7 @@ exports[`PlusIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-PlusIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -97,6 +100,7 @@ exports[`PlusIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-PlusIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/QuestionMarkCircleIcon/__snapshots__/QuestionMarkCircleIcon.spec.jsx.snap
+++ b/src/components/Icon/QuestionMarkCircleIcon/__snapshots__/QuestionMarkCircleIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`QuestionMarkCircleIcon [common] example testing should match snapshot(s
   aspectRatio="xMidYMid meet"
   className="lucid-QuestionMarkCircleIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`QuestionMarkCircleIcon [common] example testing should match snapshot(s
   aspectRatio="xMidYMid meet"
   className="lucid-QuestionMarkCircleIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/RefreshIcon/__snapshots__/RefreshIcon.spec.jsx.snap
+++ b/src/components/Icon/RefreshIcon/__snapshots__/RefreshIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`RefreshIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-RefreshIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`RefreshIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-RefreshIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -67,6 +69,7 @@ exports[`RefreshIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-RefreshIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -82,6 +85,7 @@ exports[`RefreshIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-RefreshIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/ResizeIcon/__snapshots__/ResizeIcon.spec.jsx.snap
+++ b/src/components/Icon/ResizeIcon/__snapshots__/ResizeIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ResizeIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-ResizeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`ResizeIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-ResizeIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/SearchIcon/__snapshots__/SearchIcon.spec.jsx.snap
+++ b/src/components/Icon/SearchIcon/__snapshots__/SearchIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SearchIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-SearchIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -20,6 +21,7 @@ exports[`SearchIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-SearchIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -67,6 +69,7 @@ exports[`SearchIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-SearchIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -82,6 +85,7 @@ exports[`SearchIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-SearchIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/SeparatorIcon/__snapshots__/SeparatorIcon.spec.jsx.snap
+++ b/src/components/Icon/SeparatorIcon/__snapshots__/SeparatorIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SeparatorIcon [common] example testing should match snapshot(s) for 1.d
   aspectRatio="xMidYMid meet"
   className="lucid-SeparatorIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`SeparatorIcon [common] example testing should match snapshot(s) for 3.d
   aspectRatio="xMidYMid meet"
   className="lucid-SeparatorIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/SettingsIcon/__snapshots__/SettingsIcon.spec.jsx.snap
+++ b/src/components/Icon/SettingsIcon/__snapshots__/SettingsIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SettingsIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-SettingsIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`SettingsIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-SettingsIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/ShoppingCartIcon/__snapshots__/ShoppingCartIcon.spec.jsx.snap
+++ b/src/components/Icon/ShoppingCartIcon/__snapshots__/ShoppingCartIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ShoppingCartIcon [common] example testing should match snapshot(s) for 
   aspectRatio="xMidYMid meet"
   className="lucid-ShoppingCartIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`ShoppingCartIcon [common] example testing should match snapshot(s) for 
   aspectRatio="xMidYMid meet"
   className="lucid-ShoppingCartIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/StarIcon/__snapshots__/StarIcon.spec.jsx.snap
+++ b/src/components/Icon/StarIcon/__snapshots__/StarIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`StarIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-StarIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`StarIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-StarIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/StarOutlineIcon/__snapshots__/StarOutlineIcon.spec.jsx.snap
+++ b/src/components/Icon/StarOutlineIcon/__snapshots__/StarOutlineIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`StarOutlineIcon [common] example testing should match snapshot(s) for 1
   aspectRatio="xMidYMid meet"
   className="lucid-StarOutlineIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`StarOutlineIcon [common] example testing should match snapshot(s) for 3
   aspectRatio="xMidYMid meet"
   className="lucid-StarOutlineIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/StopwatchIcon/__snapshots__/StopwatchIcon.spec.jsx.snap
+++ b/src/components/Icon/StopwatchIcon/__snapshots__/StopwatchIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`StopwatchIcon [common] example testing should match snapshot(s) for 1.d
   aspectRatio="xMidYMid meet"
   className="lucid-StopwatchIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`StopwatchIcon [common] example testing should match snapshot(s) for 3.d
   aspectRatio="xMidYMid meet"
   className="lucid-StopwatchIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"
@@ -51,6 +53,7 @@ exports[`StopwatchIcon [common] example testing should match snapshot(s) for 4.b
   aspectRatio="xMidYMid meet"
   className="lucid-StopwatchIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -66,6 +69,7 @@ exports[`StopwatchIcon [common] example testing should match snapshot(s) for 4.b
   aspectRatio="xMidYMid meet"
   className="lucid-StopwatchIcon"
   isBadge={true}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/SuccessIcon/__snapshots__/SuccessIcon.spec.jsx.snap
+++ b/src/components/Icon/SuccessIcon/__snapshots__/SuccessIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SuccessIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-SuccessIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -50,6 +51,7 @@ exports[`SuccessIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-SuccessIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/SuccessLightIcon/__snapshots__/SuccessLightIcon.spec.jsx.snap
+++ b/src/components/Icon/SuccessLightIcon/__snapshots__/SuccessLightIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 
   aspectRatio="xMidYMid meet"
   className="lucid-SuccessLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -46,6 +47,7 @@ exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 
   aspectRatio="xMidYMid meet"
   className="lucid-SuccessLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/SwitchIcon/__snapshots__/SwitchIcon.spec.jsx.snap
+++ b/src/components/Icon/SwitchIcon/__snapshots__/SwitchIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SwitchIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-SwitchIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`SwitchIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-SwitchIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/TableGearIcon/__snapshots__/TableGearIcon.spec.jsx.snap
+++ b/src/components/Icon/TableGearIcon/__snapshots__/TableGearIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`TableGearIcon [common] example testing should match snapshot(s) for 1.d
   aspectRatio="xMidYMid meet"
   className="lucid-TableGearIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -98,6 +99,7 @@ exports[`TableGearIcon [common] example testing should match snapshot(s) for 3.d
   aspectRatio="xMidYMid meet"
   className="lucid-TableGearIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/TextIcon/__snapshots__/TextIcon.spec.jsx.snap
+++ b/src/components/Icon/TextIcon/__snapshots__/TextIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`TextIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-TextIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -44,6 +45,7 @@ exports[`TextIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-TextIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/UnlinkedIcon/__snapshots__/UnlinkedIcon.spec.jsx.snap
+++ b/src/components/Icon/UnlinkedIcon/__snapshots__/UnlinkedIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`UnlinkedIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-UnlinkedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`UnlinkedIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-UnlinkedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/UnlockedIcon/__snapshots__/UnlockedIcon.spec.jsx.snap
+++ b/src/components/Icon/UnlockedIcon/__snapshots__/UnlockedIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`UnlockedIcon [common] example testing should match snapshot(s) for 1.de
   aspectRatio="xMidYMid meet"
   className="lucid-UnlockedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`UnlockedIcon [common] example testing should match snapshot(s) for 3.di
   aspectRatio="xMidYMid meet"
   className="lucid-UnlockedIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/UploadIcon/__snapshots__/UploadIcon.spec.jsx.snap
+++ b/src/components/Icon/UploadIcon/__snapshots__/UploadIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`UploadIcon [common] example testing should match snapshot(s) for 1.defa
   aspectRatio="xMidYMid meet"
   className="lucid-UploadIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`UploadIcon [common] example testing should match snapshot(s) for 3.disa
   aspectRatio="xMidYMid meet"
   className="lucid-UploadIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/UserIcon/__snapshots__/UserIcon.spec.jsx.snap
+++ b/src/components/Icon/UserIcon/__snapshots__/UserIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`UserIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-UserIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`UserIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-UserIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/VideoIcon/__snapshots__/VideoIcon.spec.jsx.snap
+++ b/src/components/Icon/VideoIcon/__snapshots__/VideoIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`VideoIcon [common] example testing should match snapshot(s) for 1.defau
   aspectRatio="xMidYMid meet"
   className="lucid-VideoIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -40,6 +41,7 @@ exports[`VideoIcon [common] example testing should match snapshot(s) for 3.disab
   aspectRatio="xMidYMid meet"
   className="lucid-VideoIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/ViewIcon/__snapshots__/ViewIcon.spec.jsx.snap
+++ b/src/components/Icon/ViewIcon/__snapshots__/ViewIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`ViewIcon [common] example testing should match snapshot(s) for 1.defaul
   aspectRatio="xMidYMid meet"
   className="lucid-ViewIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -36,6 +37,7 @@ exports[`ViewIcon [common] example testing should match snapshot(s) for 3.disabl
   aspectRatio="xMidYMid meet"
   className="lucid-ViewIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/WarningIcon/__snapshots__/WarningIcon.spec.jsx.snap
+++ b/src/components/Icon/WarningIcon/__snapshots__/WarningIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`WarningIcon [common] example testing should match snapshot(s) for 1.def
   aspectRatio="xMidYMid meet"
   className="lucid-WarningIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -66,6 +67,7 @@ exports[`WarningIcon [common] example testing should match snapshot(s) for 3.dis
   aspectRatio="xMidYMid meet"
   className="lucid-WarningIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/WarningLightIcon/__snapshots__/WarningLightIcon.spec.jsx.snap
+++ b/src/components/Icon/WarningLightIcon/__snapshots__/WarningLightIcon.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`WarningLightIcon [common] example testing should match snapshot(s) for 
   aspectRatio="xMidYMid meet"
   className="lucid-WarningLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={false}
   size={16}
   viewBox="0 0 16 16"
@@ -54,6 +55,7 @@ exports[`WarningLightIcon [common] example testing should match snapshot(s) for 
   aspectRatio="xMidYMid meet"
   className="lucid-WarningLightIcon"
   isBadge={false}
+  isClickable={false}
   isDisabled={true}
   size={16}
   viewBox="0 0 16 16"

--- a/src/components/Icon/__snapshots__/Icon.spec.jsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.spec.jsx.snap
@@ -25,7 +25,6 @@ exports[`Icon [common] example testing should match snapshot(s) for 2.clickable 
 <svg
   className="lucid-Icon lucid-Icon-is-clickable"
   height={16}
-  onClick={[Function]}
   preserveAspectRatio="xMidYMid meet"
   style={Object {}}
   viewBox="0 0 16 16"

--- a/src/components/Icon/__snapshots__/Icon.spec.jsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.spec.jsx.snap
@@ -4,6 +4,7 @@ exports[`Icon [common] example testing should match snapshot(s) for 1.default 1`
 <svg
   className="lucid-Icon"
   height={16}
+  onClick={[Function]}
   preserveAspectRatio="xMidYMid meet"
   style={Object {}}
   viewBox="0 0 16 16"
@@ -25,6 +26,7 @@ exports[`Icon [common] example testing should match snapshot(s) for 2.clickable 
 <svg
   className="lucid-Icon lucid-Icon-is-clickable"
   height={16}
+  onClick={[Function]}
   preserveAspectRatio="xMidYMid meet"
   style={Object {}}
   viewBox="0 0 16 16"
@@ -46,6 +48,7 @@ exports[`Icon [common] example testing should match snapshot(s) for 3.disabled 1
 <svg
   className="lucid-Icon lucid-Icon-is-disabled"
   height={16}
+  onClick={[Function]}
   preserveAspectRatio="xMidYMid meet"
   style={Object {}}
   viewBox="0 0 16 16"

--- a/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
+++ b/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
@@ -252,6 +252,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
         <LoadingIcon
           aspectRatio="xMidYMid meet"
           isBadge={false}
+          isClickable={false}
           isDisabled={false}
           size={16}
           speed="slow"
@@ -345,6 +346,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
         <LoadingIcon
           aspectRatio="xMidYMid meet"
           isBadge={false}
+          isClickable={false}
           isDisabled={false}
           size={16}
           speed="fast"

--- a/src/components/SearchField/__snapshots__/SearchField.spec.jsx.snap
+++ b/src/components/SearchField/__snapshots__/SearchField.spec.jsx.snap
@@ -133,6 +133,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 5.cus
       aspectRatio="xMidYMid meet"
       className="lucid-SearchField-Icon"
       isBadge={false}
+      isClickable={false}
       isDisabled={false}
       size={16}
       speed="normal"
@@ -334,6 +335,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
       aspectRatio="xMidYMid meet"
       className="lucid-SearchField-Icon"
       isBadge={false}
+      isClickable={false}
       isDisabled={false}
       size={16}
       speed="normal"
@@ -367,6 +369,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
       aspectRatio="xMidYMid meet"
       className="lucid-SearchField-Icon lucid-SearchField-Icon-active"
       isBadge={false}
+      isClickable={false}
       isDisabled={false}
       size={16}
       speed="normal"

--- a/src/components/SearchableSelect/__snapshots__/SearchableSelect.spec.jsx.snap
+++ b/src/components/SearchableSelect/__snapshots__/SearchableSelect.spec.jsx.snap
@@ -881,6 +881,7 @@ exports[`SearchableSelect [common] example testing should match snapshot(s) for 
     <LoadingIcon
       aspectRatio="xMidYMid meet"
       isBadge={false}
+      isClickable={false}
       isDisabled={false}
       size={16}
       speed="normal"


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
