### PR TITLE
#939: flushing onChangeDebounced when blurring or submitting

### DIFF
--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -176,15 +176,18 @@ const TextField = createClass({
 	},
 
 	handleBlur(event) {
-		const { onBlur } = this.props;
+		const { onBlur, onChangeDebounced } = this.props;
 
 		const value = _.get(event, 'target.value', '');
 
+		if (onChangeDebounced !== _.noop) {
+			this._handleChangeDebounced.flush();
+		}
 		onBlur(value, { event, props: this.props });
 	},
 
 	handleKeyDown(event) {
-		const { props, props: { onSubmit, onKeyDown } } = this;
+		const { props, props: { onSubmit, onKeyDown, onChangeDebounced } } = this;
 		const value = _.get(event, 'target.value', '');
 
 		// If the consumer passed an onKeyDown, we call it
@@ -193,6 +196,10 @@ const TextField = createClass({
 		}
 
 		if (event.keyCode === KEYCODE.Enter) {
+			if (onChangeDebounced !== _.noop) {
+				this._handleChangeDebounced.flush();
+			}
+
 			onSubmit(value, { event, props: this.props });
 		}
 	},

--- a/src/components/TextField/TextField.spec.jsx
+++ b/src/components/TextField/TextField.spec.jsx
@@ -143,4 +143,69 @@ describe('TextField', () => {
 
 		assert(event.persist.called);
 	});
+
+	it('should flush the `onChangeDebounced`-handled event before blurring', () => {
+		const onBlur = sinon.spy();
+		const internalChangeSpy = sinon.spy();
+		const onChangeDebounced = () => {
+			assert(onBlur.notCalled);
+			internalChangeSpy();
+		};
+		const event = {
+			target: {
+				value: 'foo',
+			},
+			persist: () => {},
+		};
+
+		const wrapper = shallow(
+			<TextField
+				onBlur={onBlur}
+				debounceLevel={100}
+				onChangeDebounced={onChangeDebounced}
+			/>
+		);
+
+		wrapper.find('input').simulate('change', event);
+		assert(internalChangeSpy.notCalled);
+
+		wrapper.find('input').simulate('blur');
+		assert(internalChangeSpy.calledOnce);
+		assert(onBlur.calledOnce);
+	});
+
+	it('should flush the `onChangeDebounced`-handled event before submitting', () => {
+		const onSubmit = sinon.spy();
+		const internalChangeSpy = sinon.spy();
+		const onChangeDebounced = () => {
+			assert(onSubmit.notCalled);
+			internalChangeSpy();
+		};
+		const event = {
+			target: {
+				value: 'foo',
+			},
+			persist: () => {},
+		};
+
+		const wrapper = shallow(
+			<TextField
+				onSubmit={onSubmit}
+				debounceLevel={100}
+				onChangeDebounced={onChangeDebounced}
+			/>
+		);
+
+		wrapper.find('input').simulate('change', event);
+		assert(internalChangeSpy.notCalled);
+
+		wrapper.find('input').simulate('keydown', {
+			keyCode: KEYCODE.Enter,
+			target: {
+				value: 'foo',
+			},
+		});
+		assert(internalChangeSpy.calledOnce);
+		assert(onSubmit.calledOnce);
+	});
 });


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval
