### PR TITLE
Fixes ANXR-1520 by adding diagonal tick labels to `Axis`

### DIFF
--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -172,7 +172,9 @@ const Axis = createClass({
 					x =
 						textOrientation === 'vertical' ? 0 : orientationSign * tickSpacing;
 					y =
-						textOrientation === 'vertical' ? orientationSign * tickSpacing : 0;
+						textOrientation === 'vertical' || textOrientation === 'diagonal'
+							? orientationSign * tickSpacing
+							: 0;
 					dy =
 						textOrientation === 'vertical'
 							? '0em'

--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -74,6 +74,11 @@ const Axis = createClass({
 			an ordinal scale, this number is treated as an absolute number of ticks
 			to display and is powered by our own utility function \`discreteTicks\`.
 		`,
+
+		textOrientation: oneOf(['vertical', 'horizontal', 'diagonal'])`
+			Determines the orientation of the tick text. This may override what the orient prop
+			tries to determine.
+		`,
 	},
 
 	getDefaultProps() {
@@ -99,6 +104,7 @@ const Axis = createClass({
 			outerTickSize,
 			tickFormat = scale.tickFormat ? scale.tickFormat() : _.identity,
 			tickPadding,
+			textOrientation,
 			...passThroughs
 		} = this.props;
 
@@ -108,6 +114,28 @@ const Axis = createClass({
 		const range = scale.range();
 		const sign = orient === 'top' || orient === 'left' ? -1 : 1;
 		const isH = orient === 'top' || orient === 'bottom'; // is horizontal
+		const orientationProperties = {
+			vertical: {
+				transform: 'rotate(-90)',
+				// check textAnchor
+				textAnchor: sign < 0 ? 'end' : 'start',
+				x: isH ? 0 : sign * tickSpacing,
+				y: isH ? sign * tickSpacing : 0,
+			},
+			horizontal: {
+				transform: '',
+				textAnchor: isH ? 'middle' : sign < 0 ? 'end' : 'start',
+				x: isH ? 0 : sign * tickSpacing,
+				y: isH ? sign * tickSpacing : 0,
+			},
+			diagonal: {
+				transform: 'rotate(45)',
+				textAnchor: 'start',
+				x: sign * tickSpacing,
+				y: sign * tickSpacing,
+			},
+		};
+		const orientationKey = textOrientation || 'horizontal';
 
 		let scaleNormalized = scale;
 
@@ -147,16 +175,17 @@ const Axis = createClass({
 						/>
 						<text
 							className={cx('&-tick-text')}
-							x={isH ? 0 : sign * tickSpacing}
-							y={isH ? sign * tickSpacing : 0}
+							x={orientationProperties[orientationKey].x}
+							y={orientationProperties[orientationKey].y}
 							dy={
 								isH
 									? sign < 0 ? '0em' : '.71em' // magic d3 number
 									: '.32em' // magic d3 number
 							}
 							style={{
-								textAnchor: isH ? 'middle' : sign < 0 ? 'end' : 'start',
+								textAnchor: orientationProperties[orientationKey].textAnchor,
 							}}
+							transform={orientationProperties[orientationKey].transform}
 						>
 							{tickFormat(tick)}
 						</text>

--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -243,12 +243,7 @@ const Axis = createClass({
 							className={cx('&-tick-text')}
 							x={orientationProperties[orientationKey].x}
 							y={orientationProperties[orientationKey].y}
-							dy={
-								orientationProperties[orientationKey].dy
-								// isH
-								// 	? sign < 0 ? '0em' : '.71em' // magic d3 number
-								// 	: '.32em' // magic d3 number
-							}
+							dy={orientationProperties[orientationKey].dy}
 							style={{
 								textAnchor: orientationProperties[orientationKey].textAnchor,
 							}}

--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -114,14 +114,55 @@ const Axis = createClass({
 		const range = scale.range();
 		const sign = orient === 'top' || orient === 'left' ? -1 : 1;
 		const isH = orient === 'top' || orient === 'bottom'; // is horizontal
+		const getOrientationProperties = (orient, textOrientation) => {
+			let textAnchor;
+			switch (orient) {
+				case 'bottom':
+					textAnchor =
+						textOrientation === 'vertical'
+							? 'end'
+							: textOrientation === 'diagonal' ? 'start' : 'middle';
+					break;
+				case 'top':
+					textAnchor =
+						textOrientation === 'vertical'
+							? 'end'
+							: textOrientation === 'diagonal' ? 'start' : 'middle';
+					break;
+				case 'right':
+					textAnchor =
+						textOrientation === 'vertical'
+							? 'end'
+							: textOrientation === 'diagonal' ? 'start' : 'middle';
+					break;
+				case 'left':
+					textAnchor =
+						textOrientation === 'vertical'
+							? 'middle'
+							: textOrientation === 'diagonal' ? 'end' : 'end';
+					break;
+			}
+			return {
+				transform:
+					textOrientation === 'vertical'
+						? 'rotate(-90)'
+						: textOrientation === 'diagonal' ? 'rotate(45)' : '',
+				textAnchor,
+				x: -1 * tickSpacing,
+				y: -1 * tickSpacing / 2,
+			};
+		};
 		const orientationProperties = {
-			vertical: {
-				transform: 'rotate(-90)',
-				// check textAnchor
-				textAnchor: sign < 0 ? 'end' : 'start',
-				x: isH ? 0 : sign * tickSpacing,
-				y: isH ? sign * tickSpacing : 0,
-			},
+			vertical: getOrientationProperties(orient, 'vertical'),
+			// vertical: {
+			// 	transform: 'rotate(-90)',
+			// 	// check textAnchor
+			// 	textAnchor: sign < 0 ? 'end' : 'end',
+			// 	// x: isH ? 0 : sign * tickSpacing,
+			// 	// y: isH ? sign * tickSpacing : 0,
+			// 	x: (-1 * tickSpacing),
+			// 	y: (-1 * tickSpacing) / 2,
+			// },
 			horizontal: {
 				transform: '',
 				textAnchor: isH ? 'middle' : sign < 0 ? 'end' : 'start',

--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -77,7 +77,7 @@ const Axis = createClass({
 
 		textOrientation: oneOf(['vertical', 'horizontal', 'diagonal'])`
 			Determines the orientation of the tick text. This may override what the orient prop
-			tries to determine.
+			tries to determine. This defaults to \`horizontal\`.
 		`,
 	},
 
@@ -86,6 +86,7 @@ const Axis = createClass({
 			innerTickSize: 6, // same as d3
 			outerTickSize: 6, // same as d3
 			tickPadding: 3, // same as d3
+			textOrientation: 'horizontal',
 			orient: 'bottom',
 			tickCount: null,
 		};
@@ -185,11 +186,7 @@ const Axis = createClass({
 				transform:
 					textOrientation === 'vertical'
 						? 'rotate(-90)'
-						: textOrientation === 'horizontal'
-							? ''
-							: orient === 'bottom' || orient === 'left'
-								? 'rotate(-30)'
-								: 'rotate(-30)',
+						: textOrientation === 'horizontal' ? '' : 'rotate(-30)',
 				textAnchor,
 				x,
 				y,

--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -115,31 +115,71 @@ const Axis = createClass({
 		const sign = orient === 'top' || orient === 'left' ? -1 : 1;
 		const isH = orient === 'top' || orient === 'bottom'; // is horizontal
 		const getOrientationProperties = (orient, textOrientation) => {
-			let textAnchor;
+			let textAnchor, x, y, dy;
+			let orientationSign = sign;
 			switch (orient) {
 				case 'bottom':
+					if (textOrientation === 'vertical') {
+						orientationSign = -orientationSign;
+					}
 					textAnchor =
 						textOrientation === 'vertical'
 							? 'end'
 							: textOrientation === 'diagonal' ? 'start' : 'middle';
+					x =
+						textOrientation === 'vertical' || textOrientation === 'diagonal'
+							? orientationSign * tickSpacing
+							: 0;
+					y =
+						textOrientation === 'vertical' ? 0 : orientationSign * tickSpacing;
+					dy =
+						textOrientation === 'vertical' || textOrientation === 'diagonal'
+							? '.32em'
+							: '.71em';
 					break;
 				case 'top':
+					if (textOrientation === 'vertical') {
+						orientationSign = -orientationSign;
+					}
 					textAnchor =
 						textOrientation === 'vertical'
-							? 'end'
-							: textOrientation === 'diagonal' ? 'start' : 'middle';
+							? 'start'
+							: textOrientation === 'diagonal' ? 'end' : 'middle';
+					x =
+						textOrientation === 'vertical' || textOrientation === 'diagonal'
+							? orientationSign * tickSpacing
+							: 0;
+					y =
+						textOrientation === 'vertical' ? 0 : orientationSign * tickSpacing;
+					dy =
+						textOrientation === 'vertical' || textOrientation === 'diagonal'
+							? '.32em'
+							: '0em';
 					break;
 				case 'right':
-					textAnchor =
+					textAnchor = textOrientation === 'vertical' ? 'middle' : 'start';
+					x =
+						textOrientation === 'vertical' ? 0 : orientationSign * tickSpacing;
+					y =
 						textOrientation === 'vertical'
-							? 'end'
-							: textOrientation === 'diagonal' ? 'start' : 'middle';
+							? orientationSign * tickSpacing
+							: textOrientation === 'horizontal'
+								? 0
+								: -orientationSign * tickSpacing;
+					dy = textOrientation === 'vertical' ? '.71em' : '.32em';
 					break;
 				case 'left':
 					textAnchor =
 						textOrientation === 'vertical'
-							? 'middle'
+							? 'start'
 							: textOrientation === 'diagonal' ? 'end' : 'end';
+					x = orientationSign * tickSpacing;
+					y =
+						textOrientation === 'vertical' ? orientationSign * tickSpacing : 0;
+					dy =
+						textOrientation === 'vertical'
+							? '0em'
+							: textOrientation === 'horizontal' ? '.32em' : '.71em';
 					break;
 			}
 			return {
@@ -148,33 +188,15 @@ const Axis = createClass({
 						? 'rotate(-90)'
 						: textOrientation === 'diagonal' ? 'rotate(45)' : '',
 				textAnchor,
-				x: -1 * tickSpacing,
-				y: -1 * tickSpacing / 2,
+				x,
+				y,
+				dy,
 			};
 		};
 		const orientationProperties = {
 			vertical: getOrientationProperties(orient, 'vertical'),
-			// vertical: {
-			// 	transform: 'rotate(-90)',
-			// 	// check textAnchor
-			// 	textAnchor: sign < 0 ? 'end' : 'end',
-			// 	// x: isH ? 0 : sign * tickSpacing,
-			// 	// y: isH ? sign * tickSpacing : 0,
-			// 	x: (-1 * tickSpacing),
-			// 	y: (-1 * tickSpacing) / 2,
-			// },
-			horizontal: {
-				transform: '',
-				textAnchor: isH ? 'middle' : sign < 0 ? 'end' : 'start',
-				x: isH ? 0 : sign * tickSpacing,
-				y: isH ? sign * tickSpacing : 0,
-			},
-			diagonal: {
-				transform: 'rotate(45)',
-				textAnchor: 'start',
-				x: sign * tickSpacing,
-				y: sign * tickSpacing,
-			},
+			horizontal: getOrientationProperties(orient, 'horizontal'),
+			diagonal: getOrientationProperties(orient, 'diagonal'),
 		};
 		const orientationKey = textOrientation || 'horizontal';
 
@@ -219,9 +241,10 @@ const Axis = createClass({
 							x={orientationProperties[orientationKey].x}
 							y={orientationProperties[orientationKey].y}
 							dy={
-								isH
-									? sign < 0 ? '0em' : '.71em' // magic d3 number
-									: '.32em' // magic d3 number
+								orientationProperties[orientationKey].dy
+								// isH
+								// 	? sign < 0 ? '0em' : '.71em' // magic d3 number
+								// 	: '.32em' // magic d3 number
 							}
 							style={{
 								textAnchor: orientationProperties[orientationKey].textAnchor,

--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -125,17 +125,16 @@ const Axis = createClass({
 					textAnchor =
 						textOrientation === 'vertical'
 							? 'end'
-							: textOrientation === 'diagonal' ? 'start' : 'middle';
+							: textOrientation === 'diagonal' ? 'end' : 'middle';
 					x =
-						textOrientation === 'vertical' || textOrientation === 'diagonal'
+						textOrientation === 'vertical'
 							? orientationSign * tickSpacing
-							: 0;
+							: textOrientation === 'diagonal'
+								? -orientationSign * tickSpacing
+								: 0;
 					y =
 						textOrientation === 'vertical' ? 0 : orientationSign * tickSpacing;
-					dy =
-						textOrientation === 'vertical' || textOrientation === 'diagonal'
-							? '.32em'
-							: '.71em';
+					dy = textOrientation === 'vertical' ? '.32em' : '.71em';
 					break;
 				case 'top':
 					if (textOrientation === 'vertical') {
@@ -169,11 +168,9 @@ const Axis = createClass({
 					dy = textOrientation === 'vertical' ? '.71em' : '.32em';
 					break;
 				case 'left':
-					textAnchor =
-						textOrientation === 'vertical'
-							? 'start'
-							: textOrientation === 'diagonal' ? 'end' : 'end';
-					x = orientationSign * tickSpacing;
+					textAnchor = textOrientation === 'vertical' ? 'middle' : 'end';
+					x =
+						textOrientation === 'vertical' ? 0 : orientationSign * tickSpacing;
 					y =
 						textOrientation === 'vertical' ? orientationSign * tickSpacing : 0;
 					dy =
@@ -189,7 +186,7 @@ const Axis = createClass({
 						: textOrientation === 'horizontal'
 							? ''
 							: orient === 'bottom' || orient === 'left'
-								? 'rotate(45)'
+								? 'rotate(-30)'
 								: 'rotate(-30)',
 				textAnchor,
 				x,

--- a/src/components/Axis/Axis.jsx
+++ b/src/components/Axis/Axis.jsx
@@ -144,10 +144,10 @@ const Axis = createClass({
 					textAnchor =
 						textOrientation === 'vertical'
 							? 'start'
-							: textOrientation === 'diagonal' ? 'end' : 'middle';
+							: textOrientation === 'diagonal' ? 'start' : 'middle';
 					x =
 						textOrientation === 'vertical' || textOrientation === 'diagonal'
-							? orientationSign * tickSpacing
+							? -orientationSign * tickSpacing
 							: 0;
 					y =
 						textOrientation === 'vertical' ? 0 : orientationSign * tickSpacing;
@@ -165,7 +165,7 @@ const Axis = createClass({
 							? orientationSign * tickSpacing
 							: textOrientation === 'horizontal'
 								? 0
-								: -orientationSign * tickSpacing;
+								: orientationSign * tickSpacing;
 					dy = textOrientation === 'vertical' ? '.71em' : '.32em';
 					break;
 				case 'left':
@@ -186,7 +186,11 @@ const Axis = createClass({
 				transform:
 					textOrientation === 'vertical'
 						? 'rotate(-90)'
-						: textOrientation === 'diagonal' ? 'rotate(45)' : '',
+						: textOrientation === 'horizontal'
+							? ''
+							: orient === 'bottom' || orient === 'left'
+								? 'rotate(45)'
+								: 'rotate(-30)',
 				textAnchor,
 				x,
 				y,

--- a/src/components/Axis/__snapshots__/Axis.spec.jsx.snap
+++ b/src/components/Axis/__snapshots__/Axis.spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
 >
   <path
     className="lucid-Axis-domain"
-    d="M0,6V0H360V6"
+    d="M0,6V0H440V6"
   />
   <g
     key="0"
@@ -25,6 +25,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -33,7 +34,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
   </g>
   <g
     key="20000"
-    transform="translate(72, 0)"
+    transform="translate(88, 0)"
   >
     <line
       className="lucid-Axis-tick"
@@ -48,6 +49,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -56,7 +58,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
   </g>
   <g
     key="40000"
-    transform="translate(144, 0)"
+    transform="translate(176, 0)"
   >
     <line
       className="lucid-Axis-tick"
@@ -71,6 +73,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -79,7 +82,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
   </g>
   <g
     key="60000"
-    transform="translate(216, 0)"
+    transform="translate(264, 0)"
   >
     <line
       className="lucid-Axis-tick"
@@ -94,6 +97,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -102,7 +106,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
   </g>
   <g
     key="80000"
-    transform="translate(288, 0)"
+    transform="translate(352, 0)"
   >
     <line
       className="lucid-Axis-tick"
@@ -117,6 +121,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -125,7 +130,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
   </g>
   <g
     key="100000"
-    transform="translate(360, 0)"
+    transform="translate(440, 0)"
   >
     <line
       className="lucid-Axis-tick"
@@ -140,6 +145,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 2.bottom 1`]
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -174,6 +180,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 3.top 1`] = 
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={-9}
     >
@@ -197,6 +204,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 3.top 1`] = 
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={-9}
     >
@@ -220,6 +228,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 3.top 1`] = 
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={-9}
     >
@@ -243,6 +252,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 3.top 1`] = 
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={-9}
     >
@@ -266,6 +276,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 3.top 1`] = 
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={-9}
     >
@@ -289,6 +300,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 3.top 1`] = 
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={-9}
     >
@@ -323,6 +335,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -346,6 +359,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -369,6 +383,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -392,6 +407,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -415,6 +431,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -438,6 +455,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -461,6 +479,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -484,6 +503,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -507,6 +527,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -530,6 +551,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -553,6 +575,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 4.left 1`] =
           "textAnchor": "end",
         }
       }
+      transform=""
       x={-9}
       y={0}
     >
@@ -587,6 +610,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
@@ -594,7 +618,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
     </text>
   </g>
   <g
-    key="10000"
+    key="5"
     transform="translate(0, 162)"
   >
     <line
@@ -610,14 +634,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      10,000
+      5
     </text>
   </g>
   <g
-    key="20000"
+    key="10"
     transform="translate(0, 144)"
   >
     <line
@@ -633,14 +658,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      20,000
+      10
     </text>
   </g>
   <g
-    key="30000"
+    key="15"
     transform="translate(0, 126)"
   >
     <line
@@ -656,14 +682,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      30,000
+      15
     </text>
   </g>
   <g
-    key="40000"
+    key="20"
     transform="translate(0, 108)"
   >
     <line
@@ -679,14 +706,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      40,000
+      20
     </text>
   </g>
   <g
-    key="50000"
+    key="25"
     transform="translate(0, 90)"
   >
     <line
@@ -702,14 +730,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      50,000
+      25
     </text>
   </g>
   <g
-    key="60000"
+    key="30"
     transform="translate(0, 72)"
   >
     <line
@@ -725,14 +754,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      60,000
+      30
     </text>
   </g>
   <g
-    key="70000"
+    key="35"
     transform="translate(0, 54.000000000000014)"
   >
     <line
@@ -748,14 +778,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      70,000
+      35
     </text>
   </g>
   <g
-    key="80000"
+    key="40"
     transform="translate(0, 36)"
   >
     <line
@@ -771,14 +802,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      80,000
+      40
     </text>
   </g>
   <g
-    key="90000"
+    key="45"
     transform="translate(0, 18)"
   >
     <line
@@ -794,14 +826,15 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      90,000
+      45
     </text>
   </g>
   <g
-    key="100000"
+    key="50"
     transform="translate(0, 0)"
   >
     <line
@@ -817,10 +850,11 @@ exports[`Axis [common] example testing should match snapshot(s) for 5.right 1`] 
           "textAnchor": "start",
         }
       }
+      transform=""
       x={9}
       y={0}
     >
-      100,000
+      50
     </text>
   </g>
 </g>
@@ -851,6 +885,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -874,6 +909,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -897,6 +933,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -920,6 +957,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -943,6 +981,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -966,6 +1005,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -989,6 +1029,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1012,6 +1053,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1035,6 +1077,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 1`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1069,6 +1112,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 2`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1092,6 +1136,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 2`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1115,6 +1160,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 2`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1138,6 +1184,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 2`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1161,6 +1208,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 2`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1195,6 +1243,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 3`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1218,6 +1267,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 3`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1241,6 +1291,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 6.time 3`] =
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1275,6 +1326,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 7.ordinal 1`
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1298,6 +1350,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 7.ordinal 1`
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1321,6 +1374,7 @@ exports[`Axis [common] example testing should match snapshot(s) for 7.ordinal 1`
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
@@ -1344,10 +1398,631 @@ exports[`Axis [common] example testing should match snapshot(s) for 7.ordinal 1`
           "textAnchor": "middle",
         }
       }
+      transform=""
       x={0}
       y={9}
     >
       d
+    </text>
+  </g>
+</g>
+`;
+
+exports[`Axis [common] example testing should match snapshot(s) for 8.diagonal-text 1`] = `
+<g
+  className="lucid-Axis"
+>
+  <path
+    className="lucid-Axis-domain"
+    d="M0,-6V0H440V-6"
+  />
+  <g
+    key="0"
+    transform="translate(0, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={-6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={-9}
+    >
+      0
+    </text>
+  </g>
+  <g
+    key="20000"
+    transform="translate(88, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={-6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={-9}
+    >
+      20,000
+    </text>
+  </g>
+  <g
+    key="40000"
+    transform="translate(176, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={-6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={-9}
+    >
+      40,000
+    </text>
+  </g>
+  <g
+    key="60000"
+    transform="translate(264, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={-6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={-9}
+    >
+      60,000
+    </text>
+  </g>
+  <g
+    key="80000"
+    transform="translate(352, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={-6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={-9}
+    >
+      80,000
+    </text>
+  </g>
+  <g
+    key="100000"
+    transform="translate(440, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={-6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={-9}
+    >
+      100,000
+    </text>
+  </g>
+</g>
+`;
+
+exports[`Axis [common] example testing should match snapshot(s) for 8.diagonal-text 2`] = `
+<g
+  className="lucid-Axis"
+>
+  <path
+    className="lucid-Axis-domain"
+    d="M0,6V0H440V6"
+  />
+  <g
+    key="0"
+    transform="translate(0, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={9}
+    >
+      0
+    </text>
+  </g>
+  <g
+    key="20000"
+    transform="translate(88, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={9}
+    >
+      20,000
+    </text>
+  </g>
+  <g
+    key="40000"
+    transform="translate(176, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={9}
+    >
+      40,000
+    </text>
+  </g>
+  <g
+    key="60000"
+    transform="translate(264, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={9}
+    >
+      60,000
+    </text>
+  </g>
+  <g
+    key="80000"
+    transform="translate(352, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={9}
+    >
+      80,000
+    </text>
+  </g>
+  <g
+    key="100000"
+    transform="translate(440, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={0}
+      y2={6}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={9}
+    >
+      100,000
+    </text>
+  </g>
+</g>
+`;
+
+exports[`Axis [common] example testing should match snapshot(s) for 8.diagonal-text 3`] = `
+<g
+  className="lucid-Axis"
+>
+  <path
+    className="lucid-Axis-domain"
+    d="M6,150H0V0H6"
+  />
+  <g
+    key="0"
+    transform="translate(0, 150)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={9}
+    >
+      0
+    </text>
+  </g>
+  <g
+    key="20000"
+    transform="translate(0, 120)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={9}
+    >
+      20,000
+    </text>
+  </g>
+  <g
+    key="40000"
+    transform="translate(0, 90)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={9}
+    >
+      40,000
+    </text>
+  </g>
+  <g
+    key="60000"
+    transform="translate(0, 60)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={9}
+    >
+      60,000
+    </text>
+  </g>
+  <g
+    key="80000"
+    transform="translate(0, 30)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={9}
+    >
+      80,000
+    </text>
+  </g>
+  <g
+    key="100000"
+    transform="translate(0, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".32em"
+      style={
+        Object {
+          "textAnchor": "start",
+        }
+      }
+      transform="rotate(-30)"
+      x={9}
+      y={9}
+    >
+      100,000
+    </text>
+  </g>
+</g>
+`;
+
+exports[`Axis [common] example testing should match snapshot(s) for 8.diagonal-text 4`] = `
+<g
+  className="lucid-Axis"
+>
+  <path
+    className="lucid-Axis-domain"
+    d="M-6,150H0V0H-6"
+  />
+  <g
+    key="0"
+    transform="translate(0, 150)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={-6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={-9}
+    >
+      0
+    </text>
+  </g>
+  <g
+    key="20000"
+    transform="translate(0, 120)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={-6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={-9}
+    >
+      20,000
+    </text>
+  </g>
+  <g
+    key="40000"
+    transform="translate(0, 90)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={-6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={-9}
+    >
+      40,000
+    </text>
+  </g>
+  <g
+    key="60000"
+    transform="translate(0, 60)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={-6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={-9}
+    >
+      60,000
+    </text>
+  </g>
+  <g
+    key="80000"
+    transform="translate(0, 30)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={-6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={-9}
+    >
+      80,000
+    </text>
+  </g>
+  <g
+    key="100000"
+    transform="translate(0, 0)"
+  >
+    <line
+      className="lucid-Axis-tick"
+      x2={-6}
+      y2={0}
+    />
+    <text
+      className="lucid-Axis-tick-text"
+      dy=".71em"
+      style={
+        Object {
+          "textAnchor": "end",
+        }
+      }
+      transform="rotate(-30)"
+      x={-9}
+      y={-9}
+    >
+      100,000
     </text>
   </g>
 </g>

--- a/src/components/Axis/examples/2.bottom.jsx
+++ b/src/components/Axis/examples/2.bottom.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import createClass from 'create-react-class';
 import { Axis, d3Scale } from '../../../index';
 
-const margin = { right: 20, left: 20 };
-const width = 400;
-const height = 50;
+const margin = { right: 40, left: 20, top: 40, bottom: 10 };
+const width = 500;
+const height = 100;
 const innerWidth = width - margin.right - margin.left;
 const x = d3Scale
 	.scaleLinear()

--- a/src/components/Axis/examples/3.top.jsx
+++ b/src/components/Axis/examples/3.top.jsx
@@ -16,7 +16,12 @@ export default createClass({
 		return (
 			<svg width={width} height={height}>
 				<g transform={`translate(${margin.left}, ${height / 2})`}>
-					<Axis scale={x} orient="top" tickCount={6} />
+					<Axis
+						scale={x}
+						orient="top"
+						textOrientation="horizontal"
+						tickCount={6}
+					/>
 				</g>
 			</svg>
 		);

--- a/src/components/Axis/examples/5.right.jsx
+++ b/src/components/Axis/examples/5.right.jsx
@@ -8,7 +8,7 @@ const height = 200;
 const innerHeight = height - margin.top - margin.bottom;
 const y = d3Scale
 	.scaleLinear()
-	.domain([0, 100000])
+	.domain([0, 50])
 	.range([innerHeight, 0]);
 
 export default createClass({
@@ -16,7 +16,7 @@ export default createClass({
 		return (
 			<svg width={width} height={height}>
 				<g transform={`translate(0, ${margin.top})`}>
-					<Axis scale={y} orient="right" />
+					<Axis scale={y} orient="right" textOrientation="horizontal" />
 				</g>
 			</svg>
 		);

--- a/src/components/Axis/examples/8.diagonal-text.jsx
+++ b/src/components/Axis/examples/8.diagonal-text.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Axis, d3Scale } from '../../../index';
+
+const margin = { right: 20, left: 20, top: 10, bottom: 10 };
+const horizontalAxisWidth = 500;
+const horizontalAxisHeight = 100;
+const verticalAxisWidth = 100;
+const verticalAxisHeight = 200;
+const innerWidth = horizontalAxisWidth - margin.right - margin.left;
+const innerHeight = verticalAxisHeight - margin.top - margin.bottom;
+const x = d3Scale
+	.scaleLinear()
+	.domain([0, 100000])
+	.range([0, innerWidth]);
+const y = d3Scale
+	.scaleLinear()
+	.domain([0, 100000])
+	.range([innerHeight, 0]);
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<div>
+					<p>top</p>
+					<svg width={horizontalAxisWidth} height={horizontalAxisHeight}>
+						<g
+							transform={`translate(${margin.left}, ${horizontalAxisHeight /
+								2})`}
+						>
+							<Axis
+								scale={x}
+								orient="top"
+								textOrientation="diagonal"
+								tickCount={6}
+							/>
+						</g>
+					</svg>
+				</div>
+				<div>
+					<p>bottom</p>
+					<svg width={horizontalAxisWidth} height={horizontalAxisHeight}>
+						<g
+							transform={`translate(${margin.left}, ${horizontalAxisHeight /
+								2})`}
+						>
+							<Axis
+								scale={x}
+								orient="bottom"
+								textOrientation="diagonal"
+								tickCount={6}
+							/>
+						</g>
+					</svg>
+				</div>
+				<div>
+					<p>right</p>
+					<svg width={verticalAxisWidth} height={verticalAxisHeight}>
+						<g transform={`translate(0, ${margin.top})`}>
+							<Axis
+								scale={y}
+								orient="right"
+								textOrientation="diagonal"
+								tickCount={6}
+							/>
+						</g>
+					</svg>
+				</div>
+				<div>
+					<p>left</p>
+					<svg width={verticalAxisWidth} height={verticalAxisHeight}>
+						<g transform={`translate(${verticalAxisWidth - 1}, ${margin.top})`}>
+							<Axis
+								scale={y}
+								orient="left"
+								textOrientation="diagonal"
+								tickCount={6}
+							/>
+						</g>
+					</svg>
+				</div>
+			</div>
+		);
+	},
+});

--- a/src/components/Axis/examples/8.diagonal-text.jsx
+++ b/src/components/Axis/examples/8.diagonal-text.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import createClass from 'create-react-class';
 import { Axis, d3Scale } from '../../../index';
 
+// individual margin values may need to be changed to
+// prevent or add extra padding depending on use of axis.
 const margin = { right: 30, left: 20, top: 40, bottom: 10 };
 const horizontalAxisWidth = 500;
 const horizontalAxisHeight = 100;

--- a/src/components/Axis/examples/8.diagonal-text.jsx
+++ b/src/components/Axis/examples/8.diagonal-text.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import createClass from 'create-react-class';
 import { Axis, d3Scale } from '../../../index';
 
-const margin = { right: 20, left: 20, top: 10, bottom: 10 };
+const margin = { right: 30, left: 20, top: 40, bottom: 10 };
 const horizontalAxisWidth = 500;
 const horizontalAxisHeight = 100;
 const verticalAxisWidth = 100;

--- a/src/components/Axis/examples/8.diagonal-text.jsx
+++ b/src/components/Axis/examples/8.diagonal-text.jsx
@@ -4,7 +4,7 @@ import { Axis, d3Scale } from '../../../index';
 
 // individual margin values may need to be changed to
 // prevent or add extra padding depending on use of axis.
-const margin = { right: 30, left: 20, top: 40, bottom: 10 };
+const margin = { right: 40, left: 20, top: 40, bottom: 10 };
 const horizontalAxisWidth = 500;
 const horizontalAxisHeight = 100;
 const verticalAxisWidth = 100;
@@ -42,7 +42,12 @@ export default createClass({
 				</div>
 				<div>
 					<p>bottom</p>
-					<svg width={horizontalAxisWidth} height={horizontalAxisHeight}>
+					<svg
+						width={horizontalAxisWidth}
+						height={horizontalAxisHeight}
+						margin="400"
+						style={{ marginRight: 40 }}
+					>
 						<g
 							transform={`translate(${margin.left}, ${horizontalAxisHeight /
 								2})`}

--- a/src/components/Axis/examples/8.diagonal-text.jsx
+++ b/src/components/Axis/examples/8.diagonal-text.jsx
@@ -46,7 +46,6 @@ export default createClass({
 						width={horizontalAxisWidth}
 						height={horizontalAxisHeight}
 						margin="400"
-						style={{ marginRight: 40 }}
 					>
 						<g
 							transform={`translate(${margin.left}, ${horizontalAxisHeight /

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -387,7 +387,7 @@ const BarChart = createClass({
 				<g transform={`translate(${margin.left}, ${innerHeight + margin.top})`}>
 					<Axis
 						orient="bottom"
-						textOrientation="diagonal"
+						textOrientation="vertical"
 						scale={xScale}
 						outerTickSize={0}
 						tickFormat={xAxisFinalFormatter}
@@ -456,6 +456,7 @@ const BarChart = createClass({
 				<g transform={`translate(${margin.left}, ${margin.top})`}>
 					<Axis
 						orient="left"
+						textOrientation="vertical"
 						scale={yScale}
 						tickFormat={yAxisFinalFormatter}
 						tickCount={yAxisTickCount}

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -45,7 +45,7 @@ const BarChart = createClass({
 		MARGIN: {
 			top: 10,
 			right: 20,
-			bottom: 50,
+			bottom: 75,
 			left: 80,
 		},
 	},
@@ -230,7 +230,7 @@ const BarChart = createClass({
 			margin: {
 				top: 10,
 				right: 20,
-				bottom: 50,
+				bottom: 75,
 				left: 80,
 			},
 			palette: chartConstants.PALETTE_6,
@@ -387,6 +387,7 @@ const BarChart = createClass({
 				<g transform={`translate(${margin.left}, ${innerHeight + margin.top})`}>
 					<Axis
 						orient="bottom"
+						textOrientation="diagonal"
 						scale={xScale}
 						outerTickSize={0}
 						tickFormat={xAxisFinalFormatter}

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -386,8 +386,8 @@ const BarChart = createClass({
 				{/* x axis */}
 				<g transform={`translate(${margin.left}, ${innerHeight + margin.top})`}>
 					<Axis
-						orient="top"
-						textOrientation="diagonal"
+						orient="bottom"
+						textOrientation="horizontal"
 						scale={xScale}
 						outerTickSize={0}
 						tickFormat={xAxisFinalFormatter}
@@ -456,7 +456,7 @@ const BarChart = createClass({
 				<g transform={`translate(${margin.left}, ${margin.top})`}>
 					<Axis
 						orient="left"
-						textOrientation="diagonal"
+						textOrientation="horizontal"
 						scale={yScale}
 						tickFormat={yAxisFinalFormatter}
 						tickCount={yAxisTickCount}

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -386,8 +386,8 @@ const BarChart = createClass({
 				{/* x axis */}
 				<g transform={`translate(${margin.left}, ${innerHeight + margin.top})`}>
 					<Axis
-						orient="bottom"
-						textOrientation="vertical"
+						orient="top"
+						textOrientation="diagonal"
 						scale={xScale}
 						outerTickSize={0}
 						tickFormat={xAxisFinalFormatter}
@@ -456,7 +456,7 @@ const BarChart = createClass({
 				<g transform={`translate(${margin.left}, ${margin.top})`}>
 					<Axis
 						orient="left"
-						textOrientation="vertical"
+						textOrientation="diagonal"
 						scale={yScale}
 						tickFormat={yAxisFinalFormatter}
 						tickCount={yAxisTickCount}

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -241,7 +241,7 @@ const BarChart = createClass({
 			margin: {
 				top: 10,
 				right: 20,
-				bottom: 75,
+				bottom: 50,
 				left: 80,
 			},
 			palette: chartConstants.PALETTE_6,

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -402,7 +402,6 @@ const BarChart = createClass({
 				<g transform={`translate(${margin.left}, ${innerHeight + margin.top})`}>
 					<Axis
 						orient="bottom"
-						// textOrientation={xAxisTickCount > 2 ? "diagonal" : ''}
 						scale={xScale}
 						outerTickSize={0}
 						tickFormat={xAxisFinalFormatter}

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -26,6 +26,7 @@ const {
 	array,
 	bool,
 	oneOfType,
+	oneOf,
 } = PropTypes;
 
 const BarChart = createClass({
@@ -220,6 +221,16 @@ const BarChart = createClass({
 			and yAxisTooltipDataFormatter. Signature:
 			\`dataPoint => {}\`
 		`,
+
+		xAxisTextOrientation: oneOf(['vertical', 'horizontal', 'diagonal'])`
+			Determines the orientation of the tick text. This may override what the orient prop
+			tries to determine.
+		`,
+
+		yAxisTextOrientation: oneOf(['vertical', 'horizontal', 'diagonal'])`
+			Determines the orientation of the tick text. This may override what the orient prop
+			tries to determine.
+		`,
 	},
 
 	getDefaultProps() {
@@ -244,6 +255,7 @@ const BarChart = createClass({
 			xAxisTitle: null,
 			xAxisTitleColor: '#000',
 			xAxisFormatter: _.identity,
+			xAxisTextOrientation: 'horizontal',
 
 			yAxisFields: ['y'],
 			yAxisTickCount: null,
@@ -253,6 +265,7 @@ const BarChart = createClass({
 			yAxisTitleColor: '#000',
 			yAxisTooltipFormatter: (yField, yValueFormatted) =>
 				`${yField}: ${yValueFormatted}`,
+			yAxisTextOrientation: 'horizontal',
 		};
 	},
 
@@ -282,6 +295,7 @@ const BarChart = createClass({
 			xAxisTitle,
 			xAxisTitleColor,
 			xAxisTickCount,
+			xAxisTextOrientation,
 
 			yAxisFields,
 			yAxisFormatter,
@@ -295,6 +309,7 @@ const BarChart = createClass({
 			yAxisMax = yAxisIsStacked
 				? maxByFieldsStacked(data, yAxisFields)
 				: maxByFields(data, yAxisFields),
+			yAxisTextOrientation,
 
 			...passThroughs
 		} = this.props;
@@ -387,11 +402,12 @@ const BarChart = createClass({
 				<g transform={`translate(${margin.left}, ${innerHeight + margin.top})`}>
 					<Axis
 						orient="bottom"
-						textOrientation="horizontal"
+						// textOrientation={xAxisTickCount > 2 ? "diagonal" : ''}
 						scale={xScale}
 						outerTickSize={0}
 						tickFormat={xAxisFinalFormatter}
 						tickCount={xAxisTickCount}
+						textOrientation={xAxisTextOrientation}
 					/>
 
 					{hasLegend ? (
@@ -460,6 +476,7 @@ const BarChart = createClass({
 						scale={yScale}
 						tickFormat={yAxisFinalFormatter}
 						tickCount={yAxisTickCount}
+						textOrientation={yAxisTextOrientation}
 					/>
 				</g>
 

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -46,7 +46,7 @@ const BarChart = createClass({
 		MARGIN: {
 			top: 10,
 			right: 20,
-			bottom: 75,
+			bottom: 50,
 			left: 80,
 		},
 	},

--- a/src/components/BarChart/__snapshots__/BarChart.spec.jsx.snap
+++ b/src/components/BarChart/__snapshots__/BarChart.spec.jsx.snap
@@ -7,44 +7,46 @@ exports[`BarChart [common] example testing should match snapshot(s) for 01.basic
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
     />
   </g>
   <g
-    transform="translate(80, 10)"
+    transform="translate(80, 20)"
   >
     <Axis
       innerTickSize={6}
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
     />
   </g>
   <g
-    transform="translate(0, 10)"
+    transform="translate(0, 20)"
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={305}
       label="Revenue"
       orient="left"
       width={80}
     />
   </g>
   <g
-    transform="translate(80, 10)"
+    transform="translate(80, 20)"
   >
     <Bars
       colorOffset={0}
@@ -105,13 +107,14 @@ exports[`BarChart [common] example testing should match snapshot(s) for 03.group
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -125,6 +128,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 03.group
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -135,7 +139,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 03.group
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={315}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -239,13 +243,14 @@ exports[`BarChart [common] example testing should match snapshot(s) for 04.group
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -259,6 +264,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 04.group
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -269,7 +275,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 04.group
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={315}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -349,13 +355,14 @@ exports[`BarChart [common] example testing should match snapshot(s) for 05.limit
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={5}
       tickFormat={[Function]}
       tickPadding={3}
@@ -369,6 +376,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 05.limit
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={4}
       tickFormat={[Function]}
       tickPadding={3}
@@ -488,24 +496,25 @@ exports[`BarChart [common] example testing should match snapshot(s) for 06.all-t
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={2}
       tickFormat={[Function]}
       tickPadding={3}
     />
   </g>
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <AxisLabel
       color="#000"
-      height={50}
+      height={75}
       label="Weekdays"
       orient="bottom"
       width={900}
@@ -519,6 +528,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 06.all-t
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={4}
       tickFormat={[Function]}
       tickPadding={3}
@@ -529,7 +539,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 06.all-t
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={315}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -608,13 +618,14 @@ exports[`BarChart [common] example testing should match snapshot(s) for 07.stack
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -628,6 +639,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 07.stack
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -638,7 +650,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 07.stack
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={315}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -710,13 +722,14 @@ exports[`BarChart [common] example testing should match snapshot(s) for 08.unfor
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -730,6 +743,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 08.unfor
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -740,7 +754,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 08.unfor
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={315}
       label="Revenue"
       orient="left"
       width={80}
@@ -808,13 +822,14 @@ exports[`BarChart [common] example testing should match snapshot(s) for 09.forma
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -828,6 +843,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 09.forma
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -838,7 +854,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 09.forma
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={315}
       label="Revenue"
       orient="left"
       width={80}
@@ -906,13 +922,14 @@ exports[`BarChart [common] example testing should match snapshot(s) for 10.forma
   width={1000}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(80, 325)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -926,6 +943,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 10.forma
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -936,7 +954,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 10.forma
   >
     <AxisLabel
       color="#000"
-      height={340}
+      height={315}
       label="Revenue"
       orient="left"
       width={80}
@@ -1008,7 +1026,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 11.empty
     width={1000}
   >
     <g
-      transform="translate(80, 350)"
+      transform="translate(80, 325)"
     >
       <Axis
         innerTickSize={6}
@@ -1058,7 +1076,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 12.empty
     width={1000}
   >
     <g
-      transform="translate(80, 350)"
+      transform="translate(80, 325)"
     >
       <Axis
         innerTickSize={6}
@@ -1089,37 +1107,39 @@ exports[`BarChart [common] example testing should match snapshot(s) for 12.empty
 exports[`BarChart [common] example testing should match snapshot(s) for 13.many-bars 1`] = `
 <svg
   className="lucid-BarChart"
-  height={400}
-  width={1000}
+  height={600}
+  width={1400}
 >
   <g
-    transform="translate(80, 350)"
+    transform="translate(300, 300)"
   >
     <Axis
       innerTickSize={6}
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
-      tickCount={null}
+      textOrientation="diagonal"
+      tickCount={20}
       tickFormat={[Function]}
       tickPadding={3}
     />
   </g>
   <g
-    transform="translate(80, 10)"
+    transform="translate(300, 10)"
   >
     <Axis
       innerTickSize={6}
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
     />
   </g>
   <g
-    transform="translate(80, 10)"
+    transform="translate(300, 10)"
   >
     <Bars
       colorOffset={0}

--- a/src/components/BarChart/__snapshots__/BarChart.spec.jsx.snap
+++ b/src/components/BarChart/__snapshots__/BarChart.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 01.basic
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -39,7 +39,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 01.basic
   >
     <AxisLabel
       color="#000"
-      height={305}
+      height={330}
       label="Revenue"
       orient="left"
       width={80}
@@ -1033,6 +1033,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 11.empty
         orient="bottom"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickPadding={3}
       />
@@ -1045,6 +1046,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 11.empty
         orient="left"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickFormat={[Function]}
         tickPadding={3}
@@ -1083,6 +1085,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 12.empty
         orient="bottom"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickPadding={3}
       />
@@ -1095,6 +1098,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 12.empty
         orient="left"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickFormat={[Function]}
         tickPadding={3}

--- a/src/components/BarChart/__snapshots__/BarChart.spec.jsx.snap
+++ b/src/components/BarChart/__snapshots__/BarChart.spec.jsx.snap
@@ -107,7 +107,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 03.group
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -139,7 +139,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 03.group
   >
     <AxisLabel
       color="#000"
-      height={315}
+      height={340}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -243,7 +243,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 04.group
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -275,7 +275,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 04.group
   >
     <AxisLabel
       color="#000"
-      height={315}
+      height={340}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -355,7 +355,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 05.limit
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -496,7 +496,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 06.all-t
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -510,11 +510,11 @@ exports[`BarChart [common] example testing should match snapshot(s) for 06.all-t
     />
   </g>
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <AxisLabel
       color="#000"
-      height={75}
+      height={50}
       label="Weekdays"
       orient="bottom"
       width={900}
@@ -539,7 +539,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 06.all-t
   >
     <AxisLabel
       color="#000"
-      height={315}
+      height={340}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -618,7 +618,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 07.stack
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -650,7 +650,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 07.stack
   >
     <AxisLabel
       color="#000"
-      height={315}
+      height={340}
       label="Fruit Count"
       orient="left"
       width={80}
@@ -722,7 +722,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 08.unfor
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -754,7 +754,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 08.unfor
   >
     <AxisLabel
       color="#000"
-      height={315}
+      height={340}
       label="Revenue"
       orient="left"
       width={80}
@@ -822,7 +822,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 09.forma
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -854,7 +854,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 09.forma
   >
     <AxisLabel
       color="#000"
-      height={315}
+      height={340}
       label="Revenue"
       orient="left"
       width={80}
@@ -922,7 +922,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 10.forma
   width={1000}
 >
   <g
-    transform="translate(80, 325)"
+    transform="translate(80, 350)"
   >
     <Axis
       innerTickSize={6}
@@ -954,7 +954,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 10.forma
   >
     <AxisLabel
       color="#000"
-      height={315}
+      height={340}
       label="Revenue"
       orient="left"
       width={80}
@@ -1026,7 +1026,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 11.empty
     width={1000}
   >
     <g
-      transform="translate(80, 325)"
+      transform="translate(80, 350)"
     >
       <Axis
         innerTickSize={6}
@@ -1078,7 +1078,7 @@ exports[`BarChart [common] example testing should match snapshot(s) for 12.empty
     width={1000}
   >
     <g
-      transform="translate(80, 325)"
+      transform="translate(80, 350)"
     >
       <Axis
         innerTickSize={6}

--- a/src/components/BarChart/examples/01.basic.jsx
+++ b/src/components/BarChart/examples/01.basic.jsx
@@ -13,7 +13,7 @@ export default createClass({
 	render() {
 		return (
 			<div>
-				<BarChart data={data} yAxisTitle="Revenue" />
+				<BarChart data={data} yAxisTitle="Revenue" margin={{ top: 20 }} />
 			</div>
 		);
 	},

--- a/src/components/BarChart/examples/13.many-bars.jsx
+++ b/src/components/BarChart/examples/13.many-bars.jsx
@@ -10,6 +10,16 @@ const data = _.map(_.range(0, 200), n => ({
 
 export default createClass({
 	render() {
-		return <BarChart data={data} />;
+		return (
+			<BarChart
+				data={data}
+				xAxisTextOrientation="diagonal"
+				yAxisTextOrientation="horizontal"
+				xAxisTickCount={20}
+				height={600}
+				width={1400}
+				margin={{ bottom: 300, left: 300 }}
+			/>
+		);
 	},
 });

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -35,6 +35,7 @@ const {
 	string,
 	bool,
 	oneOfType,
+	oneOf,
 } = PropTypes;
 
 const LineChart = createClass({
@@ -192,6 +193,11 @@ const LineChart = createClass({
 			\`number\` is supported only for backwards compatability.
 		`,
 
+		xAxisTextOrientation: oneOf(['vertical', 'horizontal', 'diagonal'])`
+			Determines the orientation of the tick text. This may override what the orient prop
+			tries to determine.
+		`,
+
 		yAxisFields: arrayOf(string)`
 			An array of your y axis fields. Typically this will just be a single item
 			unless you need to display multiple lines. The order of the array
@@ -316,6 +322,11 @@ const LineChart = createClass({
 			Set the starting index where colors start rotating for points and lines
 			along the y2 axis.
 		`,
+
+		yAxisTextOrientation: oneOf(['vertical', 'horizontal', 'diagonal'])`
+			Determines the orientation of the tick text. This may override what the orient prop
+			tries to determine.
+		`,
 	},
 
 	getDefaultProps() {
@@ -339,6 +350,7 @@ const LineChart = createClass({
 			xAxisTitleColor: '#000',
 			// E.g. "Mon 06/06/2016 15:46:19"
 			xAxisTooltipFormatter: d3TimeFormat.timeFormat('%a %x %X'),
+			xAxisTextOrientation: 'horizontal',
 
 			yAxisFields: ['y'],
 			yAxisIsStacked: false,
@@ -359,6 +371,7 @@ const LineChart = createClass({
 			y2AxisTitle: null,
 			y2AxisTitleColor: '#000',
 			y2AxisColorOffset: 1,
+			yAxisTextOrientation: 'horizontal',
 		};
 	},
 
@@ -408,6 +421,7 @@ const LineChart = createClass({
 			xAxisTooltipFormatter,
 			xAxisMin = minByFields(data, xAxisField),
 			xAxisMax = maxByFields(data, xAxisField),
+			xAxisTextOrientation,
 
 			yAxisFields,
 			yAxisFormatter,
@@ -437,6 +451,7 @@ const LineChart = createClass({
 				? maxByFieldsStacked(data, y2AxisFields)
 				: maxByFields(data, y2AxisFields),
 			y2AxisColorOffset,
+			yAxisTextOrientation,
 
 			...passThroughs
 		} = this.props;
@@ -664,6 +679,7 @@ const LineChart = createClass({
 						tickCount={xAxisTickCount}
 						ticks={xAxisTicks}
 						ref="xAxis"
+						textOrientation={xAxisTextOrientation}
 					/>
 
 					{/* legend */}
@@ -757,6 +773,7 @@ const LineChart = createClass({
 						tickFormat={yAxisFinalFormatter}
 						tickCount={yAxisTickCount}
 						ref="yAxis"
+						textOrientation={yAxisTextOrientation}
 					/>
 				</g>
 

--- a/src/components/LineChart/__snapshots__/LineChart.spec.jsx.snap
+++ b/src/components/LineChart/__snapshots__/LineChart.spec.jsx.snap
@@ -17,6 +17,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 01.basi
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -30,6 +31,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 01.basi
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -161,6 +163,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 03.mult
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -174,6 +177,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 03.mult
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -636,6 +640,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 04.mult
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -649,6 +654,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 04.mult
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -809,6 +815,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 05.stac
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -822,6 +829,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 05.stac
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1050,6 +1058,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 06.dual
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1063,6 +1072,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 06.dual
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1087,6 +1097,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 06.dual
       orient="right"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1364,6 +1375,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={5}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1388,6 +1400,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={5}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1412,6 +1425,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
       orient="right"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={5}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1658,6 +1672,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 08.stac
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1671,6 +1686,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 08.stac
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1802,6 +1818,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 09.stac
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1815,6 +1832,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 09.stac
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1944,6 +1962,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 10.abbr
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -1957,6 +1976,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 10.abbr
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -2096,6 +2116,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 11.colo
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -2157,6 +2178,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 11.colo
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -2170,6 +2192,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 11.colo
       orient="right"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -2633,6 +2656,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 12.empt
         orient="left"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickPadding={3}
       />
@@ -2645,6 +2669,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 12.empt
         orient="bottom"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickFormat={[Function]}
         tickPadding={3}
@@ -2683,6 +2708,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 13.empt
         orient="left"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickPadding={3}
       />
@@ -2695,6 +2721,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 13.empt
         orient="bottom"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickFormat={[Function]}
         tickPadding={3}
@@ -2741,6 +2768,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 14.empt
         orient="left"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickPadding={3}
       />
@@ -2753,6 +2781,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 14.empt
         orient="bottom"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickFormat={[Function]}
         tickPadding={3}
@@ -2781,6 +2810,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 15.load
         orient="left"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickPadding={3}
       />
@@ -2793,6 +2823,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 15.load
         orient="bottom"
         outerTickSize={6}
         scale={[Function]}
+        textOrientation="horizontal"
         tickCount={null}
         tickFormat={[Function]}
         tickPadding={3}
@@ -2819,6 +2850,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 16.fine
       orient="bottom"
       outerTickSize={0}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}
@@ -2839,6 +2871,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 16.fine
       orient="left"
       outerTickSize={6}
       scale={[Function]}
+      textOrientation="horizontal"
       tickCount={null}
       tickFormat={[Function]}
       tickPadding={3}

--- a/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
+++ b/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
@@ -59,7 +59,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".2"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -136,7 +136,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -213,7 +213,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -310,7 +310,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -402,7 +402,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -482,7 +482,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -559,7 +559,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,

--- a/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
+++ b/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
@@ -59,7 +59,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".2"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -79,6 +79,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -89,6 +90,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle="Revenue"
     yAxisTitleColor="#000"
@@ -134,7 +136,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -154,6 +156,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -164,6 +167,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle={null}
     yAxisTitleColor="#000"
@@ -209,7 +213,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -229,6 +233,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -239,6 +244,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle={null}
     yAxisTitleColor="#000"
@@ -303,7 +309,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -323,6 +329,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -333,6 +340,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle={null}
     yAxisTitleColor="#000"
@@ -392,7 +400,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -412,6 +420,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -422,6 +431,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle={null}
     yAxisTitleColor="#000"
@@ -470,7 +480,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -490,6 +500,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -500,6 +511,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle={null}
     yAxisTitleColor="#000"
@@ -545,7 +557,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     key=".0"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -565,6 +577,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -575,6 +588,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle={null}
     yAxisTitleColor="#000"

--- a/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
+++ b/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
@@ -31,7 +31,7 @@ exports[`OverlayWrapper [common] example testing should match snapshot(s) for 1.
     key=".1"
     margin={
       Object {
-        "bottom": 75,
+        "bottom": 50,
         "left": 80,
         "right": 20,
         "top": 10,

--- a/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
+++ b/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
@@ -31,7 +31,7 @@ exports[`OverlayWrapper [common] example testing should match snapshot(s) for 1.
     key=".1"
     margin={
       Object {
-        "bottom": 50,
+        "bottom": 75,
         "left": 80,
         "right": 20,
         "top": 10,
@@ -51,6 +51,7 @@ exports[`OverlayWrapper [common] example testing should match snapshot(s) for 1.
     width={1000}
     xAxisField="x"
     xAxisFormatter={[Function]}
+    xAxisTextOrientation="horizontal"
     xAxisTickCount={null}
     xAxisTitle={null}
     xAxisTitleColor="#000"
@@ -61,6 +62,7 @@ exports[`OverlayWrapper [common] example testing should match snapshot(s) for 1.
     }
     yAxisIsStacked={false}
     yAxisMin={0}
+    yAxisTextOrientation="horizontal"
     yAxisTickCount={null}
     yAxisTitle={null}
     yAxisTitleColor="#000"


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
