### PR TITLE
Fixes #943 by changing unselected tab color to @color-darkGray

### DIFF
--- a/src/components/Tabs/Tabs.less
+++ b/src/components/Tabs/Tabs.less
@@ -42,7 +42,7 @@
 		align-items: stretch;
 		box-sizing: border-box;
 		cursor: pointer;
-		color: @color-primary;
+		color: @color-darkGray;
 		user-select: none;
 		margin-bottom: -@Tabs-border-width;
 		border: @Tabs-border-width solid @color-borderColorLight;

--- a/src/components/VerticalListMenu/VerticalListMenu.less
+++ b/src/components/VerticalListMenu/VerticalListMenu.less
@@ -72,7 +72,7 @@
 			border-width: 1px 0 0;
 			border-color: @color-gray;
 			border-style: solid;
-			color: @color-primary;
+			color: @color-darkGray;
 			padding-left: 15px;
 
 			&-text {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
