### PR TITLE
Fixes #949 adds appropriate focus color for different kinds of buttons

### DIFF
--- a/src/components/Button/Button.less
+++ b/src/components/Button/Button.less
@@ -79,6 +79,10 @@
 		color: @color-white;
 		border-color: @featured-color-success-borderColor;
 
+		&:focus {
+			.focus-glow(@featured-color-success-30);
+		}
+
 		.lucid-Icon { fill: @color-white; }
 	}
 
@@ -89,6 +93,10 @@
 
 		border-color: @featured-color-info-borderColor;
 		color: @color-white;
+
+		&:focus {
+			.focus-glow(@featured-color-info-30);
+		}
 
 		.lucid-Icon { fill: @color-white; }
 	}
@@ -101,6 +109,10 @@
 		border-color: @featured-color-warning-borderColor;
 		color: @color-white;
 
+		&:focus {
+			.focus-glow(@featured-color-warning-30);
+		}
+
 		.lucid-Icon { fill: @color-white; }
 	}
 
@@ -111,6 +123,10 @@
 
 		border-color: @featured-color-danger-borderColor;
 		color: @color-white;
+
+		&:focus {
+			.focus-glow(@featured-color-danger-30);
+		}
 
 		.lucid-Icon { fill: @color-white; }
 	}

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -142,8 +142,11 @@
 @featured-color-default: #f3f3f3;
 @featured-color-primary: @color-primary;
 @featured-color-success: #3fa516;
+@featured-color-success-30: fade(@featured-color-success, 30%);
 @featured-color-info: #0089c4;
+@featured-color-info-30: fade(@featured-color-info, 30%);
 @featured-color-warning: #feb209;
+@featured-color-warning-30: fade(@featured-color-warning, 30%);
 @featured-color-danger: #f7403a;
 @featured-color-danger-30: fade(@featured-color-danger, 30%);
 


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
