### PR TITLE
Fixes #955 by allowing Bar component to accept both string and number type for dimension.

### DIFF
--- a/src/components/Bar/Bar.jsx
+++ b/src/components/Bar/Bar.jsx
@@ -41,11 +41,11 @@ const Bar = createClass({
 			y coordinate.
 		`,
 
-		height: number`
+		height: PropTypes.oneOfType([number, string])`
 			Height of the bar.
 		`,
 
-		width: number`
+		width: PropTypes.oneOfType([number, string])`
 			Width of the bar.
 		`,
 

--- a/src/components/Bar/__snapshots__/Bar.spec.jsx.snap
+++ b/src/components/Bar/__snapshots__/Bar.spec.jsx.snap
@@ -30,6 +30,36 @@ exports[`Bar [common] example testing should match snapshot(s) for custom-colors
 />
 `;
 
+exports[`Bar [common] example testing should match snapshot(s) for custom-dimension-units 1`] = `
+<rect
+  className="lucid-Bar"
+  height="100%"
+  style={
+    Object {
+      "fill": "#f80",
+    }
+  }
+  width="10%"
+  x={5}
+  y={0}
+/>
+`;
+
+exports[`Bar [common] example testing should match snapshot(s) for custom-dimension-units 2`] = `
+<rect
+  className="lucid-Bar"
+  height="100%"
+  style={
+    Object {
+      "fill": "#abc123",
+    }
+  }
+  width="10%"
+  x={5}
+  y={0}
+/>
+`;
+
 exports[`Bar [common] example testing should match snapshot(s) for regular-colors 1`] = `
 <rect
   className="lucid-Bar lucid-Bar-color-chart-0-lightest"

--- a/src/components/Bar/examples/custom-dimension-units.jsx
+++ b/src/components/Bar/examples/custom-dimension-units.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Bar } from '../../../index';
+
+const svgProps = {
+	width: 20,
+	height: 100,
+};
+
+const pointProps = {
+	x: 5,
+	y: 0,
+	width: '10%',
+	height: '100%',
+};
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<svg {...svgProps}>
+					<Bar {...pointProps} color="#f80" />
+				</svg>
+
+				<svg {...svgProps}>
+					<Bar {...pointProps} color="#abc123" />
+				</svg>
+			</div>
+		);
+	},
+});


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- ~One core team UX approval~
