### PR TITLE
flex sidebar and don't shrink the header

### DIFF
--- a/src/components/Sidebar/Sidebar.less
+++ b/src/components/Sidebar/Sidebar.less
@@ -20,6 +20,8 @@
 			z-index: @zindex-base;
 			background-color: @color-white;
 			overflow: auto;
+			display: flex;
+			flex-direction: column;
 
 			.lucid-Sidebar-is-position-left& {
 				border-right: @border-standardBorder;
@@ -52,6 +54,7 @@
 				font: @size-L @fontFamily;
 				font-weight: bold;
 				display: flex;
+				flex-shrink: 0;
 
 				.lucid-Sidebar-is-position-left& {
 					flex-direction: row;
@@ -97,6 +100,11 @@
 						fill: @color-darkGray;
 					}
 				}
+			}
+
+			& > .lucid-Sidebar-Bar-content {
+				overflow: auto;
+				flex: 1;
 			}
 
 			& > .lucid-Sidebar-Bar-content.lucid-Sidebar-Bar-content-has-gutters {


### PR DESCRIPTION
this adds display flex to the sidebar so that additionally users can add display flex to the `.lucid-Sidebar-Bar-content` and allow the sidebar content to be scrolled separately from the header.

![scroll](https://cl.ly/77dee39f9839/Screen%20Recording%202018-12-03%20at%2010.21%20AM.gif)

without this it would shrink the header:
![squish](https://cl.ly/a3418c91d0b7/Screen%252520Shot%2525202018-12-03%252520at%25252010.12.17%252520AM.png)


## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
