### PR TITLE
fix failing object checks that broke after the babel 7 upgrade

### DIFF
--- a/src/util/component-types.js
+++ b/src/util/component-types.js
@@ -2,7 +2,10 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'react-peek/prop-types';
 import _ from 'lodash';
-import { omitFunctionPropsDeep } from './state-management';
+import {
+	isPlainObjectOrEsModule,
+	omitFunctionPropsDeep,
+} from './state-management';
 
 // creates a React component
 export function createClass(definition = {}) {
@@ -78,7 +81,7 @@ export function createElements(type, values = []) {
 			if (React.isValidElement(typeValue) && typeValue.type === type) {
 				return elements.concat(typeValue);
 			} else if (
-				_.isPlainObject(typeValue) &&
+				isPlainObjectOrEsModule(typeValue) &&
 				!React.isValidElement(typeValue)
 			) {
 				return elements.concat(React.createElement(type, typeValue));

--- a/src/util/state-management.js
+++ b/src/util/state-management.js
@@ -8,18 +8,22 @@ export function getDeepPaths(obj, path = []) {
 	return _.reduce(
 		obj,
 		(terminalKeys, value, key) =>
-			_.isPlainObject(value)
+			isPlainObjectOrEsModule(value)
 				? terminalKeys.concat(getDeepPaths(value, path.concat(key)))
 				: terminalKeys.concat([path.concat(key)]),
 		[]
 	);
 }
 
+export function isPlainObjectOrEsModule(obj) {
+	return _.isPlainObject(obj) || _.get(obj, '__esModule', false);
+}
+
 export function omitFunctionPropsDeep(obj) {
 	return _.reduce(
 		obj,
 		(memo, value, key) => {
-			if (_.isPlainObject(value)) {
+			if (isPlainObjectOrEsModule(value)) {
 				memo[key] = omitFunctionPropsDeep(value);
 			} else if (!_.isFunction(value)) {
 				memo[key] = value;
@@ -128,7 +132,7 @@ export function getStatefulPropsContext(reducers, { getState, setState }) {
  * to maintain their caches.
  */
 export const reduceSelectors = _.memoize(selectors => {
-	if (!_.isPlainObject(selectors) && !_.get(selectors, '__esModule', false)) {
+	if (!isPlainObjectOrEsModule(selectors)) {
 		throw new Error(
 			'Selectors must be a plain object with function or plain object values'
 		);


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
