### PR TITLE
whitelist css as side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A UI component library from AppNexus.",
   "main": "dist/index.js",
   "module": "lib/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css",
+    "*.less"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/appnexus/lucid.git"


### PR DESCRIPTION
treeshaking was removing less/css from our production build.  Looks good now.

https://docspot.adnxs.net/projects/lucid/allow-css-side-effects/?selectedKind=SearchField&selectedStory=default&full=0&addons=1&stories=1&panelRight=1&addonPanel=lucid-docs-panel-props

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
