### PR TITLE
safeguard against duplicate portal ids

### DIFF
--- a/src/components/ContextMenu/ContextMenu.jsx
+++ b/src/components/ContextMenu/ContextMenu.jsx
@@ -7,7 +7,7 @@ import {
 	getAbsoluteBoundingClientRect,
 	sharesAncestor,
 } from '../../util/dom-helpers';
-import { lucidClassNames } from '../../util/style-helpers';
+import { lucidClassNames, uniqueName } from '../../util/style-helpers';
 
 const cx = lucidClassNames.bind('&-ContextMenu');
 
@@ -141,7 +141,7 @@ const ContextMenu = createClass({
 	getInitialState() {
 		const { portalId } = this.props;
 		return {
-			portalId: portalId || _.uniqueId('ContextMenu-Portal-'),
+			portalId: portalId || uniqueName('ContextMenu-Portal-'),
 			targetRect: {
 				bottom: 0,
 				top: 0,

--- a/src/components/ContextMenu/__snapshots__/ContextMenu.spec.jsx.snap
+++ b/src/components/ContextMenu/__snapshots__/ContextMenu.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 1.bas
   </Button>
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-7"
+    portalId="5619791615151244-ContextMenu-Portal-7"
     style={
       Object {
         "background": "white",
@@ -45,7 +45,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 2.bas
   </Button>
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-8"
+    portalId="5619791615151244-ContextMenu-Portal-8"
     style={
       Object {
         "background": "white",
@@ -107,7 +107,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 4.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-9"
+    portalId="5619791615151244-ContextMenu-Portal-9"
     style={
       Object {
         "background": "white",
@@ -144,7 +144,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-10"
+    portalId="5619791615151244-ContextMenu-Portal-10"
     style={
       Object {
         "background": "white",
@@ -177,7 +177,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-11"
+    portalId="5619791615151244-ContextMenu-Portal-11"
     style={
       Object {
         "background": "white",
@@ -210,7 +210,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-12"
+    portalId="5619791615151244-ContextMenu-Portal-12"
     style={
       Object {
         "background": "white",
@@ -243,7 +243,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-13"
+    portalId="5619791615151244-ContextMenu-Portal-13"
     style={
       Object {
         "background": "white",
@@ -276,7 +276,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-14"
+    portalId="5619791615151244-ContextMenu-Portal-14"
     style={
       Object {
         "background": "white",
@@ -309,7 +309,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-15"
+    portalId="5619791615151244-ContextMenu-Portal-15"
     style={
       Object {
         "background": "white",
@@ -342,7 +342,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-16"
+    portalId="5619791615151244-ContextMenu-Portal-16"
     style={
       Object {
         "background": "white",
@@ -375,7 +375,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-17"
+    portalId="5619791615151244-ContextMenu-Portal-17"
     style={
       Object {
         "background": "white",
@@ -408,7 +408,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-18"
+    portalId="5619791615151244-ContextMenu-Portal-18"
     style={
       Object {
         "background": "white",
@@ -441,7 +441,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-19"
+    portalId="5619791615151244-ContextMenu-Portal-19"
     style={
       Object {
         "background": "white",
@@ -474,7 +474,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-20"
+    portalId="5619791615151244-ContextMenu-Portal-20"
     style={
       Object {
         "background": "white",
@@ -507,7 +507,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-21"
+    portalId="5619791615151244-ContextMenu-Portal-21"
     style={
       Object {
         "background": "white",
@@ -540,7 +540,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-22"
+    portalId="5619791615151244-ContextMenu-Portal-22"
     style={
       Object {
         "background": "white",
@@ -573,7 +573,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-23"
+    portalId="5619791615151244-ContextMenu-Portal-23"
     style={
       Object {
         "background": "white",
@@ -606,7 +606,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-24"
+    portalId="5619791615151244-ContextMenu-Portal-24"
     style={
       Object {
         "background": "white",
@@ -639,7 +639,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-25"
+    portalId="5619791615151244-ContextMenu-Portal-25"
     style={
       Object {
         "background": "white",
@@ -672,7 +672,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-26"
+    portalId="5619791615151244-ContextMenu-Portal-26"
     style={
       Object {
         "background": "white",
@@ -705,7 +705,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-27"
+    portalId="5619791615151244-ContextMenu-Portal-27"
     style={
       Object {
         "background": "white",
@@ -738,7 +738,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-28"
+    portalId="5619791615151244-ContextMenu-Portal-28"
     style={
       Object {
         "background": "white",
@@ -771,7 +771,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-29"
+    portalId="5619791615151244-ContextMenu-Portal-29"
     style={
       Object {
         "background": "white",
@@ -804,7 +804,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-30"
+    portalId="5619791615151244-ContextMenu-Portal-30"
     style={
       Object {
         "background": "white",
@@ -837,7 +837,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-31"
+    portalId="5619791615151244-ContextMenu-Portal-31"
     style={
       Object {
         "background": "white",
@@ -870,7 +870,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-32"
+    portalId="5619791615151244-ContextMenu-Portal-32"
     style={
       Object {
         "background": "white",
@@ -903,7 +903,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-33"
+    portalId="5619791615151244-ContextMenu-Portal-33"
     style={
       Object {
         "background": "white",
@@ -936,7 +936,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-34"
+    portalId="5619791615151244-ContextMenu-Portal-34"
     style={
       Object {
         "background": "white",
@@ -969,7 +969,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-35"
+    portalId="5619791615151244-ContextMenu-Portal-35"
     style={
       Object {
         "background": "white",
@@ -1002,7 +1002,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="ContextMenu-Portal-36"
+    portalId="5619791615151244-ContextMenu-Portal-36"
     style={
       Object {
         "background": "white",
@@ -1035,7 +1035,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-37"
+    portalId="5619791615151244-ContextMenu-Portal-37"
     style={
       Object {
         "background": "white",
@@ -1068,7 +1068,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-38"
+    portalId="5619791615151244-ContextMenu-Portal-38"
     style={
       Object {
         "background": "white",
@@ -1101,7 +1101,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-39"
+    portalId="5619791615151244-ContextMenu-Portal-39"
     style={
       Object {
         "background": "white",
@@ -1134,7 +1134,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-40"
+    portalId="5619791615151244-ContextMenu-Portal-40"
     style={
       Object {
         "background": "white",
@@ -1167,7 +1167,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-41"
+    portalId="5619791615151244-ContextMenu-Portal-41"
     style={
       Object {
         "background": "white",
@@ -1200,7 +1200,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-42"
+    portalId="5619791615151244-ContextMenu-Portal-42"
     style={
       Object {
         "background": "white",
@@ -1233,7 +1233,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-43"
+    portalId="5619791615151244-ContextMenu-Portal-43"
     style={
       Object {
         "background": "white",
@@ -1266,7 +1266,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-44"
+    portalId="5619791615151244-ContextMenu-Portal-44"
     style={
       Object {
         "background": "white",
@@ -1299,7 +1299,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-45"
+    portalId="5619791615151244-ContextMenu-Portal-45"
     style={
       Object {
         "background": "white",
@@ -1332,7 +1332,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-46"
+    portalId="5619791615151244-ContextMenu-Portal-46"
     style={
       Object {
         "background": "white",
@@ -1365,7 +1365,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-47"
+    portalId="5619791615151244-ContextMenu-Portal-47"
     style={
       Object {
         "background": "white",
@@ -1398,7 +1398,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-48"
+    portalId="5619791615151244-ContextMenu-Portal-48"
     style={
       Object {
         "background": "white",
@@ -1431,7 +1431,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-49"
+    portalId="5619791615151244-ContextMenu-Portal-49"
     style={
       Object {
         "background": "white",
@@ -1464,7 +1464,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-50"
+    portalId="5619791615151244-ContextMenu-Portal-50"
     style={
       Object {
         "background": "white",
@@ -1497,7 +1497,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-51"
+    portalId="5619791615151244-ContextMenu-Portal-51"
     style={
       Object {
         "background": "white",
@@ -1530,7 +1530,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-52"
+    portalId="5619791615151244-ContextMenu-Portal-52"
     style={
       Object {
         "background": "white",
@@ -1563,7 +1563,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-53"
+    portalId="5619791615151244-ContextMenu-Portal-53"
     style={
       Object {
         "background": "white",
@@ -1596,7 +1596,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-54"
+    portalId="5619791615151244-ContextMenu-Portal-54"
     style={
       Object {
         "background": "white",
@@ -1629,7 +1629,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-55"
+    portalId="5619791615151244-ContextMenu-Portal-55"
     style={
       Object {
         "background": "white",
@@ -1662,7 +1662,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-56"
+    portalId="5619791615151244-ContextMenu-Portal-56"
     style={
       Object {
         "background": "white",
@@ -1695,7 +1695,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-57"
+    portalId="5619791615151244-ContextMenu-Portal-57"
     style={
       Object {
         "background": "white",
@@ -1728,7 +1728,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-58"
+    portalId="5619791615151244-ContextMenu-Portal-58"
     style={
       Object {
         "background": "white",
@@ -1761,7 +1761,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-59"
+    portalId="5619791615151244-ContextMenu-Portal-59"
     style={
       Object {
         "background": "white",
@@ -1794,7 +1794,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-60"
+    portalId="5619791615151244-ContextMenu-Portal-60"
     style={
       Object {
         "background": "white",
@@ -1827,7 +1827,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-61"
+    portalId="5619791615151244-ContextMenu-Portal-61"
     style={
       Object {
         "background": "white",
@@ -1860,7 +1860,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-62"
+    portalId="5619791615151244-ContextMenu-Portal-62"
     style={
       Object {
         "background": "white",
@@ -1893,7 +1893,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="ContextMenu-Portal-63"
+    portalId="5619791615151244-ContextMenu-Portal-63"
     style={
       Object {
         "background": "white",
@@ -1926,7 +1926,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-64"
+    portalId="5619791615151244-ContextMenu-Portal-64"
     style={
       Object {
         "background": "white",
@@ -1959,7 +1959,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-65"
+    portalId="5619791615151244-ContextMenu-Portal-65"
     style={
       Object {
         "background": "white",
@@ -1992,7 +1992,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-66"
+    portalId="5619791615151244-ContextMenu-Portal-66"
     style={
       Object {
         "background": "white",
@@ -2025,7 +2025,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-67"
+    portalId="5619791615151244-ContextMenu-Portal-67"
     style={
       Object {
         "background": "white",
@@ -2058,7 +2058,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-68"
+    portalId="5619791615151244-ContextMenu-Portal-68"
     style={
       Object {
         "background": "white",
@@ -2091,7 +2091,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-69"
+    portalId="5619791615151244-ContextMenu-Portal-69"
     style={
       Object {
         "background": "white",
@@ -2124,7 +2124,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-70"
+    portalId="5619791615151244-ContextMenu-Portal-70"
     style={
       Object {
         "background": "white",
@@ -2157,7 +2157,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-71"
+    portalId="5619791615151244-ContextMenu-Portal-71"
     style={
       Object {
         "background": "white",
@@ -2190,7 +2190,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-72"
+    portalId="5619791615151244-ContextMenu-Portal-72"
     style={
       Object {
         "background": "white",
@@ -2223,7 +2223,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-73"
+    portalId="5619791615151244-ContextMenu-Portal-73"
     style={
       Object {
         "background": "white",
@@ -2256,7 +2256,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-74"
+    portalId="5619791615151244-ContextMenu-Portal-74"
     style={
       Object {
         "background": "white",
@@ -2289,7 +2289,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-75"
+    portalId="5619791615151244-ContextMenu-Portal-75"
     style={
       Object {
         "background": "white",
@@ -2322,7 +2322,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-76"
+    portalId="5619791615151244-ContextMenu-Portal-76"
     style={
       Object {
         "background": "white",
@@ -2355,7 +2355,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-77"
+    portalId="5619791615151244-ContextMenu-Portal-77"
     style={
       Object {
         "background": "white",
@@ -2388,7 +2388,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-78"
+    portalId="5619791615151244-ContextMenu-Portal-78"
     style={
       Object {
         "background": "white",
@@ -2421,7 +2421,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-79"
+    portalId="5619791615151244-ContextMenu-Portal-79"
     style={
       Object {
         "background": "white",
@@ -2454,7 +2454,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-80"
+    portalId="5619791615151244-ContextMenu-Portal-80"
     style={
       Object {
         "background": "white",
@@ -2487,7 +2487,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-81"
+    portalId="5619791615151244-ContextMenu-Portal-81"
     style={
       Object {
         "background": "white",
@@ -2520,7 +2520,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-82"
+    portalId="5619791615151244-ContextMenu-Portal-82"
     style={
       Object {
         "background": "white",
@@ -2553,7 +2553,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-83"
+    portalId="5619791615151244-ContextMenu-Portal-83"
     style={
       Object {
         "background": "white",
@@ -2586,7 +2586,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-84"
+    portalId="5619791615151244-ContextMenu-Portal-84"
     style={
       Object {
         "background": "white",
@@ -2619,7 +2619,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-85"
+    portalId="5619791615151244-ContextMenu-Portal-85"
     style={
       Object {
         "background": "white",
@@ -2652,7 +2652,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-86"
+    portalId="5619791615151244-ContextMenu-Portal-86"
     style={
       Object {
         "background": "white",
@@ -2685,7 +2685,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-87"
+    portalId="5619791615151244-ContextMenu-Portal-87"
     style={
       Object {
         "background": "white",
@@ -2718,7 +2718,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-88"
+    portalId="5619791615151244-ContextMenu-Portal-88"
     style={
       Object {
         "background": "white",
@@ -2751,7 +2751,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-89"
+    portalId="5619791615151244-ContextMenu-Portal-89"
     style={
       Object {
         "background": "white",
@@ -2784,7 +2784,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="ContextMenu-Portal-90"
+    portalId="5619791615151244-ContextMenu-Portal-90"
     style={
       Object {
         "background": "white",
@@ -2817,7 +2817,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-91"
+    portalId="5619791615151244-ContextMenu-Portal-91"
     style={
       Object {
         "background": "white",
@@ -2850,7 +2850,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-92"
+    portalId="5619791615151244-ContextMenu-Portal-92"
     style={
       Object {
         "background": "white",
@@ -2883,7 +2883,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-93"
+    portalId="5619791615151244-ContextMenu-Portal-93"
     style={
       Object {
         "background": "white",
@@ -2916,7 +2916,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-94"
+    portalId="5619791615151244-ContextMenu-Portal-94"
     style={
       Object {
         "background": "white",
@@ -2949,7 +2949,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-95"
+    portalId="5619791615151244-ContextMenu-Portal-95"
     style={
       Object {
         "background": "white",
@@ -2982,7 +2982,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-96"
+    portalId="5619791615151244-ContextMenu-Portal-96"
     style={
       Object {
         "background": "white",
@@ -3015,7 +3015,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-97"
+    portalId="5619791615151244-ContextMenu-Portal-97"
     style={
       Object {
         "background": "white",
@@ -3048,7 +3048,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-98"
+    portalId="5619791615151244-ContextMenu-Portal-98"
     style={
       Object {
         "background": "white",
@@ -3081,7 +3081,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-99"
+    portalId="5619791615151244-ContextMenu-Portal-99"
     style={
       Object {
         "background": "white",
@@ -3114,7 +3114,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-100"
+    portalId="5619791615151244-ContextMenu-Portal-100"
     style={
       Object {
         "background": "white",
@@ -3147,7 +3147,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-101"
+    portalId="5619791615151244-ContextMenu-Portal-101"
     style={
       Object {
         "background": "white",
@@ -3180,7 +3180,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-102"
+    portalId="5619791615151244-ContextMenu-Portal-102"
     style={
       Object {
         "background": "white",
@@ -3213,7 +3213,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-103"
+    portalId="5619791615151244-ContextMenu-Portal-103"
     style={
       Object {
         "background": "white",
@@ -3246,7 +3246,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-104"
+    portalId="5619791615151244-ContextMenu-Portal-104"
     style={
       Object {
         "background": "white",
@@ -3279,7 +3279,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-105"
+    portalId="5619791615151244-ContextMenu-Portal-105"
     style={
       Object {
         "background": "white",
@@ -3312,7 +3312,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-106"
+    portalId="5619791615151244-ContextMenu-Portal-106"
     style={
       Object {
         "background": "white",
@@ -3345,7 +3345,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-107"
+    portalId="5619791615151244-ContextMenu-Portal-107"
     style={
       Object {
         "background": "white",
@@ -3378,7 +3378,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-108"
+    portalId="5619791615151244-ContextMenu-Portal-108"
     style={
       Object {
         "background": "white",
@@ -3411,7 +3411,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-109"
+    portalId="5619791615151244-ContextMenu-Portal-109"
     style={
       Object {
         "background": "white",
@@ -3444,7 +3444,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-110"
+    portalId="5619791615151244-ContextMenu-Portal-110"
     style={
       Object {
         "background": "white",
@@ -3477,7 +3477,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-111"
+    portalId="5619791615151244-ContextMenu-Portal-111"
     style={
       Object {
         "background": "white",
@@ -3510,7 +3510,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-112"
+    portalId="5619791615151244-ContextMenu-Portal-112"
     style={
       Object {
         "background": "white",
@@ -3543,7 +3543,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-113"
+    portalId="5619791615151244-ContextMenu-Portal-113"
     style={
       Object {
         "background": "white",
@@ -3576,7 +3576,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-114"
+    portalId="5619791615151244-ContextMenu-Portal-114"
     style={
       Object {
         "background": "white",
@@ -3609,7 +3609,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-115"
+    portalId="5619791615151244-ContextMenu-Portal-115"
     style={
       Object {
         "background": "white",
@@ -3642,7 +3642,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-116"
+    portalId="5619791615151244-ContextMenu-Portal-116"
     style={
       Object {
         "background": "white",
@@ -3675,7 +3675,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="ContextMenu-Portal-117"
+    portalId="5619791615151244-ContextMenu-Portal-117"
     style={
       Object {
         "background": "white",

--- a/src/components/ContextMenu/__snapshots__/ContextMenu.spec.jsx.snap
+++ b/src/components/ContextMenu/__snapshots__/ContextMenu.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 1.bas
   </Button>
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-7"
+    portalId="1-ContextMenu-Portal-7"
     style={
       Object {
         "background": "white",
@@ -45,7 +45,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 2.bas
   </Button>
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-8"
+    portalId="1-ContextMenu-Portal-8"
     style={
       Object {
         "background": "white",
@@ -107,7 +107,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 4.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-9"
+    portalId="1-ContextMenu-Portal-9"
     style={
       Object {
         "background": "white",
@@ -144,7 +144,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-10"
+    portalId="1-ContextMenu-Portal-10"
     style={
       Object {
         "background": "white",
@@ -177,7 +177,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-11"
+    portalId="1-ContextMenu-Portal-11"
     style={
       Object {
         "background": "white",
@@ -210,7 +210,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-12"
+    portalId="1-ContextMenu-Portal-12"
     style={
       Object {
         "background": "white",
@@ -243,7 +243,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-13"
+    portalId="1-ContextMenu-Portal-13"
     style={
       Object {
         "background": "white",
@@ -276,7 +276,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-14"
+    portalId="1-ContextMenu-Portal-14"
     style={
       Object {
         "background": "white",
@@ -309,7 +309,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-15"
+    portalId="1-ContextMenu-Portal-15"
     style={
       Object {
         "background": "white",
@@ -342,7 +342,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-16"
+    portalId="1-ContextMenu-Portal-16"
     style={
       Object {
         "background": "white",
@@ -375,7 +375,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-17"
+    portalId="1-ContextMenu-Portal-17"
     style={
       Object {
         "background": "white",
@@ -408,7 +408,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-18"
+    portalId="1-ContextMenu-Portal-18"
     style={
       Object {
         "background": "white",
@@ -441,7 +441,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-19"
+    portalId="1-ContextMenu-Portal-19"
     style={
       Object {
         "background": "white",
@@ -474,7 +474,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-20"
+    portalId="1-ContextMenu-Portal-20"
     style={
       Object {
         "background": "white",
@@ -507,7 +507,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-21"
+    portalId="1-ContextMenu-Portal-21"
     style={
       Object {
         "background": "white",
@@ -540,7 +540,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-22"
+    portalId="1-ContextMenu-Portal-22"
     style={
       Object {
         "background": "white",
@@ -573,7 +573,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-23"
+    portalId="1-ContextMenu-Portal-23"
     style={
       Object {
         "background": "white",
@@ -606,7 +606,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-24"
+    portalId="1-ContextMenu-Portal-24"
     style={
       Object {
         "background": "white",
@@ -639,7 +639,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-25"
+    portalId="1-ContextMenu-Portal-25"
     style={
       Object {
         "background": "white",
@@ -672,7 +672,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-26"
+    portalId="1-ContextMenu-Portal-26"
     style={
       Object {
         "background": "white",
@@ -705,7 +705,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-27"
+    portalId="1-ContextMenu-Portal-27"
     style={
       Object {
         "background": "white",
@@ -738,7 +738,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-28"
+    portalId="1-ContextMenu-Portal-28"
     style={
       Object {
         "background": "white",
@@ -771,7 +771,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-29"
+    portalId="1-ContextMenu-Portal-29"
     style={
       Object {
         "background": "white",
@@ -804,7 +804,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-30"
+    portalId="1-ContextMenu-Portal-30"
     style={
       Object {
         "background": "white",
@@ -837,7 +837,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-31"
+    portalId="1-ContextMenu-Portal-31"
     style={
       Object {
         "background": "white",
@@ -870,7 +870,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-32"
+    portalId="1-ContextMenu-Portal-32"
     style={
       Object {
         "background": "white",
@@ -903,7 +903,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-33"
+    portalId="1-ContextMenu-Portal-33"
     style={
       Object {
         "background": "white",
@@ -936,7 +936,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-34"
+    portalId="1-ContextMenu-Portal-34"
     style={
       Object {
         "background": "white",
@@ -969,7 +969,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-35"
+    portalId="1-ContextMenu-Portal-35"
     style={
       Object {
         "background": "white",
@@ -1002,7 +1002,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-up"
-    portalId="5619791615151244-ContextMenu-Portal-36"
+    portalId="1-ContextMenu-Portal-36"
     style={
       Object {
         "background": "white",
@@ -1035,7 +1035,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-37"
+    portalId="1-ContextMenu-Portal-37"
     style={
       Object {
         "background": "white",
@@ -1068,7 +1068,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-38"
+    portalId="1-ContextMenu-Portal-38"
     style={
       Object {
         "background": "white",
@@ -1101,7 +1101,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-39"
+    portalId="1-ContextMenu-Portal-39"
     style={
       Object {
         "background": "white",
@@ -1134,7 +1134,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-40"
+    portalId="1-ContextMenu-Portal-40"
     style={
       Object {
         "background": "white",
@@ -1167,7 +1167,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-41"
+    portalId="1-ContextMenu-Portal-41"
     style={
       Object {
         "background": "white",
@@ -1200,7 +1200,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-42"
+    portalId="1-ContextMenu-Portal-42"
     style={
       Object {
         "background": "white",
@@ -1233,7 +1233,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-43"
+    portalId="1-ContextMenu-Portal-43"
     style={
       Object {
         "background": "white",
@@ -1266,7 +1266,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-44"
+    portalId="1-ContextMenu-Portal-44"
     style={
       Object {
         "background": "white",
@@ -1299,7 +1299,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-45"
+    portalId="1-ContextMenu-Portal-45"
     style={
       Object {
         "background": "white",
@@ -1332,7 +1332,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-46"
+    portalId="1-ContextMenu-Portal-46"
     style={
       Object {
         "background": "white",
@@ -1365,7 +1365,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-47"
+    portalId="1-ContextMenu-Portal-47"
     style={
       Object {
         "background": "white",
@@ -1398,7 +1398,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-48"
+    portalId="1-ContextMenu-Portal-48"
     style={
       Object {
         "background": "white",
@@ -1431,7 +1431,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-49"
+    portalId="1-ContextMenu-Portal-49"
     style={
       Object {
         "background": "white",
@@ -1464,7 +1464,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-50"
+    portalId="1-ContextMenu-Portal-50"
     style={
       Object {
         "background": "white",
@@ -1497,7 +1497,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-51"
+    portalId="1-ContextMenu-Portal-51"
     style={
       Object {
         "background": "white",
@@ -1530,7 +1530,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-52"
+    portalId="1-ContextMenu-Portal-52"
     style={
       Object {
         "background": "white",
@@ -1563,7 +1563,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-53"
+    portalId="1-ContextMenu-Portal-53"
     style={
       Object {
         "background": "white",
@@ -1596,7 +1596,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-54"
+    portalId="1-ContextMenu-Portal-54"
     style={
       Object {
         "background": "white",
@@ -1629,7 +1629,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-55"
+    portalId="1-ContextMenu-Portal-55"
     style={
       Object {
         "background": "white",
@@ -1662,7 +1662,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-56"
+    portalId="1-ContextMenu-Portal-56"
     style={
       Object {
         "background": "white",
@@ -1695,7 +1695,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-57"
+    portalId="1-ContextMenu-Portal-57"
     style={
       Object {
         "background": "white",
@@ -1728,7 +1728,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-58"
+    portalId="1-ContextMenu-Portal-58"
     style={
       Object {
         "background": "white",
@@ -1761,7 +1761,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-59"
+    portalId="1-ContextMenu-Portal-59"
     style={
       Object {
         "background": "white",
@@ -1794,7 +1794,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-60"
+    portalId="1-ContextMenu-Portal-60"
     style={
       Object {
         "background": "white",
@@ -1827,7 +1827,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-61"
+    portalId="1-ContextMenu-Portal-61"
     style={
       Object {
         "background": "white",
@@ -1860,7 +1860,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-62"
+    portalId="1-ContextMenu-Portal-62"
     style={
       Object {
         "background": "white",
@@ -1893,7 +1893,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-down"
-    portalId="5619791615151244-ContextMenu-Portal-63"
+    portalId="1-ContextMenu-Portal-63"
     style={
       Object {
         "background": "white",
@@ -1926,7 +1926,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-64"
+    portalId="1-ContextMenu-Portal-64"
     style={
       Object {
         "background": "white",
@@ -1959,7 +1959,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-65"
+    portalId="1-ContextMenu-Portal-65"
     style={
       Object {
         "background": "white",
@@ -1992,7 +1992,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-66"
+    portalId="1-ContextMenu-Portal-66"
     style={
       Object {
         "background": "white",
@@ -2025,7 +2025,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-67"
+    portalId="1-ContextMenu-Portal-67"
     style={
       Object {
         "background": "white",
@@ -2058,7 +2058,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-68"
+    portalId="1-ContextMenu-Portal-68"
     style={
       Object {
         "background": "white",
@@ -2091,7 +2091,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-69"
+    portalId="1-ContextMenu-Portal-69"
     style={
       Object {
         "background": "white",
@@ -2124,7 +2124,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-70"
+    portalId="1-ContextMenu-Portal-70"
     style={
       Object {
         "background": "white",
@@ -2157,7 +2157,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-71"
+    portalId="1-ContextMenu-Portal-71"
     style={
       Object {
         "background": "white",
@@ -2190,7 +2190,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-72"
+    portalId="1-ContextMenu-Portal-72"
     style={
       Object {
         "background": "white",
@@ -2223,7 +2223,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-73"
+    portalId="1-ContextMenu-Portal-73"
     style={
       Object {
         "background": "white",
@@ -2256,7 +2256,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-74"
+    portalId="1-ContextMenu-Portal-74"
     style={
       Object {
         "background": "white",
@@ -2289,7 +2289,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-75"
+    portalId="1-ContextMenu-Portal-75"
     style={
       Object {
         "background": "white",
@@ -2322,7 +2322,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-76"
+    portalId="1-ContextMenu-Portal-76"
     style={
       Object {
         "background": "white",
@@ -2355,7 +2355,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-77"
+    portalId="1-ContextMenu-Portal-77"
     style={
       Object {
         "background": "white",
@@ -2388,7 +2388,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-78"
+    portalId="1-ContextMenu-Portal-78"
     style={
       Object {
         "background": "white",
@@ -2421,7 +2421,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-79"
+    portalId="1-ContextMenu-Portal-79"
     style={
       Object {
         "background": "white",
@@ -2454,7 +2454,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-80"
+    portalId="1-ContextMenu-Portal-80"
     style={
       Object {
         "background": "white",
@@ -2487,7 +2487,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-81"
+    portalId="1-ContextMenu-Portal-81"
     style={
       Object {
         "background": "white",
@@ -2520,7 +2520,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-82"
+    portalId="1-ContextMenu-Portal-82"
     style={
       Object {
         "background": "white",
@@ -2553,7 +2553,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-83"
+    portalId="1-ContextMenu-Portal-83"
     style={
       Object {
         "background": "white",
@@ -2586,7 +2586,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-84"
+    portalId="1-ContextMenu-Portal-84"
     style={
       Object {
         "background": "white",
@@ -2619,7 +2619,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-85"
+    portalId="1-ContextMenu-Portal-85"
     style={
       Object {
         "background": "white",
@@ -2652,7 +2652,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-86"
+    portalId="1-ContextMenu-Portal-86"
     style={
       Object {
         "background": "white",
@@ -2685,7 +2685,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-87"
+    portalId="1-ContextMenu-Portal-87"
     style={
       Object {
         "background": "white",
@@ -2718,7 +2718,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-88"
+    portalId="1-ContextMenu-Portal-88"
     style={
       Object {
         "background": "white",
@@ -2751,7 +2751,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-89"
+    portalId="1-ContextMenu-Portal-89"
     style={
       Object {
         "background": "white",
@@ -2784,7 +2784,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-left"
-    portalId="5619791615151244-ContextMenu-Portal-90"
+    portalId="1-ContextMenu-Portal-90"
     style={
       Object {
         "background": "white",
@@ -2817,7 +2817,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-91"
+    portalId="1-ContextMenu-Portal-91"
     style={
       Object {
         "background": "white",
@@ -2850,7 +2850,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-92"
+    portalId="1-ContextMenu-Portal-92"
     style={
       Object {
         "background": "white",
@@ -2883,7 +2883,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-93"
+    portalId="1-ContextMenu-Portal-93"
     style={
       Object {
         "background": "white",
@@ -2916,7 +2916,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-94"
+    portalId="1-ContextMenu-Portal-94"
     style={
       Object {
         "background": "white",
@@ -2949,7 +2949,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-95"
+    portalId="1-ContextMenu-Portal-95"
     style={
       Object {
         "background": "white",
@@ -2982,7 +2982,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-96"
+    portalId="1-ContextMenu-Portal-96"
     style={
       Object {
         "background": "white",
@@ -3015,7 +3015,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-97"
+    portalId="1-ContextMenu-Portal-97"
     style={
       Object {
         "background": "white",
@@ -3048,7 +3048,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-98"
+    portalId="1-ContextMenu-Portal-98"
     style={
       Object {
         "background": "white",
@@ -3081,7 +3081,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-99"
+    portalId="1-ContextMenu-Portal-99"
     style={
       Object {
         "background": "white",
@@ -3114,7 +3114,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-100"
+    portalId="1-ContextMenu-Portal-100"
     style={
       Object {
         "background": "white",
@@ -3147,7 +3147,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-101"
+    portalId="1-ContextMenu-Portal-101"
     style={
       Object {
         "background": "white",
@@ -3180,7 +3180,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-102"
+    portalId="1-ContextMenu-Portal-102"
     style={
       Object {
         "background": "white",
@@ -3213,7 +3213,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-103"
+    portalId="1-ContextMenu-Portal-103"
     style={
       Object {
         "background": "white",
@@ -3246,7 +3246,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-104"
+    portalId="1-ContextMenu-Portal-104"
     style={
       Object {
         "background": "white",
@@ -3279,7 +3279,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-105"
+    portalId="1-ContextMenu-Portal-105"
     style={
       Object {
         "background": "white",
@@ -3312,7 +3312,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-106"
+    portalId="1-ContextMenu-Portal-106"
     style={
       Object {
         "background": "white",
@@ -3345,7 +3345,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-107"
+    portalId="1-ContextMenu-Portal-107"
     style={
       Object {
         "background": "white",
@@ -3378,7 +3378,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-108"
+    portalId="1-ContextMenu-Portal-108"
     style={
       Object {
         "background": "white",
@@ -3411,7 +3411,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-109"
+    portalId="1-ContextMenu-Portal-109"
     style={
       Object {
         "background": "white",
@@ -3444,7 +3444,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-110"
+    portalId="1-ContextMenu-Portal-110"
     style={
       Object {
         "background": "white",
@@ -3477,7 +3477,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-111"
+    portalId="1-ContextMenu-Portal-111"
     style={
       Object {
         "background": "white",
@@ -3510,7 +3510,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-112"
+    portalId="1-ContextMenu-Portal-112"
     style={
       Object {
         "background": "white",
@@ -3543,7 +3543,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-113"
+    portalId="1-ContextMenu-Portal-113"
     style={
       Object {
         "background": "white",
@@ -3576,7 +3576,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-114"
+    portalId="1-ContextMenu-Portal-114"
     style={
       Object {
         "background": "white",
@@ -3609,7 +3609,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-115"
+    portalId="1-ContextMenu-Portal-115"
     style={
       Object {
         "background": "white",
@@ -3642,7 +3642,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-116"
+    portalId="1-ContextMenu-Portal-116"
     style={
       Object {
         "background": "white",
@@ -3675,7 +3675,7 @@ exports[`ContextMenu [common] example testing should match snapshot(s) for 5.dir
   Target
   <Portal
     className="lucid-ContextMenu-FlyOut lucid-ContextMenu-FlyOut-right"
-    portalId="5619791615151244-ContextMenu-Portal-117"
+    portalId="1-ContextMenu-Portal-117"
     style={
       Object {
         "background": "white",

--- a/src/components/DropMenu/DropMenu.jsx
+++ b/src/components/DropMenu/DropMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
 import _ from 'lodash';
-import { lucidClassNames } from '../../util/style-helpers';
+import { lucidClassNames, uniqueName } from '../../util/style-helpers';
 import {
 	createClass,
 	getFirst,
@@ -441,7 +441,7 @@ const DropMenu = createClass({
 			flattenedOptionsData: [],
 			ungroupedOptionData: [],
 			optionGroupDataLookup: {},
-			portalId: this.props.portalId || _.uniqueId('DropMenu-Portal-'),
+			portalId: this.props.portalId || uniqueName('DropMenu-Portal-'),
 		};
 	},
 

--- a/src/components/DropMenu/__snapshots__/DropMenu.spec.jsx.snap
+++ b/src/components/DropMenu/__snapshots__/DropMenu.spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 01.basic
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-7"
+    portalId="3898404018074826-DropMenu-Portal-7"
   >
     <ContextMenu.Target
       elementType="span"
@@ -84,7 +84,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 02.butto
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-8"
+    portalId="3898404018074826-DropMenu-Portal-8"
   >
     <ContextMenu.Target
       elementType="span"
@@ -164,7 +164,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 03.disab
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-9"
+    portalId="3898404018074826-DropMenu-Portal-9"
   >
     <ContextMenu.Target
       elementType="span"
@@ -242,7 +242,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 04.disab
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-10"
+    portalId="3898404018074826-DropMenu-Portal-10"
   >
     <ContextMenu.Target
       elementType="span"
@@ -322,7 +322,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 05.group
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-11"
+    portalId="3898404018074826-DropMenu-Portal-11"
   >
     <ContextMenu.Target
       elementType="span"
@@ -462,7 +462,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 06.text-
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-12"
+    portalId="3898404018074826-DropMenu-Portal-12"
   >
     <ContextMenu.Target
       elementType="span"
@@ -547,7 +547,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 07.actio
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-13"
+    portalId="3898404018074826-DropMenu-Portal-13"
   >
     <ContextMenu.Target
       elementType="span"
@@ -623,7 +623,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 08.no-wr
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-14"
+    portalId="3898404018074826-DropMenu-Portal-14"
   >
     <ContextMenu.Target
       elementType="span"
@@ -703,7 +703,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 09.state
     isExpanded={true}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="DropMenu-Portal-15"
+    portalId="3898404018074826-DropMenu-Portal-15"
   >
     <ContextMenu.Target
       elementType="span"

--- a/src/components/DropMenu/__snapshots__/DropMenu.spec.jsx.snap
+++ b/src/components/DropMenu/__snapshots__/DropMenu.spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 01.basic
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-7"
+    portalId="1-DropMenu-Portal-7"
   >
     <ContextMenu.Target
       elementType="span"
@@ -84,7 +84,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 02.butto
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-8"
+    portalId="1-DropMenu-Portal-8"
   >
     <ContextMenu.Target
       elementType="span"
@@ -164,7 +164,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 03.disab
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-9"
+    portalId="1-DropMenu-Portal-9"
   >
     <ContextMenu.Target
       elementType="span"
@@ -242,7 +242,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 04.disab
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-10"
+    portalId="1-DropMenu-Portal-10"
   >
     <ContextMenu.Target
       elementType="span"
@@ -322,7 +322,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 05.group
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-11"
+    portalId="1-DropMenu-Portal-11"
   >
     <ContextMenu.Target
       elementType="span"
@@ -462,7 +462,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 06.text-
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-12"
+    portalId="1-DropMenu-Portal-12"
   >
     <ContextMenu.Target
       elementType="span"
@@ -547,7 +547,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 07.actio
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-13"
+    portalId="1-DropMenu-Portal-13"
   >
     <ContextMenu.Target
       elementType="span"
@@ -623,7 +623,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 08.no-wr
     isExpanded={false}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-14"
+    portalId="1-DropMenu-Portal-14"
   >
     <ContextMenu.Target
       elementType="span"
@@ -703,7 +703,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 09.state
     isExpanded={true}
     minWidthOffset={0}
     onClickOut={[Function]}
-    portalId="3898404018074826-DropMenu-Portal-15"
+    portalId="1-DropMenu-Portal-15"
   >
     <ContextMenu.Target
       elementType="span"

--- a/src/components/Overlay/Overlay.jsx
+++ b/src/components/Overlay/Overlay.jsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'react-peek/prop-types';
 import Portal from '../Portal/Portal';
 import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
-import { lucidClassNames } from '../../util/style-helpers';
+import { lucidClassNames, uniqueName } from '../../util/style-helpers';
 import { createClass, omitProps } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-Overlay');
@@ -76,7 +76,7 @@ const Overlay = createClass({
 		return {
 			// This must be in state because getDefaultProps only runs once per
 			// component import which causes collisions
-			portalId: this.props.portalId || _.uniqueId('Overlay-Portal-'),
+			portalId: this.props.portalId || uniqueName('Overlay-Portal-'),
 		};
 	},
 

--- a/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
+++ b/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Overlay [common] example testing should match snapshot(s) for basic 1`] = `
 <Portal
-  portalId="Overlay-Portal-7"
+  portalId="383848317566352-Overlay-Portal-7"
 >
   <CSSTransitionGroup
     transitionAppear={false}
@@ -17,7 +17,7 @@ exports[`Overlay [common] example testing should match snapshot(s) for basic 1`]
 
 exports[`Overlay [common] example testing should match snapshot(s) for no-modal 1`] = `
 <Portal
-  portalId="Overlay-Portal-8"
+  portalId="383848317566352-Overlay-Portal-8"
 >
   <CSSTransitionGroup
     transitionAppear={false}
@@ -32,6 +32,6 @@ exports[`Overlay [common] example testing should match snapshot(s) for no-modal 
 
 exports[`Overlay should render with isAnimated=false 1`] = `
 <Portal
-  portalId="Overlay-Portal-12"
+  portalId="383848317566352-Overlay-Portal-12"
 />
 `;

--- a/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
+++ b/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Overlay [common] example testing should match snapshot(s) for basic 1`] = `
 <Portal
-  portalId="383848317566352-Overlay-Portal-7"
+  portalId="1-Overlay-Portal-7"
 >
   <CSSTransitionGroup
     transitionAppear={false}
@@ -17,7 +17,7 @@ exports[`Overlay [common] example testing should match snapshot(s) for basic 1`]
 
 exports[`Overlay [common] example testing should match snapshot(s) for no-modal 1`] = `
 <Portal
-  portalId="383848317566352-Overlay-Portal-8"
+  portalId="1-Overlay-Portal-8"
 >
   <CSSTransitionGroup
     transitionAppear={false}
@@ -32,6 +32,6 @@ exports[`Overlay [common] example testing should match snapshot(s) for no-modal 
 
 exports[`Overlay should render with isAnimated=false 1`] = `
 <Portal
-  portalId="383848317566352-Overlay-Portal-12"
+  portalId="1-Overlay-Portal-12"
 />
 `;

--- a/src/components/RadioGroup/RadioGroup.jsx
+++ b/src/components/RadioGroup/RadioGroup.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
-import { lucidClassNames } from '../../util/style-helpers';
+import { lucidClassNames, uniqueName } from '../../util/style-helpers';
 import {
 	createClass,
 	getFirst,
@@ -95,7 +95,7 @@ const RadioGroup = createClass({
 
 	getDefaultProps() {
 		return {
-			name: _.uniqueId(`${cx('&')}-`),
+			name: uniqueName(`${cx('&')}-`),
 			onSelect: _.noop,
 			selectedIndex: 0,
 			isDisabled: false,

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
@@ -14,7 +14,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={true}
     key="0"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -36,7 +36,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="1"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -58,7 +58,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="2"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -80,7 +80,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="3"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -102,7 +102,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="4"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -131,7 +131,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={true}
     key="0"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -153,7 +153,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="1"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -175,7 +175,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="2"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -197,7 +197,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="3"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -219,7 +219,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="4"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -248,7 +248,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
     isDisabled={false}
     isSelected={true}
     key="0"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -292,7 +292,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
     isDisabled={false}
     isSelected={false}
     key="1"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -341,7 +341,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
     isDisabled={false}
     isSelected={false}
     key="2"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -645,7 +645,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for statef
     isDisabled={false}
     isSelected={true}
     key="0"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -667,7 +667,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for statef
     isDisabled={false}
     isSelected={false}
     key="1"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -689,7 +689,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for statef
     isDisabled={false}
     isSelected={false}
     key="2"
-    name="lucid-RadioGroup-2"
+    name="8984211157799808-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.spec.jsx.snap
@@ -14,7 +14,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={true}
     key="0"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -36,7 +36,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="1"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -58,7 +58,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="2"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -80,7 +80,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="3"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -102,7 +102,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for defaul
     isDisabled={false}
     isSelected={false}
     key="4"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -131,7 +131,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={true}
     key="0"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -153,7 +153,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="1"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -175,7 +175,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="2"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -197,7 +197,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="3"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -219,7 +219,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for is-dis
     isDisabled={true}
     isSelected={false}
     key="4"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -248,7 +248,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
     isDisabled={false}
     isSelected={true}
     key="0"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -292,7 +292,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
     isDisabled={false}
     isSelected={false}
     key="1"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -341,7 +341,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for nested
     isDisabled={false}
     isSelected={false}
     key="2"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -645,7 +645,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for statef
     isDisabled={false}
     isSelected={true}
     key="0"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -667,7 +667,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for statef
     isDisabled={false}
     isSelected={false}
     key="1"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {
@@ -689,7 +689,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for statef
     isDisabled={false}
     isSelected={false}
     key="2"
-    name="8984211157799808-lucid-RadioGroup-2"
+    name="1-lucid-RadioGroup-2"
     onSelect={[Function]}
     style={
       Object {

--- a/src/util/style-helpers.js
+++ b/src/util/style-helpers.js
@@ -1,6 +1,8 @@
 import _ from 'lodash';
 import classNames from 'classnames';
 
+const RANDOM_INTEGER = _.random(0, Number.MAX_SAFE_INTEGER);
+
 /**
  * bindClassNames
  *
@@ -40,3 +42,7 @@ export const NAMESPACE = 'lucid';
  *   }, ['custom-classname']) === 'lucid-Button lucid-Button-active custom-classname'
  */
 export const lucidClassNames = bindClassNames(NAMESPACE);
+
+export function uniqueName(prefix) {
+	return _.uniqueId(`${RANDOM_INTEGER}-${prefix}`);
+}

--- a/src/util/style-helpers.spec.js
+++ b/src/util/style-helpers.spec.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import _ from 'lodash';
-import { bindClassNames, lucidClassNames } from './style-helpers';
+import { bindClassNames, lucidClassNames, uniqueName } from './style-helpers';
 
 describe('#bindClassNames', function() {
 	it('should always return a function', () => {
@@ -129,4 +129,22 @@ describe('#lucidClassNames', function() {
 			'lucid-Button my-custom-class another-class'
 		);
 	});
+});
+
+describe('#uniqueName', () => {
+	it('should increment by one every time it is called', () => {
+		const first = _.parseInt(_.split(uniqueName('foo'), 'foo')[1]);
+		const second = _.parseInt(_.split(uniqueName('foo'), 'foo')[1]);
+		assert.equal(first + 1, second);
+	});
+
+	it(
+		'should reuse random prefix. This will safeguard against unfortunate cases where two ' +
+			'lucid instances are present.',
+		() => {
+			const first = _.split(uniqueName('foo'), 'foo')[0];
+			const second = _.split(uniqueName('foo'), 'foo')[0];
+			assert.equal(first, second);
+		}
+	);
 });

--- a/tests/init.js
+++ b/tests/init.js
@@ -1,6 +1,11 @@
+import _ from 'lodash';
+
 // Mock RAF
 // looks like this will be unnecessary starting with jest@21.3.0
 // https://github.com/facebook/jest/issues/4545#issuecomment-338217594
 global.requestAnimationFrame = function(callback) {
 	setTimeout(callback, 0);
 };
+
+//mock random so tests/snapshots are deterministic
+_.random = jest.fn(() => 1);


### PR DESCRIPTION
safeguard against duplicate portal ids when (for some not ideal reason) multiple instances of the lucid library are loaded by consumer apps

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ x Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
