### PR TITLE
full width sidepanel content

### DIFF
--- a/src/components/SidePanel/SidePanel.less
+++ b/src/components/SidePanel/SidePanel.less
@@ -96,6 +96,7 @@
 			.@{prefix}-SidePanel-content {
 				overflow: auto;
 				padding: 20px 20px 20px 0;
+				flex: 1;
 			}
 
 		}


### PR DESCRIPTION
the sidepanel uses `display: flex` for the content, so make this content area `flex: 1` to be full width.