### PR TITLE
adjust Breadcrumb to fit children and use a single element for separator

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.jsx
@@ -70,10 +70,7 @@ const Breadcrumb = createClass({
 								className={cx('&-Item', props.className)}
 							>
 								{props.children}
-								<span className={cx('&-BreadcrumbSeparator')}>
-									<span />
-									<span />
-								</span>
+								<span className={cx('&-BreadcrumbSeparator')} />
 							</li>
 						))}
 						<li

--- a/src/components/Breadcrumb/Breadcrumb.less
+++ b/src/components/Breadcrumb/Breadcrumb.less
@@ -2,7 +2,6 @@
 @import (reference) '../../styles/mixins.less';
 
 .@{prefix}-Breadcrumb {
-
 	@breadcrumb-margin: 7px;
 	font: @font;
 	font-weight: @font-weight-medium;
@@ -16,7 +15,7 @@
 		align-items: center;
 		padding: 0;
 		margin: 0;
-		height: 12px;
+		min-height: 16px;
 
 		> .@{prefix}-Breadcrumb-Item {
 			display: flex;
@@ -31,7 +30,8 @@
 				justify-content: center;
 				text-decoration: none;
 				color: @color-textColor;
-				line-height: 0;
+				line-height: 12px;
+				min-height: 16px;
 
 				&:hover {
 					text-decoration: underline;
@@ -46,21 +46,11 @@
 			}
 
 			.@{prefix}-Breadcrumb-BreadcrumbSeparator {
-				margin: 2px 0 0 2px;
-
-				> span {
-					display: inline-block;
-					width: 8px;
-					height: 16px;
-					transform: rotate(30deg);
-					opacity: 0.7;
-
-					&:first-child {
-						border-right: 1px solid @color-neutral-6;
-					}
-				}
+				margin: 0 8px;
+				border-right: 1px solid @color-neutral-6;
+				height: 16px;
+				transform: rotate(30deg);
 			}
 		}
 	}
 }
-


### PR DESCRIPTION
problem: the breadcrumb component doesn't encapsulate it's children, which can cause weird spacing interactions with its siblings.

the light blue shows the Breadcrumb container and the gray shows the containers for each breadcrumb item. 
![image](https://user-images.githubusercontent.com/648/57641307-8ed74800-7569-11e9-9f11-e2e096a5e45b.png)

fixed (gray shows Breadcrumb container and yellow shows Breadcrumb item):
![image](https://user-images.githubusercontent.com/648/57641380-bc23f600-7569-11e9-9366-b1c913ffb35b.png)

This also changes the separator to be a single span.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
