### PR TITLE
use react to create a portal so that context is available

### DIFF
--- a/src/components/Portal/Portal.jsx
+++ b/src/components/Portal/Portal.jsx
@@ -59,7 +59,7 @@ const Portal = createClass({
 		this.setState({ isReady: true });
 	},
 	componentWillUnmount() {
-		if (this.manuallyCreatedPOrtal) {
+		if (this.manuallyCreatedPortal) {
 			this.portalElement.remove();
 		}
 	},

--- a/src/components/Portal/Portal.spec.jsx
+++ b/src/components/Portal/Portal.spec.jsx
@@ -8,7 +8,7 @@ describe('Portal', () => {
 	describe('props', () => {
 		describe('portalId', () => {
 			it('should set the id of the portal DOM element portalId', () => {
-				const wrapper = mount(<Portal portalId='test1234' />);
+				const wrapper = mount(<Portal portalId="test1234" />);
 
 				assert(document.getElementById('test1234'));
 				wrapper.unmount();
@@ -18,7 +18,7 @@ describe('Portal', () => {
 		describe('children', () => {
 			it('should pass thru children', () => {
 				const wrapper = mount(
-					<Portal portalId='test1234'>
+					<Portal portalId="test1234">
 						<button>test</button>
 					</Portal>
 				);
@@ -28,5 +28,12 @@ describe('Portal', () => {
 				wrapper.unmount();
 			});
 		});
+	});
+
+	it('removes itself on unmount', () => {
+		const wrapper = mount(<Portal portalId="unmount-test" />);
+		expect(document.getElementById('unmount-test')).toBeTruthy();
+		wrapper.unmount();
+		expect(document.getElementById('unmount-test')).toBeNull();
 	});
 });

--- a/src/components/Portal/examples/basic.jsx
+++ b/src/components/Portal/examples/basic.jsx
@@ -24,6 +24,7 @@ export default createClass({
 		return (
 			<Portal
 				portalId='example-portal123'
+				className='example-portal-container'
 				style={{
 					width: 128,
 					height: 128,

--- a/src/components/Portal/examples/context.jsx
+++ b/src/components/Portal/examples/context.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
+
+import { Button, Portal } from '../../../index';
+
+const context = React.createContext({
+	display: 'hello',
+});
+
+class ExampleApp extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			counter: 0,
+			increment: () => {
+				this.setState(({ counter }) => ({ counter: counter + 1 }));
+			},
+		};
+	}
+
+	render() {
+		return (
+			<context.Provider value={this.state}>
+				{this.props.children}
+			</context.Provider>
+		);
+	}
+}
+ExampleApp.propTypes = {
+	children: PropTypes.node,
+};
+
+export default createClass({
+	render() {
+		return (
+			<ExampleApp>
+				<context.Consumer>
+					{({ counter, increment }) => (
+						<div>
+							<h1>counter: {counter}</h1>
+							<Button kind='primary' onClick={increment}>
+								increment
+							</Button>
+						</div>
+					)}
+				</context.Consumer>
+				<Portal
+					style={{
+						marginTop: 20,
+						border: '1px solid #333',
+						padding: 10,
+						width: 100,
+						height: 100,
+						backgroundColor: 'yellow',
+					}}
+				>
+					<context.Consumer>
+						{({ counter, increment }) => (
+							<div>
+								inside the portal counter: {counter}
+								<Button kind='primary' onClick={increment}>
+									increment
+								</Button>
+							</div>
+						)}
+					</context.Consumer>
+				</Portal>
+			</ExampleApp>
+		);
+	},
+});


### PR DESCRIPTION
lucid's portal implementation loses react context.

This pull request changes the portal implementation to use `React.createPortal` to [ensure that context is preserved](https://reactjs.org/docs/portals.html).

An example using context has been added.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
