### PR TITLE
add prop to Paginator to show total count

### DIFF
--- a/src/components/Paginator/Paginator.jsx
+++ b/src/components/Paginator/Paginator.jsx
@@ -64,6 +64,17 @@ const Paginator = createClass({
 			SingleSelect component for the page size selector.
 		`,
 
+		showTotalObjects: bool`
+			Show total count of objects.
+		`,
+
+		objectLabel: string`
+			Label when showTotalObjects is true with 1 or fewer objects.
+		`,
+		objectLabelPlural: string`
+			Label when showTotalObjects is true with more than 1 objects.
+		`,
+
 		totalPages: number`
 			number to display in \`of \${totalPages}\`, calculated from
 			\`totalPages\` and selected page size by default.
@@ -97,9 +108,12 @@ const Paginator = createClass({
 		return {
 			hasPageSizeSelector: false,
 			isDisabled: false,
+			objectLabel: 'Object',
+			objectLabelPlural: 'Objects',
 			onPageSelect: _.noop,
 			selectedPageIndex: 0,
 			selectedPageSizeIndex: 0,
+			showTotalObjects: false,
 			totalCount: null,
 			pageSizeOptions: [10, 50, 100],
 			SingleSelect: {
@@ -124,12 +138,16 @@ const Paginator = createClass({
 			className,
 			hasPageSizeSelector,
 			isDisabled,
+			objectLabel,
+			objectLabelPlural,
 			onPageSelect,
 			onPageSizeSelect,
 			pageSizeOptions,
 			selectedPageIndex,
 			selectedPageSizeIndex,
+			showTotalObjects,
 			totalPages,
+			totalCount,
 			style,
 			SingleSelect: singleSelectProps,
 			TextField: textFieldProps,
@@ -137,6 +155,11 @@ const Paginator = createClass({
 
 		return (
 			<div style={style} className={cx('&', className)}>
+				{showTotalObjects && _.isNumber(totalCount) && (
+					<div className={cx('&-total-count')}>
+						{totalCount} {totalCount <= 1 ? objectLabel : objectLabelPlural}
+					</div>
+				)}
 				{hasPageSizeSelector ? (
 					<div className={cx('&-page-size-container')}>
 						<span className={cx('&-rows-per-page-label')}>Rows per page:</span>

--- a/src/components/Paginator/Paginator.less
+++ b/src/components/Paginator/Paginator.less
@@ -5,6 +5,10 @@
 	font-size: @fontSize;
 	font-family: @fontFamily;
 
+	&-total-count {
+		flex: 1;
+	}
+
 	&-rows-per-page-label {
 		margin-right: @size-XS;
 	}

--- a/src/components/Paginator/Paginator.spec.jsx
+++ b/src/components/Paginator/Paginator.spec.jsx
@@ -291,5 +291,57 @@ describe('Paginator', () => {
 				);
 			});
 		});
+
+		describe('showTotalObjects', () => {
+			it('should not show a total count when totalCount is null', () => {
+				const wrapper = shallow(<Paginator showTotalObjects />);
+
+				expect(wrapper.find('.lucid-Paginator-total-count')).toHaveLength(0);
+			});
+
+			it('should show a total count', () => {
+				const wrapper = shallow(
+					<Paginator showTotalObjects totalCount={101} />
+				);
+
+				expect(wrapper.exists('.lucid-Paginator-total-count')).toEqual(true);
+				expect(wrapper.find('.lucid-Paginator-total-count').text()).toContain(
+					'101 Objects'
+				);
+			});
+
+			it('should show a total count', () => {
+				const wrapper = shallow(<Paginator showTotalObjects totalCount={1} />);
+
+				expect(wrapper.exists('.lucid-Paginator-total-count')).toEqual(true);
+				expect(wrapper.find('.lucid-Paginator-total-count').text()).toContain(
+					'1 Object'
+				);
+			});
+		});
+
+		describe('objectLabel for total count', () => {
+			it('should show the objectLabel with totalCount = 1', () => {
+				const wrapper = shallow(
+					<Paginator showTotalObjects totalCount={1} objectLabel='test123' />
+				);
+				expect(wrapper.find('.lucid-Paginator-total-count').text()).toContain(
+					'1 test123'
+				);
+			});
+
+			it('should show the objectLabelPlural with totalCount = 2', () => {
+				const wrapper = shallow(
+					<Paginator
+						showTotalObjects
+						totalCount={2}
+						objectLabelPlural='twocounts'
+					/>
+				);
+				expect(wrapper.find('.lucid-Paginator-total-count').text()).toContain(
+					'2 twocounts'
+				);
+			});
+		});
 	});
 });

--- a/src/components/Paginator/__snapshots__/Paginator.spec.jsx.snap
+++ b/src/components/Paginator/__snapshots__/Paginator.spec.jsx.snap
@@ -269,3 +269,416 @@ exports[`Paginator [common] example testing should match snapshot(s) for 3.disab
   </Button>
 </div>
 `;
+
+exports[`Paginator [common] example testing should match snapshot(s) for 4.show-object-count 1`] = `
+<div
+  className="lucid-Paginator"
+>
+  <div
+    className="lucid-Paginator-total-count"
+  >
+    101
+     
+    Objects
+  </div>
+  <div
+    className="lucid-Paginator-page-size-container"
+  >
+    <span
+      className="lucid-Paginator-rows-per-page-label"
+    >
+      Rows per page:
+    </span>
+    <SingleSelect
+      DropMenu={
+        Object {
+          "direction": "up",
+        }
+      }
+      hasReset={false}
+      isDisabled={false}
+      isInvisible={true}
+      isSelectionHighlighted={false}
+      selectedIndex={0}
+    >
+      <SingleSelect.Option
+        key="10"
+      >
+        10
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="50"
+      >
+        50
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="100"
+      >
+        100
+      </SingleSelect.Option>
+    </SingleSelect>
+  </div>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={true}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="left"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+  <TextField
+    debounceLevel={500}
+    isDisabled={false}
+    isMultiLine={false}
+    lazyLevel={1000}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onChangeDebounced={[Function]}
+    onSubmit={[Function]}
+    rows={5}
+    style={null}
+    value={1}
+  />
+  <span>
+    of 
+  </span>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={false}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="right"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+</div>
+`;
+
+exports[`Paginator [common] example testing should match snapshot(s) for 4.show-object-count 2`] = `
+<div
+  className="lucid-Paginator"
+>
+  <div
+    className="lucid-Paginator-page-size-container"
+  >
+    <span
+      className="lucid-Paginator-rows-per-page-label"
+    >
+      Rows per page:
+    </span>
+    <SingleSelect
+      DropMenu={
+        Object {
+          "direction": "up",
+        }
+      }
+      hasReset={false}
+      isDisabled={false}
+      isInvisible={true}
+      isSelectionHighlighted={false}
+      selectedIndex={0}
+    >
+      <SingleSelect.Option
+        key="10"
+      >
+        10
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="50"
+      >
+        50
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="100"
+      >
+        100
+      </SingleSelect.Option>
+    </SingleSelect>
+  </div>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={true}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="left"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+  <TextField
+    debounceLevel={500}
+    isDisabled={false}
+    isMultiLine={false}
+    lazyLevel={1000}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onChangeDebounced={[Function]}
+    onSubmit={[Function]}
+    rows={5}
+    style={null}
+    value={1}
+  />
+  <span>
+    of 
+  </span>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={false}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="right"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+</div>
+`;
+
+exports[`Paginator [common] example testing should match snapshot(s) for 4.show-object-count 3`] = `
+<div
+  className="lucid-Paginator"
+>
+  <div
+    className="lucid-Paginator-total-count"
+  >
+    1
+     
+    singular object
+  </div>
+  <div
+    className="lucid-Paginator-page-size-container"
+  >
+    <span
+      className="lucid-Paginator-rows-per-page-label"
+    >
+      Rows per page:
+    </span>
+    <SingleSelect
+      DropMenu={
+        Object {
+          "ContextMenu": Object {
+            "alignment": "start",
+            "direction": "down",
+            "directonOffset": 0,
+            "getAlignmentOffset": [Function],
+            "isExpanded": true,
+            "minWidthOffset": 0,
+            "onClickOut": null,
+            "portalId": null,
+          },
+          "alignment": "start",
+          "direction": "down",
+          "flyOutStyle": Object {
+            "maxHeight": "18em",
+          },
+          "focusedIndex": null,
+          "isDisabled": false,
+          "isExpanded": false,
+          "onCollapse": [Function],
+          "onExpand": [Function],
+          "onFocusNext": [Function],
+          "onFocusOption": [Function],
+          "onFocusPrev": [Function],
+          "onSelect": [Function],
+          "selectedIndices": Array [],
+        }
+      }
+      hasReset={false}
+      isDisabled={false}
+      isInvisible={true}
+      isSelectionHighlighted={false}
+      selectedIndex={0}
+    >
+      <SingleSelect.Option
+        key="10"
+      >
+        10
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="50"
+      >
+        50
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="100"
+      >
+        100
+      </SingleSelect.Option>
+    </SingleSelect>
+  </div>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={true}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="left"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+  <TextField
+    debounceLevel={500}
+    isDisabled={false}
+    isMultiLine={false}
+    lazyLevel={1000}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onChangeDebounced={[Function]}
+    onSubmit={[Function]}
+    rows={5}
+    style={null}
+    value={1}
+  />
+  <span>
+    of 
+  </span>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={false}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="right"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+</div>
+`;
+
+exports[`Paginator [common] example testing should match snapshot(s) for 4.show-object-count 4`] = `
+<div
+  className="lucid-Paginator"
+>
+  <div
+    className="lucid-Paginator-total-count"
+  >
+    2
+     
+    is more than one
+  </div>
+  <div
+    className="lucid-Paginator-page-size-container"
+  >
+    <span
+      className="lucid-Paginator-rows-per-page-label"
+    >
+      Rows per page:
+    </span>
+    <SingleSelect
+      DropMenu={
+        Object {
+          "ContextMenu": Object {
+            "alignment": "start",
+            "direction": "down",
+            "directonOffset": 0,
+            "getAlignmentOffset": [Function],
+            "isExpanded": true,
+            "minWidthOffset": 0,
+            "onClickOut": null,
+            "portalId": null,
+          },
+          "alignment": "start",
+          "direction": "down",
+          "flyOutStyle": Object {
+            "maxHeight": "18em",
+          },
+          "focusedIndex": null,
+          "isDisabled": false,
+          "isExpanded": false,
+          "onCollapse": [Function],
+          "onExpand": [Function],
+          "onFocusNext": [Function],
+          "onFocusOption": [Function],
+          "onFocusPrev": [Function],
+          "onSelect": [Function],
+          "selectedIndices": Array [],
+        }
+      }
+      hasReset={false}
+      isDisabled={false}
+      isInvisible={true}
+      isSelectionHighlighted={false}
+      selectedIndex={0}
+    >
+      <SingleSelect.Option
+        key="10"
+      >
+        10
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="50"
+      >
+        50
+      </SingleSelect.Option>
+      <SingleSelect.Option
+        key="100"
+      >
+        100
+      </SingleSelect.Option>
+    </SingleSelect>
+  </div>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={true}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="left"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+  <TextField
+    debounceLevel={500}
+    isDisabled={false}
+    isMultiLine={false}
+    lazyLevel={1000}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onChangeDebounced={[Function]}
+    onSubmit={[Function]}
+    rows={5}
+    style={null}
+    value={1}
+  />
+  <span>
+    of 
+  </span>
+  <Button
+    hasOnlyIcon={true}
+    isActive={false}
+    isDisabled={false}
+    kind="invisible"
+    onClick={[Function]}
+    type="button"
+  >
+    <ArrowIcon
+      direction="right"
+      viewBox="0 0 16 16"
+    />
+  </Button>
+</div>
+`;

--- a/src/components/Paginator/examples/4.show-object-count.jsx
+++ b/src/components/Paginator/examples/4.show-object-count.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Paginator } from '../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<p>A paginator displaying a total count of objects.</p>
+
+				<section>
+					<Paginator
+						hasPageSizeSelector
+						showTotalObjects
+						totalCount={101}
+						SingleSelect={{
+							DropMenu: { direction: 'up' },
+						}}
+					/>
+
+					<p>
+						Total count is hidden if <code>totalCount</code> is not a valid
+						number
+					</p>
+
+					<Paginator
+						hasPageSizeSelector
+						showTotalObjects
+						SingleSelect={{
+							DropMenu: { direction: 'up' },
+						}}
+					/>
+				</section>
+
+				<p>
+					The label can be changed using <code>objectLabel</code> and{' '}
+					<code>objectLabelPlural</code>
+				</p>
+				<section>
+					<Paginator
+						hasPageSizeSelector
+						showTotalObjects
+						totalCount={1}
+						objectLabel='singular object'
+					/>
+					<Paginator
+						hasPageSizeSelector
+						showTotalObjects
+						totalCount={2}
+						objectLabelPlural='is more than one'
+					/>
+				</section>
+			</div>
+		);
+	},
+});


### PR DESCRIPTION
Adds the ability to show the `totalCount` to the left side of the `Paginator`.

Additional props `objectLabel` and `objectLabelPlural` to customize the text after the total count number. 

This does not affect how the `Paginator` appears when `showTotalObjects` is not provided.

<img width="1074" alt="Screen Shot 2019-06-03 at 12 12 18 PM" src="https://user-images.githubusercontent.com/648/58838222-f0438180-8612-11e9-9dc6-5faabd9f5f60.png">

## Affected Component

- Paginator
  - new props: `showTotalObjects`, `objectLabel`, `objectLabelPlural`

