### PR TITLE
Additional expander label data and remove transition

### DIFF
--- a/src/components/Expander/Expander.jsx
+++ b/src/components/Expander/Expander.jsx
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
-import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	createClass,
@@ -148,16 +147,9 @@ const Expander = createClass({
 					<span className={cx('&-icon')}>
 						<ChevronIcon direction={isExpanded ? 'up' : 'down'} />
 					</span>
-					<ReactTransitionGroup
-						transitionName={cx('&-text')}
-						transitionEnterTimeout={100}
-						transitionLeaveTimeout={100}
-						className={cx('&-text')}
-					>
-						{labelChildProp ? (
-							<span key={this._labelKey}>{labelChildProp.children}</span>
-						) : null}
-					</ReactTransitionGroup>
+					{labelChildProp && (
+						<span className={cx('&-text')}>{labelChildProp.children}</span>
+					)}
 				</header>
 				<Collapsible
 					isExpanded={isExpanded}

--- a/src/components/Expander/Expander.jsx
+++ b/src/components/Expander/Expander.jsx
@@ -49,6 +49,22 @@ const Expander = createClass({
 				`,
 			},
 		}),
+		AdditionalLabelContent: createClass({
+			displayName: 'Expander.AdditionalLabelContent',
+			statics: {
+				peek: {
+					description: `
+						Renders a \`<span>\` to be shown next to the expander label.
+					`,
+				},
+			},
+			propName: 'AdditionalLabelContent',
+			propTypes: {
+				children: node`
+					Used to display additional information or/and actions next to expander label.
+				`,
+			},
+		}),
 	},
 
 	reducers,
@@ -79,6 +95,11 @@ const Expander = createClass({
 		Label: any`
 			Child element whose children represents content to be shown next to the
 			expander icon.
+		`,
+
+		AdditionalLabelContent: node`
+			Child element whose children respresent content to be shown inside
+			Expander.Label and to the right of it
 		`,
 
 		kind: oneOf(['simple', 'highlighted'])`
@@ -130,6 +151,10 @@ const Expander = createClass({
 			_.map(findTypes(this.props, Expander.Label), 'props')
 		);
 
+		const additionalLabelContentChildProp = _.first(
+			_.map(findTypes(this.props, Expander.AdditionalLabelContent), 'props')
+		);
+
 		return (
 			<div
 				{...omitProps(passThroughs, Expander)}
@@ -143,12 +168,19 @@ const Expander = createClass({
 				)}
 				style={style}
 			>
-				<header className={cx('&-header')} onClick={this.handleToggle}>
-					<span className={cx('&-icon')}>
-						<ChevronIcon direction={isExpanded ? 'up' : 'down'} />
-					</span>
-					{labelChildProp && (
-						<span className={cx('&-text')}>{labelChildProp.children}</span>
+				<header className={cx('&-header')}>
+					<div className={cx('&-header-toggle')} onClick={this.handleToggle}>
+						<span className={cx('&-icon')}>
+							<ChevronIcon direction={isExpanded ? 'up' : 'down'} />
+						</span>
+						{labelChildProp && (
+							<span className={cx('&-text')}>{labelChildProp.children}</span>
+						)}
+					</div>
+					{additionalLabelContentChildProp && (
+						<div className={cx('&-additional-content')}>
+							{additionalLabelContentChildProp.children}
+						</div>
 					)}
 				</header>
 				<Collapsible

--- a/src/components/Expander/Expander.less
+++ b/src/components/Expander/Expander.less
@@ -42,21 +42,10 @@
 	}
 
 	&-text {
-		.transition-group-animation-fade(@timing-animation-hover);
-
 		color: @color-darkGray;
 		height: @size-expander-button;
 		font-weight: @font-weight-medium;
 		position: relative;
-
-		// Since we have two elements in the dom during the transition from one
-		// label to another, we want the element that's leaving to appear "over
-		// the top" of the label that coming in.
-		&-leave {
-			position: absolute;
-			top: 0;
-			left: 0;
-		}
 
 		> * {
 			line-height: @size-expander-button;

--- a/src/components/Expander/Expander.less
+++ b/src/components/Expander/Expander.less
@@ -9,7 +9,6 @@
 		width: @size-expander-button;
 		height: @size-expander-button;
 		align-items: center;
-		display: flex;
 		justify-content: center;
 		margin-right: @size-XS;
 	}
@@ -17,7 +16,6 @@
 	&-header {
 		align-items: center;
 		color: @color-darkGray;
-		cursor: pointer;
 		display: flex;
 		font: @font;
 		justify-content: flex-start;
@@ -39,18 +37,27 @@
 				}
 			}
 		}
+
+		&-toggle {
+			cursor: pointer;
+		}
 	}
 
 	&-text {
 		color: @color-darkGray;
 		height: @size-expander-button;
 		font-weight: @font-weight-medium;
+		margin-right: @size-XS;
 		position: relative;
 
 		> * {
 			line-height: @size-expander-button;
 			white-space: nowrap;
 		}
+	}
+
+	&-additional-content {
+		flex: 1;
 	}
 
 	&-content {

--- a/src/components/Expander/Expander.less
+++ b/src/components/Expander/Expander.less
@@ -20,26 +20,21 @@
 		font: @font;
 		justify-content: flex-start;
 
-		&:hover {
-			> .@{prefix}-Expander-icon {
-				.box-sizing();
+		&-toggle {
+			cursor: pointer;
 
-				background-color: @featured-color-default-backgroundColorHover;
-				outline: none;
-			}
+			&:hover {
+				> .@{prefix}-Expander-icon {
+					.box-sizing();
 
-			> .@{prefix}-Expander-text {
+					background-color: @featured-color-default-backgroundColorHover;
+					outline: none;
+				}
 
-				// `text-decoration `does not inherit when you're using `position:
-				// absolute` as per the spec
-				> span {
+				> .@{prefix}-Expander-text {
 					text-decoration: underline;
 				}
 			}
-		}
-
-		&-toggle {
-			cursor: pointer;
 		}
 	}
 
@@ -47,7 +42,6 @@
 		color: @color-darkGray;
 		height: @size-expander-button;
 		font-weight: @font-weight-medium;
-		margin-right: @size-XS;
 		position: relative;
 
 		> * {
@@ -58,6 +52,7 @@
 
 	&-additional-content {
 		flex: 1;
+		margin-left: @size-standard;
 	}
 
 	&-content {

--- a/src/components/Expander/Expander.spec.jsx
+++ b/src/components/Expander/Expander.spec.jsx
@@ -12,7 +12,7 @@ describe('Expander', () => {
 	common(Expander);
 	controls(Expander, {
 		callbackName: 'onToggle',
-		controlSelector: '.lucid-Expander-header',
+		controlSelector: '.lucid-Expander-header-toggle',
 		eventType: 'click',
 	});
 
@@ -108,6 +108,36 @@ describe('Expander', () => {
 			});
 		});
 
+		describe('AdditionalLabelContent (as a prop)', () => {
+			it('renders the value in `lucid-Expander-additional-content` class', () => {
+				const additionalContent = <div>Hello</div>;
+				const wrapper = shallow(
+					<Expander>
+						<Expander.AdditionalLabelContent>
+							{additionalContent}
+						</Expander.AdditionalLabelContent>
+					</Expander>
+				);
+				assert.equal(
+					wrapper.find('.lucid-Expander-additional-content').prop('children'),
+					additionalContent
+				);
+			});
+		});
+
+		describe('AdditionalLabelContent (as a child)', () => {
+			it('renders the value in `lucid-Expander-additional-content` class', () => {
+				const additionalContent = <div>Hello</div>;
+				const wrapper = shallow(
+					<Expander AdditionalLabelContent={additionalContent} />
+				);
+				assert.equal(
+					wrapper.find('.lucid-Expander-additional-content').prop('children'),
+					additionalContent
+				);
+			});
+		});
+
 		describe('pass throughs', () => {
 			it('passes through all props not defined in `propTypes` to the root element.', () => {
 				const wrapper = shallow(
@@ -144,7 +174,7 @@ describe('Expander', () => {
 			wrapper = mount(<Expander onToggle={onToggle} Label='foo' />);
 
 			wrapper
-				.find('.lucid-Expander-header')
+				.find('.lucid-Expander-header-toggle')
 				.first()
 				.simulate('click');
 			wrapper
@@ -166,7 +196,7 @@ describe('Expander', () => {
 			);
 
 			wrapper
-				.find('.lucid-Expander-header')
+				.find('.lucid-Expander-header-toggle')
 				.first()
 				.simulate('click');
 			wrapper
@@ -190,7 +220,7 @@ describe('Expander', () => {
 			);
 
 			wrapper
-				.find('.lucid-Expander-header')
+				.find('.lucid-Expander-header-toggle')
 				.first()
 				.simulate('click');
 			wrapper

--- a/src/components/Expander/Expander.spec.jsx
+++ b/src/components/Expander/Expander.spec.jsx
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import assert from 'assert';
 import React from 'react';
-import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 
@@ -84,11 +83,10 @@ describe('Expander', () => {
 		});
 
 		describe('Label (as a prop)', () => {
-			it('renders the value in the header in a `SPAN` element neighboring its `ChevronIcon` instance.', () => {
+			it('renders the value in the header in `lucid-Expander-text` class neighboring `ChevronIcon` instance.', () => {
 				assert.equal(
 					shallow(<Expander Label='foo' />)
-						.find(ReactTransitionGroup)
-						.find('span')
+						.find('.lucid-Expander-text')
 						.prop('children'),
 					'foo'
 				);
@@ -96,7 +94,7 @@ describe('Expander', () => {
 		});
 
 		describe('Label (as a child)', () => {
-			it('renders the value in the header in a `SPAN` element neighboring its `ChevronIcon` instance.', () => {
+			it('renders the value in the header in `lucid-Expander-text` class neighboring `ChevronIcon` instance.', () => {
 				const wrapper = shallow(
 					<Expander>
 						<Expander.Label>foo</Expander.Label>
@@ -104,10 +102,7 @@ describe('Expander', () => {
 				);
 
 				assert.equal(
-					wrapper
-						.find(ReactTransitionGroup)
-						.find('span')
-						.prop('children'),
+					wrapper.find('.lucid-Expander-text').prop('children'),
 					'foo'
 				);
 			});
@@ -146,7 +141,7 @@ describe('Expander', () => {
 	describe('user clicks on the header', () => {
 		it('calls the function passed in as the `onToggle` prop', () => {
 			const onToggle = sinon.spy();
-			wrapper = mount(<Expander onToggle={onToggle} />);
+			wrapper = mount(<Expander onToggle={onToggle} Label='foo' />);
 
 			wrapper
 				.find('.lucid-Expander-header')
@@ -166,7 +161,9 @@ describe('Expander', () => {
 
 		it('should call `onToggle` correctly when not `isExpanded`', () => {
 			const onToggle = sinon.spy();
-			wrapper = mount(<Expander isExpanded={false} onToggle={onToggle} />);
+			wrapper = mount(
+				<Expander isExpanded={false} onToggle={onToggle} Label='foo' />
+			);
 
 			wrapper
 				.find('.lucid-Expander-header')
@@ -188,7 +185,9 @@ describe('Expander', () => {
 
 		it('should call `onToggle` correctly when `isExpanded`', () => {
 			const onToggle = sinon.spy();
-			wrapper = mount(<Expander isExpanded={true} onToggle={onToggle} />);
+			wrapper = mount(
+				<Expander isExpanded={true} onToggle={onToggle} Label='foo' />
+			);
 
 			wrapper
 				.find('.lucid-Expander-header')

--- a/src/components/Expander/__snapshots__/Expander.spec.jsx.snap
+++ b/src/components/Expander/__snapshots__/Expander.spec.jsx.snap
@@ -186,32 +186,30 @@ exports[`Expander [common] example testing should match snapshot(s) for 4.intera
     <div
       className="lucid-Expander-additional-content"
     >
-      <span>
-        <Button
-          hasOnlyIcon={false}
-          isActive={false}
-          isDisabled={false}
-          kind="invisible"
-          onClick={[Function]}
-          type="button"
-        >
-          <EditIcon />
-          Edit
-        </Button>
-        <Button
-          hasOnlyIcon={false}
-          isActive={false}
-          isDisabled={false}
-          kind="invisible"
-          onClick={[Function]}
-          type="button"
-        >
-          <CrossIcon
-            presetSize="small"
-          />
-          Clear All
-        </Button>
-      </span>
+      <Button
+        hasOnlyIcon={false}
+        isActive={false}
+        isDisabled={false}
+        kind="invisible"
+        onClick={[Function]}
+        type="button"
+      >
+        <EditIcon />
+        Edit
+      </Button>
+      <Button
+        hasOnlyIcon={false}
+        isActive={false}
+        isDisabled={false}
+        kind="invisible"
+        onClick={[Function]}
+        type="button"
+      >
+        <CrossIcon
+          presetSize="small"
+        />
+        Clear All
+      </Button>
     </div>
   </header>
   <Collapsible
@@ -226,32 +224,30 @@ exports[`Expander [common] example testing should match snapshot(s) for 4.intera
       Show Stuff
     </Expander.Label>
     <Expander.AdditionalLabelContent>
-      <span>
-        <Button
-          hasOnlyIcon={false}
-          isActive={false}
-          isDisabled={false}
-          kind="invisible"
-          onClick={[Function]}
-          type="button"
-        >
-          <EditIcon />
-          Edit
-        </Button>
-        <Button
-          hasOnlyIcon={false}
-          isActive={false}
-          isDisabled={false}
-          kind="invisible"
-          onClick={[Function]}
-          type="button"
-        >
-          <CrossIcon
-            presetSize="small"
-          />
-          Clear All
-        </Button>
-      </span>
+      <Button
+        hasOnlyIcon={false}
+        isActive={false}
+        isDisabled={false}
+        kind="invisible"
+        onClick={[Function]}
+        type="button"
+      >
+        <EditIcon />
+        Edit
+      </Button>
+      <Button
+        hasOnlyIcon={false}
+        isActive={false}
+        isDisabled={false}
+        kind="invisible"
+        onClick={[Function]}
+        type="button"
+      >
+        <CrossIcon
+          presetSize="small"
+        />
+        Clear All
+      </Button>
     </Expander.AdditionalLabelContent>
     <p>
       Tacos craft beer humblebrag meditation. Cold-pressed next level man bun readymade beard, wayfarers fanny pack keytar helvetica knausgaard biodiesel lumbersexual. Knausgaard echo park whatever four loko messenger bag hella. Cardigan church-key brooklyn letterpress artisan venmo, gastropub hella. Single-origin coffee selfies four loko, biodiesel health goth truffaut migas sustainable kale chips disrupt locavore meggings mustache actually retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally before they sold out gochujang pork belly franzen.

--- a/src/components/Expander/__snapshots__/Expander.spec.jsx.snap
+++ b/src/components/Expander/__snapshots__/Expander.spec.jsx.snap
@@ -15,21 +15,11 @@ exports[`Expander [common] example testing should match snapshot(s) for 1.expand
         direction="up"
       />
     </span>
-    <CSSTransitionGroup
+    <span
       className="lucid-Expander-text"
-      transitionAppear={false}
-      transitionEnter={true}
-      transitionEnterTimeout={100}
-      transitionLeave={true}
-      transitionLeaveTimeout={100}
-      transitionName="lucid-Expander-text"
     >
-      <span
-        key="0"
-      >
-        Show Less
-      </span>
-    </CSSTransitionGroup>
+      Show Less
+    </span>
   </header>
   <Collapsible
     className="lucid-Expander-content"
@@ -64,21 +54,11 @@ exports[`Expander [common] example testing should match snapshot(s) for 2.intera
         direction="down"
       />
     </span>
-    <CSSTransitionGroup
+    <span
       className="lucid-Expander-text"
-      transitionAppear={false}
-      transitionEnter={true}
-      transitionEnterTimeout={100}
-      transitionLeave={true}
-      transitionLeaveTimeout={100}
-      transitionName="lucid-Expander-text"
     >
-      <span
-        key="0"
-      >
-        Show More
-      </span>
-    </CSSTransitionGroup>
+      Show More
+    </span>
   </header>
   <Collapsible
     className="lucid-Expander-content"
@@ -128,21 +108,11 @@ exports[`Expander [common] example testing should match snapshot(s) for 3.intera
         direction="down"
       />
     </span>
-    <CSSTransitionGroup
+    <span
       className="lucid-Expander-text"
-      transitionAppear={false}
-      transitionEnter={true}
-      transitionEnterTimeout={100}
-      transitionLeave={true}
-      transitionLeaveTimeout={100}
-      transitionName="lucid-Expander-text"
     >
-      <span
-        key="0"
-      >
-        Show Stuff
-      </span>
-    </CSSTransitionGroup>
+      Show Stuff
+    </span>
   </header>
   <Collapsible
     className="lucid-Expander-content"

--- a/src/components/Expander/__snapshots__/Expander.spec.jsx.snap
+++ b/src/components/Expander/__snapshots__/Expander.spec.jsx.snap
@@ -6,20 +6,24 @@ exports[`Expander [common] example testing should match snapshot(s) for 1.expand
 >
   <header
     className="lucid-Expander-header"
-    onClick={[Function]}
   >
-    <span
-      className="lucid-Expander-icon"
+    <div
+      className="lucid-Expander-header-toggle"
+      onClick={[Function]}
     >
-      <ChevronIcon
-        direction="up"
-      />
-    </span>
-    <span
-      className="lucid-Expander-text"
-    >
-      Show Less
-    </span>
+      <span
+        className="lucid-Expander-icon"
+      >
+        <ChevronIcon
+          direction="up"
+        />
+      </span>
+      <span
+        className="lucid-Expander-text"
+      >
+        Show Less
+      </span>
+    </div>
   </header>
   <Collapsible
     className="lucid-Expander-content"
@@ -45,20 +49,24 @@ exports[`Expander [common] example testing should match snapshot(s) for 2.intera
 >
   <header
     className="lucid-Expander-header"
-    onClick={[Function]}
   >
-    <span
-      className="lucid-Expander-icon"
+    <div
+      className="lucid-Expander-header-toggle"
+      onClick={[Function]}
     >
-      <ChevronIcon
-        direction="down"
-      />
-    </span>
-    <span
-      className="lucid-Expander-text"
-    >
-      Show More
-    </span>
+      <span
+        className="lucid-Expander-icon"
+      >
+        <ChevronIcon
+          direction="down"
+        />
+      </span>
+      <span
+        className="lucid-Expander-text"
+      >
+        Show More
+      </span>
+    </div>
   </header>
   <Collapsible
     className="lucid-Expander-content"
@@ -99,20 +107,24 @@ exports[`Expander [common] example testing should match snapshot(s) for 3.intera
 >
   <header
     className="lucid-Expander-header"
-    onClick={[Function]}
   >
-    <span
-      className="lucid-Expander-icon"
+    <div
+      className="lucid-Expander-header-toggle"
+      onClick={[Function]}
     >
-      <ChevronIcon
-        direction="down"
-      />
-    </span>
-    <span
-      className="lucid-Expander-text"
-    >
-      Show Stuff
-    </span>
+      <span
+        className="lucid-Expander-icon"
+      >
+        <ChevronIcon
+          direction="down"
+        />
+      </span>
+      <span
+        className="lucid-Expander-text"
+      >
+        Show Stuff
+      </span>
+    </div>
   </header>
   <Collapsible
     className="lucid-Expander-content"
@@ -125,6 +137,122 @@ exports[`Expander [common] example testing should match snapshot(s) for 3.intera
     <Expander.Label>
       Show Stuff
     </Expander.Label>
+    <p>
+      Tacos craft beer humblebrag meditation. Cold-pressed next level man bun readymade beard, wayfarers fanny pack keytar helvetica knausgaard biodiesel lumbersexual. Knausgaard echo park whatever four loko messenger bag hella. Cardigan church-key brooklyn letterpress artisan venmo, gastropub hella. Single-origin coffee selfies four loko, biodiesel health goth truffaut migas sustainable kale chips disrupt locavore meggings mustache actually retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally before they sold out gochujang pork belly franzen.
+    </p>
+    <p>
+      Sriracha put a bird on it chia, locavore wolf affogato tote bag neutra umami food truck austin keytar cronut man bun. Kitsch man braid occupy art party, tousled waistcoat tilde YOLO keytar street art selvage. Salvia pour-over keytar intelligentsia. Marfa yr stumptown, before they sold out lo-fi literally art party williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic aesthetic kickstarter, dreamcatcher four dollar toast whatever tattooed quinoa. Single-origin coffee blog lomo, freegan next level ramps small batch put a bird on it listicle stumptown. Stumptown mumblecore vinyl, mustache street art wayfarers lumbersexual everyday carry irony pitchfork gochujang pug DIY gentrify.
+    </p>
+    <p>
+      Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B asymmetrical meggings kombucha banh mi meh skateboard artisan man braid. Ugh semiotics intelligentsia sustainable, craft beer next level meggings before they sold out heirloom iPhone try-hard. Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS thundercats man braid waistcoat ennui. Church-key knausgaard austin organic farm-to-table neutra franzen bespoke, mlkshk narwhal DIY raw denim retro. Mlkshk locavore try-hard roof party flexitarian. Letterpress beard fixie, umami waistcoat salvia ennui four loko seitan lomo franzen pickled shoreditch master cleanse.
+    </p>
+    <p>
+      Tacos craft beer humblebrag meditation. Cold-pressed next level man bun readymade beard, wayfarers fanny pack keytar helvetica knausgaard biodiesel lumbersexual. Knausgaard echo park whatever four loko messenger bag hella. Cardigan church-key brooklyn letterpress artisan venmo, gastropub hella. Single-origin coffee selfies four loko, biodiesel health goth truffaut migas sustainable kale chips disrupt locavore meggings mustache actually retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally before they sold out gochujang pork belly franzen.
+    </p>
+    <p>
+      Sriracha put a bird on it chia, locavore wolf affogato tote bag neutra umami food truck austin keytar cronut man bun. Kitsch man braid occupy art party, tousled waistcoat tilde YOLO keytar street art selvage. Salvia pour-over keytar intelligentsia. Marfa yr stumptown, before they sold out lo-fi literally art party williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic aesthetic kickstarter, dreamcatcher four dollar toast whatever tattooed quinoa. Single-origin coffee blog lomo, freegan next level ramps small batch put a bird on it listicle stumptown. Stumptown mumblecore vinyl, mustache street art wayfarers lumbersexual everyday carry irony pitchfork gochujang pug DIY gentrify.
+    </p>
+    <p>
+      Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B asymmetrical meggings kombucha banh mi meh skateboard artisan man braid. Ugh semiotics intelligentsia sustainable, craft beer next level meggings before they sold out heirloom iPhone try-hard. Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS thundercats man braid waistcoat ennui. Church-key knausgaard austin organic farm-to-table neutra franzen bespoke, mlkshk narwhal DIY raw denim retro. Mlkshk locavore try-hard roof party flexitarian. Letterpress beard fixie, umami waistcoat salvia ennui four loko seitan lomo franzen pickled shoreditch master cleanse.
+    </p>
+  </Collapsible>
+</div>
+`;
+
+exports[`Expander [common] example testing should match snapshot(s) for 4.interactive-with-changing-labels-and-additional-label-content 1`] = `
+<div
+  className="lucid-Expander"
+>
+  <header
+    className="lucid-Expander-header"
+  >
+    <div
+      className="lucid-Expander-header-toggle"
+      onClick={[Function]}
+    >
+      <span
+        className="lucid-Expander-icon"
+      >
+        <ChevronIcon
+          direction="down"
+        />
+      </span>
+      <span
+        className="lucid-Expander-text"
+      >
+        Show Stuff
+      </span>
+    </div>
+    <div
+      className="lucid-Expander-additional-content"
+    >
+      <span>
+        <Button
+          hasOnlyIcon={false}
+          isActive={false}
+          isDisabled={false}
+          kind="invisible"
+          onClick={[Function]}
+          type="button"
+        >
+          <EditIcon />
+          Edit
+        </Button>
+        <Button
+          hasOnlyIcon={false}
+          isActive={false}
+          isDisabled={false}
+          kind="invisible"
+          onClick={[Function]}
+          type="button"
+        >
+          <CrossIcon
+            presetSize="small"
+          />
+          Clear All
+        </Button>
+      </span>
+    </div>
+  </header>
+  <Collapsible
+    className="lucid-Expander-content"
+    isAnimated={true}
+    isExpanded={false}
+    isMountControlled={true}
+    mountControlThreshold={4}
+    rootType="section"
+  >
+    <Expander.Label>
+      Show Stuff
+    </Expander.Label>
+    <Expander.AdditionalLabelContent>
+      <span>
+        <Button
+          hasOnlyIcon={false}
+          isActive={false}
+          isDisabled={false}
+          kind="invisible"
+          onClick={[Function]}
+          type="button"
+        >
+          <EditIcon />
+          Edit
+        </Button>
+        <Button
+          hasOnlyIcon={false}
+          isActive={false}
+          isDisabled={false}
+          kind="invisible"
+          onClick={[Function]}
+          type="button"
+        >
+          <CrossIcon
+            presetSize="small"
+          />
+          Clear All
+        </Button>
+      </span>
+    </Expander.AdditionalLabelContent>
     <p>
       Tacos craft beer humblebrag meditation. Cold-pressed next level man bun readymade beard, wayfarers fanny pack keytar helvetica knausgaard biodiesel lumbersexual. Knausgaard echo park whatever four loko messenger bag hella. Cardigan church-key brooklyn letterpress artisan venmo, gastropub hella. Single-origin coffee selfies four loko, biodiesel health goth truffaut migas sustainable kale chips disrupt locavore meggings mustache actually retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally before they sold out gochujang pork belly franzen.
     </p>

--- a/src/components/Expander/examples/4.interactive-with-changing-labels-and-additional-label-content.jsx
+++ b/src/components/Expander/examples/4.interactive-with-changing-labels-and-additional-label-content.jsx
@@ -9,16 +9,14 @@ export default createClass({
 				<Expander>
 					<Expander.Label>Show Stuff</Expander.Label>
 					<Expander.AdditionalLabelContent>
-						<span>
-							<Button kind='invisible'>
-								<EditIcon />
-								Edit
-							</Button>
-							<Button kind='invisible'>
-								<CrossIcon />
-								Clear All
-							</Button>
-						</span>
+						<Button kind='invisible'>
+							<EditIcon />
+							Edit
+						</Button>
+						<Button kind='invisible'>
+							<CrossIcon />
+							Clear All
+						</Button>
 					</Expander.AdditionalLabelContent>
 					<p>
 						Tacos craft beer humblebrag meditation. Cold-pressed next level man

--- a/src/components/Expander/examples/4.interactive-with-changing-labels-and-additional-label-content.jsx
+++ b/src/components/Expander/examples/4.interactive-with-changing-labels-and-additional-label-content.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Button, CrossIcon, EditIcon, Expander } from '../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<Expander>
+					<Expander.Label>Show Stuff</Expander.Label>
+					<Expander.AdditionalLabelContent>
+						<span>
+							<Button kind='invisible'>
+								<EditIcon />
+								Edit
+							</Button>
+							<Button kind='invisible'>
+								<CrossIcon />
+								Clear All
+							</Button>
+						</span>
+					</Expander.AdditionalLabelContent>
+					<p>
+						Tacos craft beer humblebrag meditation. Cold-pressed next level man
+						bun readymade beard, wayfarers fanny pack keytar helvetica
+						knausgaard biodiesel lumbersexual. Knausgaard echo park whatever
+						four loko messenger bag hella. Cardigan church-key brooklyn
+						letterpress artisan venmo, gastropub hella. Single-origin coffee
+						selfies four loko, biodiesel health goth truffaut migas sustainable
+						kale chips disrupt locavore meggings mustache actually retro. Mlkshk
+						poutine flexitarian scenester 3 wolf moon, vice kinfolk chia blog
+						ennui bitters brooklyn quinoa marfa. Literally before they sold out
+						gochujang pork belly franzen.
+					</p>
+					<p>
+						Sriracha put a bird on it chia, locavore wolf affogato tote bag
+						neutra umami food truck austin keytar cronut man bun. Kitsch man
+						braid occupy art party, tousled waistcoat tilde YOLO keytar street
+						art selvage. Salvia pour-over keytar intelligentsia. Marfa yr
+						stumptown, before they sold out lo-fi literally art party
+						williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic
+						aesthetic kickstarter, dreamcatcher four dollar toast whatever
+						tattooed quinoa. Single-origin coffee blog lomo, freegan next level
+						ramps small batch put a bird on it listicle stumptown. Stumptown
+						mumblecore vinyl, mustache street art wayfarers lumbersexual
+						everyday carry irony pitchfork gochujang pug DIY gentrify.
+					</p>
+					<p>
+						Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth
+						migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
+						asymmetrical meggings kombucha banh mi meh skateboard artisan man
+						braid. Ugh semiotics intelligentsia sustainable, craft beer next
+						level meggings before they sold out heirloom iPhone try-hard.
+						Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS
+						thundercats man braid waistcoat ennui. Church-key knausgaard austin
+						organic farm-to-table neutra franzen bespoke, mlkshk narwhal DIY raw
+						denim retro. Mlkshk locavore try-hard roof party flexitarian.
+						Letterpress beard fixie, umami waistcoat salvia ennui four loko
+						seitan lomo franzen pickled shoreditch master cleanse.
+					</p>
+					<p>
+						Tacos craft beer humblebrag meditation. Cold-pressed next level man
+						bun readymade beard, wayfarers fanny pack keytar helvetica
+						knausgaard biodiesel lumbersexual. Knausgaard echo park whatever
+						four loko messenger bag hella. Cardigan church-key brooklyn
+						letterpress artisan venmo, gastropub hella. Single-origin coffee
+						selfies four loko, biodiesel health goth truffaut migas sustainable
+						kale chips disrupt locavore meggings mustache actually retro. Mlkshk
+						poutine flexitarian scenester 3 wolf moon, vice kinfolk chia blog
+						ennui bitters brooklyn quinoa marfa. Literally before they sold out
+						gochujang pork belly franzen.
+					</p>
+					<p>
+						Sriracha put a bird on it chia, locavore wolf affogato tote bag
+						neutra umami food truck austin keytar cronut man bun. Kitsch man
+						braid occupy art party, tousled waistcoat tilde YOLO keytar street
+						art selvage. Salvia pour-over keytar intelligentsia. Marfa yr
+						stumptown, before they sold out lo-fi literally art party
+						williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic
+						aesthetic kickstarter, dreamcatcher four dollar toast whatever
+						tattooed quinoa. Single-origin coffee blog lomo, freegan next level
+						ramps small batch put a bird on it listicle stumptown. Stumptown
+						mumblecore vinyl, mustache street art wayfarers lumbersexual
+						everyday carry irony pitchfork gochujang pug DIY gentrify.
+					</p>
+					<p>
+						Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth
+						migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
+						asymmetrical meggings kombucha banh mi meh skateboard artisan man
+						braid. Ugh semiotics intelligentsia sustainable, craft beer next
+						level meggings before they sold out heirloom iPhone try-hard.
+						Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS
+						thundercats man braid waistcoat ennui. Church-key knausgaard austin
+						organic farm-to-table neutra franzen bespoke, mlkshk narwhal DIY raw
+						denim retro. Mlkshk locavore try-hard roof party flexitarian.
+						Letterpress beard fixie, umami waistcoat salvia ennui four loko
+						seitan lomo franzen pickled shoreditch master cleanse.
+					</p>
+				</Expander>
+			</div>
+		);
+	},
+});


### PR DESCRIPTION
With a current implementation of **Expander**,  transition causes some flickering. 
Also in order to display any additional div or text on the same line as Expander Label, the div needs to be passed outside the **Expander** and then some absolute positioning needs to be applied to this div, as well as moving if to the right by 125px, and moving down the Expander Label to make sure, that they all are located on the same line.

Now you can pass an additional div, that you want to display on the same line with **AdditionalLabelContent** prop. Let me know pls if there is a better naming for it or some other comments regarding this PR.

<img width="729" alt="Screen Shot 2019-06-04 at 6 34 22 PM" src="https://user-images.githubusercontent.com/20198481/58924122-66b9af80-86f7-11e9-8f38-c3aff30b6013.png">
 


## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
