### PR TITLE
Fixes #990 by allowing any number to be passed as count value (even 0).

### DIFF
--- a/src/components/SlidePanel/SlidePanel.jsx
+++ b/src/components/SlidePanel/SlidePanel.jsx
@@ -202,8 +202,12 @@ const SlidePanel = createClass({
 							className={cx('&-slidestrip', className)}
 							style={{
 								transform: this.isDragging
-									? `translateX(calc(${tween.translateXPercentage}% + ${this.state.translateXPixel}px))`
-									: `translateX(calc(${tween.translateXPercentage}% + ${tween.translateXPixel}px))`,
+									? `translateX(calc(${tween.translateXPercentage}% + ${
+											this.state.translateXPixel
+									  }px))`
+									: `translateX(calc(${tween.translateXPercentage}% + ${
+											tween.translateXPixel
+									  }px))`,
 							}}
 							onTouchStart={this.handleTouchStart}
 							onTouchMove={this.handleTouchMove}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -597,7 +597,6 @@ const Table = createClass({
 		hasHover: bool`
 			Applies a row hover to rows. Defaults to true.
 		`,
-
 	},
 
 	getDefaultProps() {

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -124,7 +124,7 @@ const Tab = createClass({
 			>
 				<span className={cx('&-Tab-content')}>
 					{Title}
-					{count && (
+					{
 						<Badge
 							style={{
 								marginLeft: '12px',
@@ -136,7 +136,7 @@ const Tab = createClass({
 						>
 							{count}
 						</Badge>
-					)}
+					}
 				</span>
 				{isProgressive && !isLastTab && (
 					<span className={cx('&-Tab-arrow')}>

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -124,7 +124,7 @@ const Tab = createClass({
 			>
 				<span className={cx('&-Tab-content')}>
 					{Title}
-					{
+					{!_.isNil(count) && (
 						<Badge
 							style={{
 								marginLeft: '12px',
@@ -136,7 +136,7 @@ const Tab = createClass({
 						>
 							{count}
 						</Badge>
-					}
+					)}
 				</span>
 				{isProgressive && !isLastTab && (
 					<span className={cx('&-Tab-arrow')}>

--- a/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -776,11 +776,11 @@ exports[`Tabs [common] example testing should match snapshot(s) for 09-with-coun
       Three content
     </Tabs.Tab>
     <Tabs.Tab
-      Title="Three"
+      Title="Four"
       count={3}
       index={3}
       isDisabled={true}
-      isLastTab={true}
+      isLastTab={false}
       isOpen={true}
       isProgressive={false}
       isSelected={false}
@@ -788,9 +788,26 @@ exports[`Tabs [common] example testing should match snapshot(s) for 09-with-coun
       onSelect={[Function]}
     >
       <Tabs.Title>
-        Three
+        Four
       </Tabs.Title>
-      Three content
+      Four content
+    </Tabs.Tab>
+    <Tabs.Tab
+      Title="Five"
+      count={0}
+      index={4}
+      isDisabled={true}
+      isLastTab={true}
+      isOpen={true}
+      isProgressive={false}
+      isSelected={false}
+      key="4"
+      onSelect={[Function]}
+    >
+      <Tabs.Title>
+        Five
+      </Tabs.Title>
+      Five content
     </Tabs.Tab>
   </ul>
   <div
@@ -863,7 +880,7 @@ exports[`Tabs [common] example testing should match snapshot(s) for 09-with-coun
       Three content
     </Tabs.Tab>
     <Tabs.Tab
-      Title="Three"
+      Title="Four"
       count={123}
       index={3}
       isDisabled={true}
@@ -876,9 +893,9 @@ exports[`Tabs [common] example testing should match snapshot(s) for 09-with-coun
       onSelect={[Function]}
     >
       <Tabs.Title>
-        Three
+        Four
       </Tabs.Title>
-      Three content
+      Four content
     </Tabs.Tab>
   </ul>
   <div

--- a/src/components/Tabs/examples/09-with-count.jsx
+++ b/src/components/Tabs/examples/09-with-count.jsx
@@ -21,8 +21,12 @@ export default createClass({
 						Three content
 					</Tabs.Tab>
 					<Tabs.Tab count={3} isDisabled>
-						<Tabs.Title>Three</Tabs.Title>
-						Three content
+						<Tabs.Title>Four</Tabs.Title>
+						Four content
+					</Tabs.Tab>
+					<Tabs.Tab count={0} isDisabled>
+						<Tabs.Title>Five</Tabs.Title>
+						Five content
 					</Tabs.Tab>
 				</Tabs>
 
@@ -41,8 +45,8 @@ export default createClass({
 						Three content
 					</Tabs.Tab>
 					<Tabs.Tab count={123} isDisabled isVariableCountWidth={true}>
-						<Tabs.Title>Three</Tabs.Title>
-						Three content
+						<Tabs.Title>Four</Tabs.Title>
+						Four content
 					</Tabs.Tab>
 				</Tabs>
 			</div>


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [ ] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
