### PR TITLE
fix SidePanel's content heights 

### DIFF
--- a/src/components/SidePanel/SidePanel.less
+++ b/src/components/SidePanel/SidePanel.less
@@ -6,10 +6,11 @@
 
 	.@{prefix}-SidePanel-pane {
 		position: fixed;
+		height: auto;
 		top: 0;
+		bottom: 0;
 		display: flex;
 		flex-direction: column;
-		height: 100%;
 		width: 240px;
 		background-color: @color-neutral-2;
 		box-shadow: -1px 0px 5px 0px rgba(33, 31, 31, 0.3);
@@ -59,8 +60,9 @@
 			}
 		}
 		.@{prefix}-SidePanel-body {
-			height: 100%;
+			flex: 1;
 			display: flex;
+			overflow: hidden;
 
 			.@{prefix}-SidePanel-grabber {
 				background-color: @color-neutral-2;


### PR DESCRIPTION
This fixes SidePanel scrolling is able to show all content, even with top offset.

previously, the sidepanel would bleed below the viewport resulting in content that went offscreen.

The fix involves using `height: auto` and setting top, bottom and left/right to 0, since the panel is `display: fixed;`. This allows a margin-top to be applied without pushing it below the viewport.

working version:
![working version](https://cl.ly/e25132898a46/Screen%20Recording%202019-07-10%20at%2004.08%20PM.gif)

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval


