### PR TITLE
default textfield autocomplete to off.  Requested because with wrappe…

### DIFF
--- a/src/components/DropMenu/__snapshots__/DropMenu.spec.jsx.snap
+++ b/src/components/DropMenu/__snapshots__/DropMenu.spec.jsx.snap
@@ -474,6 +474,7 @@ exports[`DropMenu [common] example testing should match snapshot(s) for 06.text-
         tabIndex={0}
       >
         <TextField
+          autoComplete="off"
           debounceLevel={500}
           isDisabled={false}
           isMultiLine={false}

--- a/src/components/Paginator/__snapshots__/Paginator.spec.jsx.snap
+++ b/src/components/Paginator/__snapshots__/Paginator.spec.jsx.snap
@@ -18,6 +18,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 1.basic
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -101,6 +102,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 2.page-
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -147,6 +149,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 3.disab
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={true}
     isMultiLine={false}
@@ -230,6 +233,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 3.disab
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={true}
     isMultiLine={false}
@@ -320,6 +324,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 4.show-
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -403,6 +408,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 4.show-
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -517,6 +523,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 4.show-
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -631,6 +638,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 4.show-
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -745,6 +753,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 4.show-
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -859,6 +868,7 @@ exports[`Paginator [common] example testing should match snapshot(s) for 4.show-
     />
   </Button>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}

--- a/src/components/SearchField/__snapshots__/SearchField.spec.jsx.snap
+++ b/src/components/SearchField/__snapshots__/SearchField.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 1.def
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -33,6 +34,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 2.int
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -61,6 +63,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 3.pla
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -90,6 +93,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 4.dis
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={true}
     isMultiLine={false}
@@ -118,6 +122,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 5.cus
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -151,6 +156,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 6.cus
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -183,6 +189,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 7.val
   onKeyDown={[Function]}
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -212,6 +219,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -240,6 +248,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -269,6 +278,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={true}
     isMultiLine={false}
@@ -297,6 +307,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -325,6 +336,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -358,6 +370,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -391,6 +404,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 8.pro
   className="lucid-SearchField"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -425,6 +439,7 @@ exports[`SearchField [common] example testing should match snapshot(s) for 9.deb
   }
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -90,6 +90,10 @@ const TextField = createClass({
 			heavily inspired by the
 			[lazy-input](https:/docs.npmjs.com/package/lazy-input) component.
 		`,
+
+		autoComplete: string`
+			html attribute for controlling browser autocomplete functionality
+		`
 	},
 
 	getDefaultProps() {
@@ -105,6 +109,7 @@ const TextField = createClass({
 			debounceLevel: 500,
 			lazyLevel: 1000,
 			value: '',
+			autoComplete: 'off',
 		};
 	},
 
@@ -219,6 +224,7 @@ const TextField = createClass({
 			isMultiLine,
 			rows,
 			style,
+			autoComplete,
 			...passThroughs
 		} = this.props;
 
@@ -241,6 +247,7 @@ const TextField = createClass({
 			onKeyDown: this.handleKeyDown,
 			style,
 			rows,
+			autoComplete,
 			value,
 			ref: ref => (this.refs = { nativeElement: ref }),
 		};

--- a/src/components/TextField/__snapshots__/TextField.spec.jsx.snap
+++ b/src/components/TextField/__snapshots__/TextField.spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`TextField [common] example testing should match snapshot(s) for basic 1`] = `
 <input
+  autoComplete="off"
   className="lucid-TextField lucid-TextField-is-single-line"
   disabled={false}
   onBlur={[Function]}
@@ -21,6 +22,7 @@ exports[`TextField [common] example testing should match snapshot(s) for basic 1
 
 exports[`TextField [common] example testing should match snapshot(s) for basic 2`] = `
 <textarea
+  autoComplete="off"
   className="lucid-TextField lucid-TextField-is-multi-line"
   disabled={false}
   onBlur={[Function]}
@@ -39,6 +41,7 @@ exports[`TextField [common] example testing should match snapshot(s) for basic 2
 
 exports[`TextField [common] example testing should match snapshot(s) for debounced 1`] = `
 <input
+  autoComplete="off"
   className="lucid-TextField lucid-TextField-is-single-line"
   disabled={false}
   onBlur={[Function]}
@@ -57,6 +60,7 @@ exports[`TextField [common] example testing should match snapshot(s) for debounc
 
 exports[`TextField [common] example testing should match snapshot(s) for on-submit 1`] = `
 <input
+  autoComplete="off"
   className="lucid-TextField lucid-TextField-is-single-line"
   disabled={false}
   onBlur={[Function]}

--- a/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.jsx.snap
+++ b/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.jsx.snap
@@ -13,6 +13,7 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
   style={null}
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -41,6 +42,7 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
   style={null}
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}

--- a/src/components/Validation/__snapshots__/Validation.spec.jsx.snap
+++ b/src/components/Validation/__snapshots__/Validation.spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`Validation [common] example testing should match snapshot(s) for basic 
   className="lucid-Validation lucid-Validation-is-error"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -35,6 +36,7 @@ exports[`Validation [common] example testing should match snapshot(s) for basic 
     </span>
   </Validation.Error>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={false}
@@ -62,6 +64,7 @@ exports[`Validation [common] example testing should match snapshot(s) for basic 
   className="lucid-Validation lucid-Validation-is-error"
 >
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={true}
@@ -93,6 +96,7 @@ exports[`Validation [common] example testing should match snapshot(s) for basic 
     </span>
   </Validation.Error>
   <TextField
+    autoComplete="off"
     debounceLevel={500}
     isDisabled={false}
     isMultiLine={true}


### PR DESCRIPTION
…rs like SingleSelect it can be tedious to pass the autocomplete prop through

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
