### PR TITLE
default autoComplete attribute to off for searchable controls

### DIFF
--- a/src/components/SearchField/SearchField.jsx
+++ b/src/components/SearchField/SearchField.jsx
@@ -121,6 +121,7 @@ const SearchField = createClass({
 				onSubmit,
 				placeholder,
 				value,
+				autoComplete,
 				...passThroughs
 			},
 		} = this;
@@ -136,6 +137,7 @@ const SearchField = createClass({
 			placeholder,
 			isMultiLine: false,
 			value,
+			autoComplete,
 		};
 
 		const textFieldElement = getFirst(props, TextField) || (

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.jsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.jsx
@@ -574,6 +574,7 @@ const SearchableMultiSelect = createClass({
 					<DropMenu.Control>
 						<SearchField
 							{...searchFieldProps}
+							autoComplete={searchFieldProps.autoComplete || 'off'}
 							isDisabled={isDisabled}
 							className={cx(
 								'&-search',

--- a/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.jsx.snap
+++ b/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.jsx.snap
@@ -34,6 +34,7 @@ exports[`SearchableMultiSelect [common] example testing should match snapshot(s)
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableMultiSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -98,6 +99,7 @@ exports[`SearchableMultiSelect [common] example testing should match snapshot(s)
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableMultiSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -1535,6 +1537,7 @@ exports[`SearchableMultiSelect [common] example testing should match snapshot(s)
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableMultiSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -2750,6 +2753,7 @@ exports[`SearchableMultiSelect custom formatting should render Option child func
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableMultiSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -2879,6 +2883,7 @@ exports[`SearchableMultiSelect custom formatting should render Option.Selected i
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableMultiSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -3100,6 +3105,7 @@ exports[`SearchableMultiSelect custom formatting should render OptionGroup.Selec
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableMultiSelect-search"
         debounceLevel={500}
         isDisabled={false}

--- a/src/components/SearchableSelect/SearchableSelect.jsx
+++ b/src/components/SearchableSelect/SearchableSelect.jsx
@@ -466,6 +466,7 @@ const SearchableSelect = createClass({
 				<DropMenu.Header className={cx('&-Search-container')}>
 					<SearchField
 						{...searchFieldProps}
+						autoComplete={searchFieldProps.autoComplete || 'off'}
 						onChange={this.handleSearch}
 						value={searchText}
 					/>

--- a/src/components/SearchableSelect/__snapshots__/SearchableSelect.spec.jsx.snap
+++ b/src/components/SearchableSelect/__snapshots__/SearchableSelect.spec.jsx.snap
@@ -58,6 +58,7 @@ exports[`SearchableSelect [common] example testing should match snapshot(s) for 
     className="lucid-SearchableSelect-Search-container"
   >
     <SearchField
+      autoComplete="off"
       debounceLevel={500}
       isDisabled={false}
       onChange={[Function]}
@@ -862,6 +863,7 @@ exports[`SearchableSelect [common] example testing should match snapshot(s) for 
     className="lucid-SearchableSelect-Search-container"
   >
     <SearchField
+      autoComplete="off"
       debounceLevel={500}
       isDisabled={false}
       onChange={[Function]}
@@ -1407,6 +1409,7 @@ exports[`SearchableSelect [common] example testing should match snapshot(s) for 
     className="lucid-SearchableSelect-Search-container"
   >
     <SearchField
+      autoComplete="off"
       debounceLevel={500}
       isDisabled={false}
       onChange={[Function]}
@@ -1509,6 +1512,7 @@ exports[`SearchableSelect [common] example testing should match snapshot(s) for 
     className="lucid-SearchableSelect-Search-container"
   >
     <SearchField
+      autoComplete="off"
       debounceLevel={500}
       isDisabled={false}
       onChange={[Function]}
@@ -2309,6 +2313,7 @@ exports[`SearchableSelect child elements Option should render Option child funct
     className="lucid-SearchableSelect-Search-container"
   >
     <SearchField
+      autoComplete="off"
       debounceLevel={500}
       isDisabled={false}
       onChange={[Function]}
@@ -2412,6 +2417,7 @@ exports[`SearchableSelect child elements Option should render Option.Selected in
     className="lucid-SearchableSelect-Search-container"
   >
     <SearchField
+      autoComplete="off"
       debounceLevel={500}
       isDisabled={false}
       onChange={[Function]}

--- a/src/components/SearchableSingleSelect/SearchableSingleSelect.jsx
+++ b/src/components/SearchableSingleSelect/SearchableSingleSelect.jsx
@@ -440,6 +440,7 @@ const SearchableSingleSelect = createClass({
 					<DropMenu.Control>
 						<SearchField
 							{...searchFieldProps}
+							autoComplete={searchFieldProps.autoComplete || 'off'}
 							isDisabled={isDisabled}
 							className={cx('&-search', searchFieldProps.className)}
 							value={searchText}

--- a/src/components/SearchableSingleSelect/__snapshots__/SearchableSingleSelect.spec.jsx.snap
+++ b/src/components/SearchableSingleSelect/__snapshots__/SearchableSingleSelect.spec.jsx.snap
@@ -39,6 +39,7 @@ exports[`SearchableSingleSelect [common] example testing should match snapshot(s
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableSingleSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -471,6 +472,7 @@ exports[`SearchableSingleSelect [common] example testing should match snapshot(s
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableSingleSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -542,6 +544,7 @@ exports[`SearchableSingleSelect [common] example testing should match snapshot(s
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableSingleSelect-search"
         debounceLevel={500}
         isDisabled={true}
@@ -598,6 +601,7 @@ exports[`SearchableSingleSelect [common] example testing should match snapshot(s
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableSingleSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -646,6 +650,7 @@ exports[`SearchableSingleSelect [common] example testing should match snapshot(s
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableSingleSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -1268,6 +1273,7 @@ exports[`SearchableSingleSelect [common] example testing should match snapshot(s
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableSingleSelect-search"
         debounceLevel={500}
         isDisabled={false}
@@ -1340,6 +1346,7 @@ exports[`SearchableSingleSelect custom formatting should render Option child fun
   >
     <DropMenu.Control>
       <SearchField
+        autoComplete="off"
         className="lucid-SearchableSingleSelect-search"
         debounceLevel={500}
         isDisabled={false}


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
