### PR TITLE
use an indeterminate state for DataTable select all when partially selected

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -263,8 +263,9 @@ const DataTable = createClass({
 
 		const columnSlicer = _.flow(
 			_.compact,
-			columns => _.slice(columns, startColumn, endColumn)
+			(columns) => _.slice(columns, startColumn, endColumn)
 		);
+		const allSelected = _.every(data, 'isSelected');
 
 		return (
 			<Thead>
@@ -278,7 +279,10 @@ const DataTable = createClass({
 									width={SELECTOR_COLUMN_WIDTH}
 								>
 									<Checkbox
-										isSelected={_.every(data, 'isSelected')}
+										isSelected={allSelected}
+										isIndeterminate={
+											!allSelected && !!data.find(d => d.isSelected)
+										}
 										onSelect={this.handleSelectAll}
 									/>
 								</Th>

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -491,6 +491,33 @@ describe('DataTable', () => {
 					);
 				});
 			});
+
+			it('should have inDeterminate on the header checkbox when data is partially selected', () => {
+				const wrapper = shallow(
+					<DataTable isSelectable data={testData}>
+						<Column field='id' title='ID' />
+						<Column field='first_name' title='First' />
+						<Column field='last_name' title='Last' />
+						<Column field='email' title='Email' />
+						<Column field='occupation' title='Occupation' />
+					</DataTable>
+				);
+
+				// select the rows of the rendered table head
+				const headTrsWrapper = wrapper
+					.find(ScrollTable)
+					.shallow()
+					.find(ScrollTable.Thead)
+					.shallow()
+					.find(ScrollTable.Tr);
+
+				const firstHeadCellWrapper = headTrsWrapper
+					.shallow()
+					.find(ScrollTable.Th)
+					.first();
+				const selectAllCheckboxWrapper = firstHeadCellWrapper.find(Checkbox);
+				assert.equal(true, selectAllCheckboxWrapper.prop('isIndeterminate'), 'The CheckBox should be in an indeterminate state');
+			});
 		});
 
 		describe('onSelectAll', () => {

--- a/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
@@ -3585,7 +3585,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
         >
           <Checkbox
             isDisabled={false}
-            isIndeterminate={false}
+            isIndeterminate={true}
             isSelected={false}
             onSelect={[Function]}
           />
@@ -10334,7 +10334,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
               >
                 <Checkbox
                   isDisabled={false}
-                  isIndeterminate={false}
+                  isIndeterminate={true}
                   isSelected={false}
                   onSelect={[Function]}
                 />


### PR DESCRIPTION
use the header CheckBox to indicate when rows are partially selected versus all rows being selected.

![example gif](https://cl.ly/a9c891babdc2/Screen%20Recording%202019-07-15%20at%2004.35%20PM.gif)

One thing I noticed is that when checking if all rows are selected, our logic checks all row data for `isSelected` but does not esxclude `isDisabled` rows. Is that something we might want to do? (probably a separate pull-request)