### PR TITLE
Typography component

### DIFF
--- a/docs/load-components.js
+++ b/docs/load-components.js
@@ -1015,6 +1015,22 @@ module.exports = [
 		),
 	},
 	{
+		name: 'Typography',
+		component: getDefaultExport(
+			require('../src/components/Typography/Typography')
+		),
+		examplesContext: require.context(
+			'../src/components/Typography/examples',
+			true,
+			/\.jsx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../src/components/Typography/examples',
+			true,
+			/\.jsx?$/
+		),
+	},
+	{
 		name: 'TextField',
 		component: getDefaultExport(
 			require('../src/components/TextField/TextField')

--- a/src/components/Typography/Typography.jsx
+++ b/src/components/Typography/Typography.jsx
@@ -13,7 +13,7 @@ const Typography = createClass({
 	statics: {
 		peek: {
 			description: `
-				A general component for several types of semantic textual HTML elements.
+				A general component for several types of textual HTML elements.
 			`,
 			categories: ['text'],
 		},
@@ -29,7 +29,8 @@ const Typography = createClass({
 		`,
 
 		variant: oneOf(['h1', 'h2', 'h3', 'p', 'a', 'pre', 'code'])`
-			This prop defines the type of HTML element that will be displayed.
+			This prop defines the type of text that will be displayed.
+			It may be an actual HTML element or something with extra semantic meaning.
 		`,
 	},
 
@@ -39,18 +40,39 @@ const Typography = createClass({
 		};
 	},
 
+	elFinder: variant => {
+		switch (variant) {
+			case 'h1':
+				return 'h1';
+			case 'h2':
+				return 'h2';
+			case 'h3':
+				return 'h3';
+			case 'p':
+				return 'p';
+			case 'a':
+				return 'a';
+			case 'pre':
+				return 'pre';
+			case 'code':
+				return 'code';
+			case 'tabular':
+				return 'p';
+			default:
+				return 'p';
+		}
+	},
+
 	render() {
-		const {
-			children,
-			className,
-			variant: Element,
-			...passThroughs
-		} = this.props;
+		const { children, className, variant, ...passThroughs } = this.props;
+		const { elFinder } = this;
+
+		const Element = elFinder(variant);
 
 		return (
 			<Element
 				{...omitProps(passThroughs, Typography)}
-				className={cx('&', `&-${Element}`, className)}
+				className={cx('&', `&-${variant}`, className)}
 			>
 				{children}
 			</Element>

--- a/src/components/Typography/Typography.jsx
+++ b/src/components/Typography/Typography.jsx
@@ -40,10 +40,12 @@ const Typography = createClass({
 		h2: 'h2',
 		h3: 'h3',
 		p: 'p',
+		tabular: 'p',
 		a: 'a',
 		pre: 'pre',
 		code: 'code',
-		tabular: 'p',
+		kbd: 'kbd',
+		samp: 'samp',
 	},
 
 	render() {

--- a/src/components/Typography/Typography.jsx
+++ b/src/components/Typography/Typography.jsx
@@ -28,19 +28,29 @@ const Typography = createClass({
 			Appended to the component-specific class names set on the root element.
 		`,
 
-		variant: oneOf(['h1', 'h2', 'h3', 'p', 'a', 'pre', 'code', 'tabular'])
-			.isRequired`
+		variant: oneOf([
+			'p',
+			'tabular',
+			'h1',
+			'h2',
+			'h3',
+			'a',
+			'pre',
+			'code',
+			'kbd',
+			'samp',
+		]).isRequired`
 			This prop defines the type of text that will be displayed.
 			It may be an actual HTML element or something with extra semantic meaning.
 		`,
 	},
 
 	elementDict: {
+		p: 'p',
+		tabular: 'p',
 		h1: 'h1',
 		h2: 'h2',
 		h3: 'h3',
-		p: 'p',
-		tabular: 'p',
 		a: 'a',
 		pre: 'pre',
 		code: 'code',

--- a/src/components/Typography/Typography.jsx
+++ b/src/components/Typography/Typography.jsx
@@ -28,46 +28,29 @@ const Typography = createClass({
 			Appended to the component-specific class names set on the root element.
 		`,
 
-		variant: oneOf(['h1', 'h2', 'h3', 'p', 'a', 'pre', 'code'])`
+		variant: oneOf(['h1', 'h2', 'h3', 'p', 'a', 'pre', 'code', 'tabular'])
+			.isRequired`
 			This prop defines the type of text that will be displayed.
 			It may be an actual HTML element or something with extra semantic meaning.
 		`,
 	},
 
-	getDefaultProps() {
-		return {
-			variant: 'p',
-		};
-	},
-
-	elFinder: variant => {
-		switch (variant) {
-			case 'h1':
-				return 'h1';
-			case 'h2':
-				return 'h2';
-			case 'h3':
-				return 'h3';
-			case 'p':
-				return 'p';
-			case 'a':
-				return 'a';
-			case 'pre':
-				return 'pre';
-			case 'code':
-				return 'code';
-			case 'tabular':
-				return 'p';
-			default:
-				return 'p';
-		}
+	elementDict: {
+		h1: 'h1',
+		h2: 'h2',
+		h3: 'h3',
+		p: 'p',
+		a: 'a',
+		pre: 'pre',
+		code: 'code',
+		tabular: 'p',
 	},
 
 	render() {
 		const { children, className, variant, ...passThroughs } = this.props;
-		const { elFinder } = this;
+		const { elementDict } = this;
 
-		const Element = elFinder(variant);
+		const Element = elementDict[variant];
 
 		return (
 			<Element

--- a/src/components/Typography/Typography.jsx
+++ b/src/components/Typography/Typography.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'react-peek/prop-types';
+import { lucidClassNames } from '../../util/style-helpers';
+import { createClass, omitProps } from '../../util/component-types';
+
+const cx = lucidClassNames.bind('&-Typography');
+
+const { node, string, oneOf } = PropTypes;
+
+const Typography = createClass({
+	displayName: 'Typography',
+
+	statics: {
+		peek: {
+			description: `
+				A general component for several types of semantic textual HTML elements.
+			`,
+			categories: ['text'],
+		},
+	},
+
+	propTypes: {
+		children: node`
+			Can contain elements or nested \`Typography\` components.
+		`,
+
+		className: string`
+			Appended to the component-specific class names set on the root element.
+		`,
+
+		variant: oneOf(['h1', 'h2', 'h3', 'p', 'a', 'pre', 'code'])`
+			This prop defines the type of HTML element that will be displayed.
+		`,
+	},
+
+	getDefaultProps() {
+		return {
+			variant: 'p',
+		};
+	},
+
+	render() {
+		const {
+			children,
+			className,
+			variant: Element,
+			...passThroughs
+		} = this.props;
+
+		return (
+			<Element
+				{...omitProps(passThroughs, Typography)}
+				className={cx('&', `&-${Element}`, className)}
+			>
+				{children}
+			</Element>
+		);
+	},
+});
+
+export default Typography;

--- a/src/components/Typography/Typography.less
+++ b/src/components/Typography/Typography.less
@@ -3,6 +3,12 @@
 
 .@{prefix}-Typography {
 
+	// text for tables
+	&-tabular {
+		font-family: @font-family-tabular;
+	}
+
+	// headings
 	&-h1,
 	&-h2,
 	&-h3 {
@@ -10,9 +16,6 @@
 		font-weight: @font-weight-medium;
 		text-rendering: optimizelegibility;
 	}
-
-	// These values have been adjusted for the Xandr branding. Anything after h3
-	// shouldn't be used in practice.
 	&-h1 {
 		font-size: 24px;
 		line-height: 28px;
@@ -28,6 +31,7 @@
 		color: @color-neutral-6;
 	}
 
+	// links
 	&-a {
 		font-weight: @font-weight-medium;
 		color: @color-linkColor;
@@ -38,7 +42,7 @@
 		text-decoration: underline;
 	}
 
-	// NOTE: kbd and samp are currently not prop options for `variant`
+	// code and code-like
 	&-code,
 	&-pre,
 	&-kbd,
@@ -46,9 +50,5 @@
 		// TODO: replace this with the variable from lucid when this issue is closed:
 		// https://github.com/appnexus/lucid/issues/618
 		font-family: Menlo, Monaco, 'Ubuntu Mono', Courier, monospace;
-	}
-
-	&-tabular {
-		font-family: @font-family-tabular;
 	}
 }

--- a/src/components/Typography/Typography.less
+++ b/src/components/Typography/Typography.less
@@ -3,8 +3,6 @@
 
 .@{prefix}-Typography {
 
-	color: @color-neutral-9;
-
 	&-h1,
 	&-h2,
 	&-h3 {

--- a/src/components/Typography/Typography.less
+++ b/src/components/Typography/Typography.less
@@ -3,6 +3,10 @@
 
 .@{prefix}-Typography {
 
+	// general text
+	&-p {
+		font-family: @fontFamily;
+	}
 	// text for tables
 	&-tabular {
 		font-family: @font-family-tabular;

--- a/src/components/Typography/Typography.less
+++ b/src/components/Typography/Typography.less
@@ -1,0 +1,52 @@
+@import (reference) '../../styles/variables.less';
+@import (reference) '../../styles/mixins.less';
+
+.@{prefix}-Typography {
+
+	color: @color-neutral-9;
+
+	&-h1,
+	&-h2,
+	&-h3 {
+		margin: 0;
+		font-weight: @font-weight-medium;
+		text-rendering: optimizelegibility;
+	}
+
+	// These values have been adjusted for the Xandr branding. Anything after h3
+	// shouldn't be used in practice.
+	&-h1 {
+		font-size: 24px;
+		line-height: 28px;
+	}
+	&-h2 {
+		font-size: 16px;
+		line-height: 20px;
+	}
+	&-h3 {
+		font-size: 12px;
+		line-height: 16px;
+		text-transform: uppercase;
+		color: @color-neutral-6;
+	}
+
+	&-a {
+		font-weight: @font-weight-medium;
+		color: @color-linkColor;
+		text-decoration: none;
+	}
+	&-a:hover {
+		color: @color-linkColorHover;
+		text-decoration: underline;
+	}
+
+	// NOTE: kbd and samp are currently not prop options for `variant`
+	&-code,
+	&-pre,
+	&-kbd,
+	&-samp {
+		// TODO: replace this with the variable from lucid when this issue is closed:
+		// https://github.com/appnexus/lucid/issues/618
+		font-family: Menlo, Monaco, 'Ubuntu Mono', Courier, monospace;
+	}
+}

--- a/src/components/Typography/Typography.less
+++ b/src/components/Typography/Typography.less
@@ -49,4 +49,8 @@
 		// https://github.com/appnexus/lucid/issues/618
 		font-family: Menlo, Monaco, 'Ubuntu Mono', Courier, monospace;
 	}
+
+	&-tabular {
+		font-family: @font-family-tabular;
+	}
 }

--- a/src/components/Typography/Typography.spec.jsx
+++ b/src/components/Typography/Typography.spec.jsx
@@ -1,0 +1,6 @@
+import { common } from '../../util/generic-tests';
+import Typography from './Typography';
+
+describe('Typography', () => {
+	common(Typography);
+});

--- a/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
+++ b/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Typography [common] example testing should match snapshot(s) for 01.variants 1`] = `
-<p
-  className="lucid-Typography lucid-Typography-p"
->
-  Default (no variant specified)
-</p>
-`;
-
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 2`] = `
 <h1
   className="lucid-Typography lucid-Typography-h1"
 >
@@ -16,7 +8,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </h1>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 3`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 2`] = `
 <h2
   className="lucid-Typography lucid-Typography-h2"
 >
@@ -24,7 +16,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </h2>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 4`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 3`] = `
 <h3
   className="lucid-Typography lucid-Typography-h3"
 >
@@ -32,7 +24,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </h3>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 5`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 4`] = `
 <p
   className="lucid-Typography lucid-Typography-p"
 >
@@ -40,7 +32,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </p>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 6`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 5`] = `
 <a
   className="lucid-Typography lucid-Typography-a"
 >
@@ -48,7 +40,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </a>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 7`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 6`] = `
 <pre
   className="lucid-Typography lucid-Typography-pre"
 >
@@ -56,7 +48,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </pre>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 8`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 7`] = `
 <code
   className="lucid-Typography lucid-Typography-code"
 >
@@ -64,7 +56,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </code>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 9`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 8`] = `
 <p
   className="lucid-Typography lucid-Typography-tabular"
 >

--- a/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
+++ b/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
@@ -64,6 +64,14 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </code>
 `;
 
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 9`] = `
+<p
+  className="lucid-Typography lucid-Typography-tabular"
+>
+  tabular. text for tables
+</p>
+`;
+
 exports[`Typography [common] example testing should match snapshot(s) for 02.nested 1`] = `
 <h1
   className="lucid-Typography lucid-Typography-h1"

--- a/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
+++ b/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
@@ -1,0 +1,184 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 1`] = `
+<p
+  className="lucid-Typography lucid-Typography-p"
+>
+  Default (no variant specified)
+</p>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 2`] = `
+<h1
+  className="lucid-Typography lucid-Typography-h1"
+>
+  h1. Heading
+</h1>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 3`] = `
+<h2
+  className="lucid-Typography lucid-Typography-h2"
+>
+  h2. Heading
+</h2>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 4`] = `
+<h3
+  className="lucid-Typography lucid-Typography-h3"
+>
+  h3. Heading
+</h3>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 5`] = `
+<p
+  className="lucid-Typography lucid-Typography-p"
+>
+  p. paragraph text
+</p>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 6`] = `
+<a
+  className="lucid-Typography lucid-Typography-a"
+>
+  a. link text
+</a>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 7`] = `
+<pre
+  className="lucid-Typography lucid-Typography-pre"
+>
+  pre. preformatted text
+</pre>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 8`] = `
+<code
+  className="lucid-Typography lucid-Typography-code"
+>
+  code. snazzy code
+</code>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 02.nested 1`] = `
+<h1
+  className="lucid-Typography lucid-Typography-h1"
+>
+  Title
+</h1>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 02.nested 2`] = `
+<h2
+  className="lucid-Typography lucid-Typography-h2"
+>
+  subtitle
+</h2>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 02.nested 3`] = `
+<p
+  className="lucid-Typography lucid-Typography-p"
+>
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pencil mustachioed graeme souness, mustachioed waxy gurn rugged el snort graeme souness burt reynolds educated village people boogie nights pencil man of the year 1986, pencil village people graeme souness rugged boogie nights mouthbrow educated burt reynolds waxy gurn man of the year 1986 des lynam charming villain mustachioed cardinal richelieu el snort. Borat d’artagnan hungarian testosterone trophy frontiersman hairy kiss. beefeater chevron, hairy kiss. cardinal richelieu groucho-a-like testosterone trophy d’artagnan dick van dyke rugged chevron Droopy frontiersman borat beefeater hungarian chevron, cardinal richelieu d’artagnan beefeater el snort Droopy dodgy uncle clive groucho-a-like hairy kiss. chevron frontiersman chevron dick van dyke walrus leader of men rugged borat bad guy testosterone trophy groucho-a-like alpha trion hungarian.
+  <br />
+  <br />
+  <Typography
+    style={
+      Object {
+        "display": "block",
+      }
+    }
+    variant="a"
+  >
+    Like!
+  </Typography>
+  <Typography
+    style={
+      Object {
+        "display": "block",
+      }
+    }
+    variant="a"
+  >
+    Subscribe!
+  </Typography>
+  <br />
+  <Typography
+    variant="h3"
+  >
+    Code Example
+  </Typography>
+  <Typography
+    variant="code"
+  >
+    <ul>
+      <li>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+      </li>
+      <li>
+        Aliquam tincidunt mauris eu risus.
+      </li>
+      <li>
+        Vestibulum auctor dapibus neque.
+      </li>
+    </ul>
+  </Typography>
+</p>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 02.nested 4`] = `
+<a
+  className="lucid-Typography lucid-Typography-a"
+  style={
+    Object {
+      "display": "block",
+    }
+  }
+>
+  Like!
+</a>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 02.nested 5`] = `
+<a
+  className="lucid-Typography lucid-Typography-a"
+  style={
+    Object {
+      "display": "block",
+    }
+  }
+>
+  Subscribe!
+</a>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 02.nested 6`] = `
+<h3
+  className="lucid-Typography lucid-Typography-h3"
+>
+  Code Example
+</h3>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 02.nested 7`] = `
+<code
+  className="lucid-Typography lucid-Typography-code"
+>
+  <ul>
+    <li>
+      Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    </li>
+    <li>
+      Aliquam tincidunt mauris eu risus.
+    </li>
+    <li>
+      Vestibulum auctor dapibus neque.
+    </li>
+  </ul>
+</code>
+`;

--- a/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
+++ b/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
@@ -33,6 +33,14 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 `;
 
 exports[`Typography [common] example testing should match snapshot(s) for 01.variants 5`] = `
+<p
+  className="lucid-Typography lucid-Typography-tabular"
+>
+  tabular. text for tables
+</p>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 6`] = `
 <a
   className="lucid-Typography lucid-Typography-a"
 >
@@ -40,7 +48,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </a>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 6`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 7`] = `
 <pre
   className="lucid-Typography lucid-Typography-pre"
 >
@@ -48,7 +56,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </pre>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 7`] = `
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 8`] = `
 <code
   className="lucid-Typography lucid-Typography-code"
 >
@@ -56,12 +64,20 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </code>
 `;
 
-exports[`Typography [common] example testing should match snapshot(s) for 01.variants 8`] = `
-<p
-  className="lucid-Typography lucid-Typography-tabular"
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 9`] = `
+<kbd
+  className="lucid-Typography lucid-Typography-kbd"
 >
-  tabular. text for tables
-</p>
+  kbd. keyboard inputs
+</kbd>
+`;
+
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 10`] = `
+<samp
+  className="lucid-Typography lucid-Typography-samp"
+>
+  samp. sample code outputs
+</samp>
 `;
 
 exports[`Typography [common] example testing should match snapshot(s) for 02.nested 1`] = `
@@ -116,17 +132,7 @@ exports[`Typography [common] example testing should match snapshot(s) for 02.nes
   <Typography
     variant="code"
   >
-    <ul>
-      <li>
-        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-      </li>
-      <li>
-        Aliquam tincidunt mauris eu risus.
-      </li>
-      <li>
-        Vestibulum auctor dapibus neque.
-      </li>
-    </ul>
+    npm install all-the-things
   </Typography>
 </p>
 `;
@@ -169,16 +175,6 @@ exports[`Typography [common] example testing should match snapshot(s) for 02.nes
 <code
   className="lucid-Typography lucid-Typography-code"
 >
-  <ul>
-    <li>
-      Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-    </li>
-    <li>
-      Aliquam tincidunt mauris eu risus.
-    </li>
-    <li>
-      Vestibulum auctor dapibus neque.
-    </li>
-  </ul>
+  npm install all-the-things
 </code>
 `;

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -14,6 +14,7 @@ export default createClass({
 				<Typography variant='a'>a. link text</Typography>
 				<Typography variant='pre'>pre. preformatted text</Typography>
 				<Typography variant='code'>code. snazzy code</Typography>
+				<Typography variant='tabular'>tabular. text for tables</Typography>
 			</div>
 		);
 	},

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -6,7 +6,6 @@ export default createClass({
 	render() {
 		return (
 			<div>
-				<Typography>Default (no variant specified)</Typography>
 				<Typography variant='h1'>h1. Heading</Typography>
 				<Typography variant='h2'>h2. Heading</Typography>
 				<Typography variant='h3'>h3. Heading</Typography>

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -10,10 +10,12 @@ export default createClass({
 				<Typography variant='h2'>h2. Heading</Typography>
 				<Typography variant='h3'>h3. Heading</Typography>
 				<Typography variant='p'>p. paragraph text</Typography>
+				<Typography variant='tabular'>tabular. text for tables</Typography>
 				<Typography variant='a'>a. link text</Typography>
 				<Typography variant='pre'>pre. preformatted text</Typography>
-				<Typography variant='code'>code. snazzy code</Typography>
-				<Typography variant='tabular'>tabular. text for tables</Typography>
+				<Typography variant='code'>code. snazzy code</Typography> <br/>
+				<Typography variant='kbd'>kbd. keyboard inputs</Typography> <br/>
+				<Typography variant='samp'>samp. sample code outputs</Typography> <br/>
 			</div>
 		);
 	},

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Typography } from '../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<Typography>Default (no variant specified)</Typography>
+				<Typography variant='h1'>h1. Heading</Typography>
+				<Typography variant='h2'>h2. Heading</Typography>
+				<Typography variant='h3'>h3. Heading</Typography>
+				<Typography variant='p'>p. paragraph text</Typography>
+				<Typography variant='a'>a. link text</Typography>
+				<Typography variant='pre'>pre. preformatted text</Typography>
+				<Typography variant='code'>code. snazzy code</Typography>
+			</div>
+		);
+	},
+});

--- a/src/components/Typography/examples/02.nested.jsx
+++ b/src/components/Typography/examples/02.nested.jsx
@@ -35,11 +35,7 @@ export default createClass({
 					<br />
 					<Typography variant='h3'>Code Example</Typography>
 					<Typography variant='code'>
-						<ul>
-							<li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
-							<li>Aliquam tincidunt mauris eu risus.</li>
-							<li>Vestibulum auctor dapibus neque.</li>
-						</ul>
+						npm install all-the-things
 					</Typography>
 				</Typography>
 			</section>

--- a/src/components/Typography/examples/02.nested.jsx
+++ b/src/components/Typography/examples/02.nested.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { Typography } from '../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<section>
+				<Typography variant='h1'>Title</Typography>
+				<Typography variant='h2'>subtitle</Typography>
+				<Typography variant='p'>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+					eiusmod tempor incididunt ut labore et dolore magna aliqua. Pencil
+					mustachioed graeme souness, mustachioed waxy gurn rugged el snort
+					graeme souness burt reynolds educated village people boogie nights
+					pencil man of the year 1986, pencil village people graeme souness
+					rugged boogie nights mouthbrow educated burt reynolds waxy gurn man of
+					the year 1986 des lynam charming villain mustachioed cardinal
+					richelieu el snort. Borat d’artagnan hungarian testosterone trophy
+					frontiersman hairy kiss. beefeater chevron, hairy kiss. cardinal
+					richelieu groucho-a-like testosterone trophy d’artagnan dick van dyke
+					rugged chevron Droopy frontiersman borat beefeater hungarian chevron,
+					cardinal richelieu d’artagnan beefeater el snort Droopy dodgy uncle
+					clive groucho-a-like hairy kiss. chevron frontiersman chevron dick van
+					dyke walrus leader of men rugged borat bad guy testosterone trophy
+					groucho-a-like alpha trion hungarian.
+					<br />
+					<br />
+					<Typography variant='a' style={{ display: 'block' }}>
+						Like!
+					</Typography>
+					<Typography variant='a' style={{ display: 'block' }}>
+						Subscribe!
+					</Typography>
+					<br />
+					<Typography variant='h3'>Code Example</Typography>
+					<Typography variant='code'>
+						<ul>
+							<li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+							<li>Aliquam tincidunt mauris eu risus.</li>
+							<li>Vestibulum auctor dapibus neque.</li>
+						</ul>
+					</Typography>
+				</Typography>
+			</section>
+		);
+	},
+});

--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,7 @@ import Tag from './components/Tag/Tag';
 import TextField from './components/TextField/TextField';
 import TextFieldValidated from './components/TextFieldValidated/TextFieldValidated';
 import TextIcon from './components/Icon/TextIcon/TextIcon';
+import Typography from './components/Typography/Typography';
 import Underline from './components/Underline/Underline';
 import UnlinkedIcon from './components/Icon/UnlinkedIcon/UnlinkedIcon';
 import UnlockedIcon from './components/Icon/UnlockedIcon/UnlockedIcon';
@@ -341,6 +342,7 @@ export {
 	TextFieldValidated,
 	ToolTip,
 	ToolTipDumb,
+	Typography,
 	Underline,
 	UnlinkedIcon,
 	UnlockedIcon,

--- a/src/styles/components.less
+++ b/src/styles/components.less
@@ -77,6 +77,7 @@
 @import '../components/Validation/Validation';
 @import '../components/Tabs/Tabs';
 @import '../components/Tag/Tag';
+@import '../components/Typography/Typography';
 @import '../components/Overlay/Overlay';
 @import '../components/Dialog/Dialog';
 @import '../components/Autocomplete/Autocomplete'; // Should import after DropMenu


### PR DESCRIPTION
First pass is done. I can think of a ton of features we could add, but it could expand the API needlessly. I would say we should poll the library consumers to see the most common styles that are added to generic text components, so maybe we could generate those via props instead (allowing for DRYer code).

Docspot: https://docspot.adnxs.net/projects/lucid/typography-component/?selectedKind=Typography&selectedStory=variants&full=0&addons=1&stories=1&panelRight=1&addonPanel=lucid-docs-panel-props

## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
