### PR TITLE
fix greedy SidePanel css selector.  

### DIFF
--- a/src/components/SidePanel/SidePanel.less
+++ b/src/components/SidePanel/SidePanel.less
@@ -58,7 +58,7 @@
 					font-weight: 500;
 				}
 
-				.@{prefix}-Icon {
+				.@{prefix}-SidePanel-header-closer-button .@{prefix}-Icon {
 					stroke: @color-neutral-6;
 				}
 			}


### PR DESCRIPTION
Only the close icon should be gray in the header

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
