### PR TITLE
show an unchecked checkbox when DataTable is empty

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -279,6 +279,7 @@ const DataTable = createClass({
 									width={SELECTOR_COLUMN_WIDTH}
 								>
 									<Checkbox
+										isDisabled={!data || !data.length}
 										isSelected={data && data.length && allSelected}
 										isIndeterminate={
 											!allSelected && !!data.find(d => d.isSelected)

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -263,7 +263,7 @@ const DataTable = createClass({
 
 		const columnSlicer = _.flow(
 			_.compact,
-			(columns) => _.slice(columns, startColumn, endColumn)
+			columns => _.slice(columns, startColumn, endColumn)
 		);
 		const allSelected = _.every(data, 'isSelected');
 
@@ -279,7 +279,7 @@ const DataTable = createClass({
 									width={SELECTOR_COLUMN_WIDTH}
 								>
 									<Checkbox
-										isSelected={allSelected}
+										isSelected={data && data.length && allSelected}
 										isIndeterminate={
 											!allSelected && !!data.find(d => d.isSelected)
 										}


### PR DESCRIPTION
show an unchecked checkbox when the `DataTable` is selectable, but data is empty.

<img width="539" alt="Screen Shot 2019-07-29 at 7 58 03 AM" src="https://user-images.githubusercontent.com/648/62058630-9efcdc00-b1d6-11e9-8ebc-1003038330ad.png">


## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

/cc @rsadres 
