### PR TITLE
remove hidden overflow from body when SidePanel unmounts

### DIFF
--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -60,8 +60,12 @@ class SidePanel extends React.Component {
 	}
 
 	componentWillUnmount() {
+		const { preventBodyScroll } = this.props;
 		if (this.timerId) {
 			clearTimeout(this.timerId);
+		}
+		if (preventBodyScroll) {
+			window.document.body.style.overflow = '';
 		}
 	}
 

--- a/src/components/SidePanel/SidePanel.spec.jsx
+++ b/src/components/SidePanel/SidePanel.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import { common } from '../../util/generic-tests';
 import SidePanel from './SidePanel';
@@ -68,6 +68,19 @@ describe('SidePanel', () => {
 				);
 				expect(onResize).toHaveBeenCalled();
 			});
+		});
+	});
+
+	describe('preventBodyScroll', () => {
+		it('should hide the body overflow to prevent scrolling', () => {
+			mount(<SidePanel isExpanded preventBodyScroll />);
+			expect(document.body.style.overflow).toEqual('hidden');
+		});
+
+		it('should hide the body overflow to prevent scrolling', () => {
+			const wrapper = mount(<SidePanel isExpanded preventBodyScroll />);
+			wrapper.unmount();
+			expect(document.body.style.overflow).toEqual('');
 		});
 	});
 


### PR DESCRIPTION
When using the `preventBodyScroll` prop on `SidePanel` and the `SidePanel` unmounts, it leaves behind `overflow: hidden` on the body.

This can happen when you navigate to a different page.