### PR TITLE
Add component to render a drag and drop list

### DIFF
--- a/docs/load-components.js
+++ b/docs/load-components.js
@@ -701,6 +701,20 @@ module.exports = [
 		),
 	},
 	{
+		name: 'DraggableList',
+		component: getDefaultExport(require('../src/components/DraggableList/DraggableList')),
+		examplesContext: require.context(
+			'../src/components/DraggableList/examples',
+			true,
+			/\.jsx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../src/components/DraggableList/examples',
+			true,
+			/\.jsx?$/
+		),
+	},
+	{
 		name: 'Resizer',
 		component: getDefaultExport(require('../src/components/Resizer/Resizer')),
 		examplesContext: require.context(

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -516,7 +516,11 @@ describe('DataTable', () => {
 					.find(ScrollTable.Th)
 					.first();
 				const selectAllCheckboxWrapper = firstHeadCellWrapper.find(Checkbox);
-				assert.equal(true, selectAllCheckboxWrapper.prop('isIndeterminate'), 'The CheckBox should be in an indeterminate state');
+				assert.equal(
+					true,
+					selectAllCheckboxWrapper.prop('isIndeterminate'),
+					'The CheckBox should be in an indeterminate state'
+				);
 			});
 		});
 

--- a/src/components/DraggableList/DraggableList.jsx
+++ b/src/components/DraggableList/DraggableList.jsx
@@ -131,7 +131,7 @@ const DraggableList = createClass({
 
 		if (this.lastItemEl) {
 			const { bottom } = this.lastItemEl.getBoundingClientRect();
-			if (_.isNumber(dragIndex) && event.clientY > bottom) {
+			if (_.isFinite(dragIndex) && event.clientY > bottom) {
 				onDragOver(childCount, { event, props: this.props });
 			}
 		}

--- a/src/components/DraggableList/DraggableList.jsx
+++ b/src/components/DraggableList/DraggableList.jsx
@@ -1,0 +1,226 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'react-peek/prop-types';
+import { lucidClassNames } from '../../util/style-helpers';
+import { createClass, findTypes, omitProps } from '../../util/component-types';
+import { buildHybridComponent } from '../../util/state-management';
+import DotsIcon from '../Icon/DotsIcon/DotsIcon';
+
+import * as reducers from '../DraggableList/DraggableList.reducers';
+
+const cx = lucidClassNames.bind('&-DraggableList');
+
+const { bool, func, object, number, string } = PropTypes;
+
+const DraggableList = createClass({
+	statics: {
+		peek: {
+			description: `
+				This is a container that renders divs in a list that
+				can be drag and drop reordered.
+			`,
+			categories: ['controls'],
+		},
+	},
+
+	displayName: 'DraggableList',
+
+	components: {
+		Item: createClass({
+			displayName: 'DraggableList.Item',
+			statics: {
+				peek: {
+					description: `
+						Renders a \`<div>\` that acts as an item in the list
+					`,
+				},
+			},
+			propName: 'Item',
+		}),
+	},
+
+	reducers,
+
+	propTypes: {
+		className: string`
+			Appended to the component-specific class names set on the root element.
+		`,
+		style: object`
+			Passed through to the root element.
+		`,
+		hasDragHandle: bool`
+			Render a drag handle on list items
+		`,
+		dragIndex: number`
+			Index of the item the drag was started on
+		`,
+		dragOverIndex: number`
+			Index of the item the dragged item is hovered over
+		`,
+		onDragStart: func`
+			Called when the user starts to drag an item.
+			Signature: \`(dragIndex, { event, props }) => {}\`
+		`,
+		onDragEnd: func`
+			Called when the user stops to dragging an item.
+			Signature: \`({ event, props }) => {}\`
+		`,
+		onDragOver: func`
+			Called when the user drags an item over another item.
+			Signature: \`(dragOverIndex, { event, props }) => {}\`
+		`,
+		onDrop: func`
+			Called when the user drops an item in the list
+			Signature: \`({oldIndex, newIndex}, { event, props }) => {}\`
+		`,
+	},
+
+	getDefaultProps() {
+		return {
+			hasDragHandle: true,
+			onDragStart: _.noop,
+			onDragEnd: _.noop,
+			onDragOver: _.noop,
+			onDrop: _.noop,
+		};
+	},
+
+	isValidDropIndex(index) {
+		const { dragIndex } = this.props;
+		return index < dragIndex || index > dragIndex + 1;
+	},
+
+	handleDragStart(index) {
+		return event => {
+			const { dataTransfer } = event;
+			dataTransfer.effectAllowed = 'move';
+			dataTransfer.dropEffect = 'move';
+			dataTransfer.setData('drag', 'drag');
+			this.props.onDragStart(index, { event, props: this.props });
+		};
+	},
+
+	handleDragEnd(event) {
+		const { dragIndex, dragOverIndex, onDragEnd, onDrop } = this.props;
+		onDragEnd({ event, props: this.props });
+		if (this.isValidDropIndex(dragOverIndex)) {
+			onDrop(
+				{
+					oldIndex: dragIndex,
+					newIndex:
+						dragOverIndex > dragIndex ? dragOverIndex - 1 : dragOverIndex,
+				},
+				{ event, props: this.props }
+			);
+		}
+	},
+
+	handleDragOver(index) {
+		return event => {
+			event.preventDefault();
+			const { dragOverIndex, onDragOver } = this.props;
+			if (dragOverIndex !== index) {
+				onDragOver(index, { event, props: this.props });
+			}
+		};
+	},
+
+	handleDragLeave(event) {
+		const { dragIndex, onDragOver } = this.props;
+		const childCount = findTypes(this.props, DraggableList.Item).length;
+
+		if (this.lastItemEl) {
+			const { bottom } = this.lastItemEl.getBoundingClientRect();
+			if (_.isNumber(dragIndex) && event.clientY > bottom) {
+				onDragOver(childCount, { event, props: this.props });
+			}
+		}
+	},
+
+	render() {
+		const {
+			style,
+			className,
+			hasDragHandle,
+			dragIndex,
+			dragOverIndex,
+			...passThroughs
+		} = this.props;
+
+		const itemChildProps = _.map(
+			findTypes(this.props, DraggableList.Item),
+			'props'
+		);
+
+		const dividerIndex =
+			_.isNumber(dragIndex) && this.isValidDropIndex(dragOverIndex)
+				? dragOverIndex
+				: -1;
+
+		return (
+			<div
+				{...omitProps(passThroughs, DraggableList)}
+				className={cx(
+					'&',
+					{
+						'&-is-dragging': _.isNumber(dragIndex),
+					},
+					className
+				)}
+				style={style}
+				onDragLeave={this.handleDragLeave}
+			>
+				{_.map(itemChildProps, (itemChildProp, index) => {
+					return (
+						<div key={index}>
+							<hr
+								className={cx('&-Divider', {
+									'&-Divider-is-visible': dividerIndex === index,
+								})}
+							/>
+							<div
+								className={cx(
+									'&-Item',
+									{
+										'&-Item-is-dragging': dragIndex === index,
+										'&-Item-is-drag-over': dragOverIndex === index,
+									},
+									itemChildProp.className
+								)}
+								draggable
+								onDragStart={this.handleDragStart(index)}
+								onDragEnd={this.handleDragEnd}
+								onDragOver={this.handleDragOver(index)}
+							>
+								<div
+									{...itemChildProp}
+									className={cx('&-Item-content')}
+									ref={ref => {
+										if (index === itemChildProps.length - 1) {
+											this.lastItemEl = ref;
+										}
+									}}
+								/>
+								{hasDragHandle && (
+									<span className={cx('&-Item-handle')}>
+										<DotsIcon size={8} />
+										<DotsIcon size={8} />
+									</span>
+								)}
+							</div>
+						</div>
+					);
+				})}
+				<hr
+					key='divider'
+					className={cx('&-Divider', {
+						'&-Divider-is-visible': dividerIndex >= itemChildProps.length,
+					})}
+				/>
+			</div>
+		);
+	},
+});
+
+export default buildHybridComponent(DraggableList);
+export { DraggableList as DraggableListDumb };

--- a/src/components/DraggableList/DraggableList.less
+++ b/src/components/DraggableList/DraggableList.less
@@ -8,11 +8,18 @@
 
 	.@{prefix}-DraggableList-Item {
 		background: @color-white;
-		border: @border-standardBorder;
-		padding: 5px;
+		border: @size-borderWidth solid @color-gray;
+		padding: 5px 5px 5px 9px;
 		cursor: grab;
 		display: flex;
 		align-items: center;
+
+		&:hover {
+			border: @size-borderWidth solid @color-mediumGray;
+			.@{prefix}-DotsIcon {
+				stroke: @color-primary;
+			}
+		}
 
 		&-content {
 			flex: 1;
@@ -20,8 +27,8 @@
 
 		&-handle {
 			transform: rotate(90deg);
-			.lucid-DotsIcon {
-				stroke: @color-primaryLight;
+			.@{prefix}-DotsIcon {
+				stroke: @color-primary-50;
 
 				&:first-child {
 					margin-right: 2px;
@@ -35,7 +42,7 @@
 	}
 
 	.@{prefix}-DraggableList-Divider {
-		height: 2px;
+		height: 1px;
 		background: @color-primary;
 		visibility: hidden;
 		margin: 1px 0;

--- a/src/components/DraggableList/DraggableList.less
+++ b/src/components/DraggableList/DraggableList.less
@@ -1,0 +1,49 @@
+@import (reference) '../../styles/variables.less';
+
+.@{prefix}-DraggableList {
+
+	font-size: @fontSize;
+	font-weight: @font-weight-medium;
+	color: @color-textColor;
+
+	.@{prefix}-DraggableList-Item {
+		background: @color-white;
+		border: @border-standardBorder;
+		padding: 5px;
+		cursor: grab;
+		display: flex;
+		align-items: center;
+
+		&-content {
+			flex: 1;
+		}
+
+		&-handle {
+			transform: rotate(90deg);
+			.lucid-DotsIcon {
+				stroke: @color-primaryLight;
+
+				&:first-child {
+					margin-right: 2px;
+				}
+			}
+		}
+
+		&-is-dragging {
+			cursor: grabbing;
+		}
+	}
+
+	.@{prefix}-DraggableList-Divider {
+		height: 2px;
+		background: @color-primary;
+		visibility: hidden;
+		margin: 1px 0;
+		padding: 0;
+		border: 0;
+
+		&-is-visible {
+			visibility: visible;
+		}
+	}
+}

--- a/src/components/DraggableList/DraggableList.reducers.js
+++ b/src/components/DraggableList/DraggableList.reducers.js
@@ -1,0 +1,19 @@
+export function onDragStart(state = {}, dragIndex) {
+	return {
+		...state,
+		dragIndex,
+	};
+}
+export function onDragEnd(state = {}) {
+	return {
+		...state,
+		dragIndex: undefined,
+		dragOverIndex: undefined,
+	};
+}
+export function onDragOver(state = {}, dragOverIndex) {
+	return {
+		...state,
+		dragOverIndex,
+	};
+}

--- a/src/components/DraggableList/DraggableList.reducers.spec.js
+++ b/src/components/DraggableList/DraggableList.reducers.spec.js
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import { onDragStart, onDragEnd, onDragOver } from './DraggableList.reducers';
+
+describe('DraggableList reducers', () => {
+	describe('onDragStart', () => {
+		it('should set the dragIndex`', () => {
+			const nextState = onDragStart({}, 2);
+
+			assert.equal(nextState.dragIndex, 2, 'must update the dragIndex');
+		});
+	});
+
+	describe('onDragOver', () => {
+		it('should set the dragOverIndex`', () => {
+			const nextState = onDragOver({ dragIndex: 0 }, 3);
+
+			assert.equal(nextState.dragIndex, 0, 'must update the dragIndex');
+			assert.equal(nextState.dragOverIndex, 3, 'must update the dragOverIndex');
+		});
+	});
+
+	describe('onDragEnd', () => {
+		it('should set the dragOverIndex`', () => {
+			const nextState = onDragEnd({ dragIndex: 0, dragOverIndex: 2 });
+
+			assert.equal(nextState.dragIndex, undefined, 'must clear the dragIndex');
+			assert.equal(
+				nextState.dragOverIndex,
+				undefined,
+				'must clear the dragOverIndex'
+			);
+		});
+	});
+});

--- a/src/components/DraggableList/DraggableList.spec.jsx
+++ b/src/components/DraggableList/DraggableList.spec.jsx
@@ -1,0 +1,187 @@
+import _ from 'lodash';
+import assert from 'assert';
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import { common } from '../../util/generic-tests';
+
+import { DraggableListDumb as DraggableList } from './DraggableList';
+
+describe('DraggableList', () => {
+	common(DraggableList);
+
+	describe('props', () => {
+		describe('Item', () => {
+			it('Item as children', () => {
+				const wrapper = shallow(
+					<DraggableList>
+						<DraggableList.Item>Item One</DraggableList.Item>
+						<DraggableList.Item>Item Two</DraggableList.Item>
+					</DraggableList>
+				);
+
+				assert.equal(wrapper.find('.lucid-DraggableList-Item').length, 2);
+			});
+		});
+
+		describe('hasDragHandle', () => {
+			it('should have a drag handle on items', () => {
+				const wrapper = mount(
+					<DraggableList hasDragHandle>
+						<DraggableList.Item>Item One</DraggableList.Item>
+						<DraggableList.Item>Item Two</DraggableList.Item>
+						<DraggableList.Item>Item Three</DraggableList.Item>
+						<DraggableList.Item>Item Four</DraggableList.Item>
+					</DraggableList>
+				);
+
+				assert(wrapper.find('.lucid-DraggableList-Item-handle'), 4);
+			});
+
+			it('should not have a drag handle on items', () => {
+				const wrapper = mount(
+					<DraggableList hasDragHandle={false}>
+						<DraggableList.Item>Item One</DraggableList.Item>
+						<DraggableList.Item>Item Two</DraggableList.Item>
+						<DraggableList.Item>Item Three</DraggableList.Item>
+						<DraggableList.Item>Item Four</DraggableList.Item>
+					</DraggableList>
+				);
+
+				assert(wrapper.find('.lucid-DraggableList-Item-handle'), 0);
+			});
+		});
+
+		describe('dragOverIndex', () => {
+			it('should have a highlighted divider', () => {
+				const wrapper = mount(
+					<DraggableList dragIndex={0} dragOverIndex={2}>
+						<DraggableList.Item>Item One</DraggableList.Item>
+						<DraggableList.Item>Item Two</DraggableList.Item>
+						<DraggableList.Item>Item Three</DraggableList.Item>
+						<DraggableList.Item>Item Four</DraggableList.Item>
+					</DraggableList>
+				);
+
+				assert(wrapper.find('.lucid-DraggableList-Divider-is-visible'), 1);
+			});
+
+			it('should not have a highlighted divider when dragOverIndex is invalid', () => {
+				const wrapper = mount(
+					<DraggableList dragIndex={0} dragOverIndex={0}>
+						<DraggableList.Item>Item One</DraggableList.Item>
+						<DraggableList.Item>Item Two</DraggableList.Item>
+						<DraggableList.Item>Item Three</DraggableList.Item>
+						<DraggableList.Item>Item Four</DraggableList.Item>
+					</DraggableList>
+				);
+
+				assert(wrapper.find('.lucid-DraggableList-Divider-is-visible'), 0);
+			});
+		});
+
+		describe('onDrop', () => {
+			it('should be called when onDragEnd event handler is called on a DraggableList.Item', () => {
+				const onDrop = sinon.spy();
+				const wrapper = shallow(
+					<DraggableList dragIndex={0} dragOverIndex={3} onDrop={onDrop}>
+						<DraggableList.Item>Item One</DraggableList.Item>
+						<DraggableList.Item>Item Two</DraggableList.Item>
+						<DraggableList.Item>Item Three</DraggableList.Item>
+						<DraggableList.Item>Item Four</DraggableList.Item>
+					</DraggableList>
+				);
+
+				wrapper
+					.find('.lucid-DraggableList-Item')
+					.at(3)
+					.simulate('dragend');
+
+				assert(onDrop.called, 'must be called');
+				assert.deepEqual(
+					{ oldIndex: 0, newIndex: 2 },
+					onDrop.lastCall.args[0],
+					'must pass the old and new item indexes'
+				);
+			});
+		});
+	});
+
+	describe('onDragOver', () => {
+		it('should be called when over an item', () => {
+			const onDragOver = sinon.spy();
+			const wrapper = mount(
+				<DraggableList dragIndex={0} dragOverIndex={0} onDragOver={onDragOver}>
+					<DraggableList.Item>Item One</DraggableList.Item>
+					<DraggableList.Item>Item Two</DraggableList.Item>
+					<DraggableList.Item>Item Three</DraggableList.Item>
+					<DraggableList.Item>Item Four</DraggableList.Item>
+				</DraggableList>
+			);
+
+			wrapper
+				.find('.lucid-DraggableList-Item')
+				.at(3)
+				.simulate('dragover', { preventDefault: _.noop });
+
+			assert(onDragOver.called, 'must be called');
+			assert.equal(3, onDragOver.lastCall.args[0], 'must pass drag over index');
+		});
+
+		it('should be called when onDragLeave is called moving past the last item', () => {
+			const onDragOver = sinon.spy();
+			const wrapper = mount(
+				<DraggableList dragIndex={0} dragOverIndex={3} onDragOver={onDragOver}>
+					<DraggableList.Item>Item One</DraggableList.Item>
+					<DraggableList.Item>Item Two</DraggableList.Item>
+					<DraggableList.Item>Item Three</DraggableList.Item>
+					<DraggableList.Item>Item Four</DraggableList.Item>
+				</DraggableList>
+			);
+
+			wrapper.simulate('dragleave', { clientY: 100 });
+
+			assert(onDragOver.called, 'must be called');
+			assert.deepEqual(4, onDragOver.lastCall.args[0], 'must pass last index');
+		});
+	});
+
+	describe('pass throughs', () => {
+		it('passes through all props not defined in `propTypes` to the root element', () => {
+			const wrapper = shallow(
+				<DraggableList
+					className='wut'
+					style={{ marginRight: 10 }}
+					foo={1}
+					bar={2}
+				/>
+			);
+			const rootProps = wrapper.find('.lucid-DraggableList').props();
+
+			assert(_.has(rootProps, 'foo'), 'props missing "foo" prop');
+			assert(_.has(rootProps, 'bar'), 'props missing "bar" prop');
+		});
+
+		it('passes through Item className to the rendered item element', () => {
+			const wrapper = shallow(
+				<DraggableList>
+					<DraggableList.Item className='TestOne'>One</DraggableList.Item>
+					<DraggableList.Item className='TestTwo'>Two</DraggableList.Item>
+				</DraggableList>
+			);
+			const itemsWrapper = wrapper.find('.lucid-DraggableList-Item');
+
+			assert.equal(
+				itemsWrapper.find('.TestOne').length,
+				1,
+				'must find one item with className `TestOne`'
+			);
+			assert.equal(
+				itemsWrapper.find('.TestTwo').length,
+				1,
+				'must find one item with className `TestTwo`'
+			);
+		});
+	});
+});

--- a/src/components/DraggableList/__snapshots__/DraggableList.spec.jsx.snap
+++ b/src/components/DraggableList/__snapshots__/DraggableList.spec.jsx.snap
@@ -1,0 +1,542 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DraggableList [common] example testing should match snapshot(s) for 1.basic 1`] = `
+<div
+  className="lucid-DraggableList"
+  onDragLeave={[Function]}
+>
+  <div
+    key="0"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item One
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="1"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Two
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="2"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Three
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="3"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Four
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="4"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Five
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <hr
+    className="lucid-DraggableList-Divider"
+    key="divider"
+  />
+</div>
+`;
+
+exports[`DraggableList [common] example testing should match snapshot(s) for 2.no-drag-handle 1`] = `
+<div
+  className="lucid-DraggableList"
+  onDragLeave={[Function]}
+>
+  <div
+    key="0"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item One
+      </div>
+    </div>
+  </div>
+  <div
+    key="1"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Two
+      </div>
+    </div>
+  </div>
+  <div
+    key="2"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Three
+      </div>
+    </div>
+  </div>
+  <div
+    key="3"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Four
+      </div>
+    </div>
+  </div>
+  <div
+    key="4"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        Item Five
+      </div>
+    </div>
+  </div>
+  <hr
+    className="lucid-DraggableList-Divider"
+    key="divider"
+  />
+</div>
+`;
+
+exports[`DraggableList [common] example testing should match snapshot(s) for 3.with-children 1`] = `
+<div
+  className="lucid-DraggableList"
+  onDragLeave={[Function]}
+  style={
+    Object {
+      "width": 500,
+    }
+  }
+>
+  <div
+    key="0"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "height": 50,
+            }
+          }
+        >
+          <CheckboxLabeled
+            Label="Item One"
+            isDisabled={false}
+            isIndeterminate={false}
+            isSelected={false}
+            onSelect={[Function]}
+          />
+        </div>
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="1"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "height": 50,
+            }
+          }
+        >
+          <CheckboxLabeled
+            Label="Item Two"
+            isDisabled={false}
+            isIndeterminate={false}
+            isSelected={false}
+            onSelect={[Function]}
+          />
+        </div>
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="2"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "height": 50,
+            }
+          }
+        >
+          <CheckboxLabeled
+            Label="Item Three"
+            isDisabled={false}
+            isIndeterminate={false}
+            isSelected={false}
+            onSelect={[Function]}
+          />
+        </div>
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="3"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "height": 50,
+            }
+          }
+        >
+          <CheckboxLabeled
+            Label="Item Four"
+            isDisabled={false}
+            isIndeterminate={false}
+            isSelected={false}
+            onSelect={[Function]}
+          />
+        </div>
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    key="4"
+  >
+    <hr
+      className="lucid-DraggableList-Divider"
+    />
+    <div
+      className="lucid-DraggableList-Item"
+      draggable={true}
+      onDragEnd={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+    >
+      <div
+        className="lucid-DraggableList-Item-content"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "height": 50,
+            }
+          }
+        >
+          <CheckboxLabeled
+            Label="Item Five"
+            isDisabled={false}
+            isIndeterminate={false}
+            isSelected={false}
+            onSelect={[Function]}
+          />
+        </div>
+      </div>
+      <span
+        className="lucid-DraggableList-Item-handle"
+      >
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+        <DotsIcon
+          color="primary"
+          size={8}
+        />
+      </span>
+    </div>
+  </div>
+  <hr
+    className="lucid-DraggableList-Divider"
+    key="divider"
+  />
+</div>
+`;

--- a/src/components/DraggableList/examples/1.basic.jsx
+++ b/src/components/DraggableList/examples/1.basic.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { DraggableList } from '../../../index';
+
+export default createClass({
+	getInitialState() {
+		return {
+			items: ['Item One', 'Item Two', 'Item Three', 'Item Four', 'Item Five'],
+		};
+	},
+
+	handleDrop({ oldIndex, newIndex }) {
+		const { items } = this.state;
+		const updatedItems = items.filter((column, index) => index !== oldIndex);
+		updatedItems.splice(newIndex, 0, items[oldIndex]);
+		this.setState({ items: updatedItems });
+	},
+
+	render() {
+		const { items } = this.state;
+
+		return (
+			<DraggableList onDrop={this.handleDrop}>
+				{items.map(text => (
+					<DraggableList.Item key={text}>{text}</DraggableList.Item>
+				))}
+			</DraggableList>
+		);
+	},
+});

--- a/src/components/DraggableList/examples/2.no-drag-handle.jsx
+++ b/src/components/DraggableList/examples/2.no-drag-handle.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { DraggableList } from '../../../index';
+
+export default createClass({
+	getInitialState() {
+		return {
+			items: ['Item One', 'Item Two', 'Item Three', 'Item Four', 'Item Five'],
+		};
+	},
+
+	handleDrop({ oldIndex, newIndex }) {
+		const { items } = this.state;
+		const updatedItems = items.filter((column, index) => index !== oldIndex);
+		updatedItems.splice(newIndex, 0, items[oldIndex]);
+		this.setState({ items: updatedItems });
+	},
+
+	render() {
+		const { items } = this.state;
+
+		return (
+			<DraggableList onDrop={this.handleDrop} hasDragHandle={false}>
+				{items.map(text => (
+					<DraggableList.Item key={text}>{text}</DraggableList.Item>
+				))}
+			</DraggableList>
+		);
+	},
+});

--- a/src/components/DraggableList/examples/3.with-children.jsx
+++ b/src/components/DraggableList/examples/3.with-children.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { CheckboxLabeled, DraggableList } from '../../../index';
+
+export default createClass({
+	getInitialState() {
+		return {
+			items: ['Item One', 'Item Two', 'Item Three', 'Item Four', 'Item Five'],
+		};
+	},
+
+	handleDrop({ oldIndex, newIndex }) {
+		const { items } = this.state;
+		const updatedItems = items.filter((column, index) => index !== oldIndex);
+		updatedItems.splice(newIndex, 0, items[oldIndex]);
+		this.setState({ items: updatedItems });
+	},
+
+	render() {
+		const { items } = this.state;
+
+		return (
+			<DraggableList onDrop={this.handleDrop} style={{ width: 500 }}>
+				{items.map(text => (
+					<DraggableList.Item key={text}>
+						<div style={{ display: 'flex', alignItems: 'center', height: 50 }}>
+							<CheckboxLabeled Label={text} />
+						</div>
+					</DraggableList.Item>
+				))}
+			</DraggableList>
+		);
+	},
+});

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -13,9 +13,9 @@ export default createClass({
 				<Typography variant='tabular'>tabular. text for tables</Typography>
 				<Typography variant='a'>a. link text</Typography>
 				<Typography variant='pre'>pre. preformatted text</Typography>
-				<Typography variant='code'>code. snazzy code</Typography> <br/>
-				<Typography variant='kbd'>kbd. keyboard inputs</Typography> <br/>
-				<Typography variant='samp'>samp. sample code outputs</Typography> <br/>
+				<Typography variant='code'>code. snazzy code</Typography> <br />
+				<Typography variant='kbd'>kbd. keyboard inputs</Typography> <br />
+				<Typography variant='samp'>samp. sample code outputs</Typography> <br />
 			</div>
 		);
 	},

--- a/src/components/Typography/examples/02.nested.jsx
+++ b/src/components/Typography/examples/02.nested.jsx
@@ -34,9 +34,7 @@ export default createClass({
 					</Typography>
 					<br />
 					<Typography variant='h3'>Code Example</Typography>
-					<Typography variant='code'>
-						npm install all-the-things
-					</Typography>
+					<Typography variant='code'>npm install all-the-things</Typography>
 				</Typography>
 			</section>
 		);

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,7 @@ import QuestionMarkIcon from './components/Icon/QuestionMarkIcon/QuestionMarkIco
 import RadioButton from './components/RadioButton/RadioButton';
 import RadioButtonLabeled from './components/RadioButtonLabeled/RadioButtonLabeled';
 import RefreshIcon from './components/Icon/RefreshIcon/RefreshIcon';
+import DraggableList from './components/DraggableList/DraggableList';
 import ResizeIcon from './components/Icon/ResizeIcon/ResizeIcon';
 import Resizer from './components/Resizer/Resizer';
 import ScrollTable from './components/ScrollTable/ScrollTable';
@@ -299,6 +300,7 @@ export {
 	RadioGroup,
 	RadioGroupDumb,
 	RefreshIcon,
+	DraggableList,
 	ResizeIcon,
 	Resizer,
 	ScrollTable,

--- a/src/styles/components.less
+++ b/src/styles/components.less
@@ -60,6 +60,7 @@
 @import '../components/Paginator/Paginator';
 @import '../components/RadioButton/RadioButton';
 @import '../components/RadioGroup/RadioGroup';
+@import '../components/DraggableList/DraggableList';
 @import '../components/SingleSelect/SingleSelect';
 @import '../components/ScrollTable/ScrollTable';
 @import '../components/SearchField/SearchField';


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval

Adds a basic list component that allows rearranging items by drag and drop: https://github.com/appnexus/lucid/issues/1009.

![Jul-31-2019 15-15-56](https://user-images.githubusercontent.com/12200110/62315173-a0820a80-b449-11e9-89d4-1c1011e9e68c.gif)
