### PR TITLE
Add topOffset prop to the StickySection

### DIFF
--- a/src/components/StickySection/StickySection.jsx
+++ b/src/components/StickySection/StickySection.jsx
@@ -40,6 +40,10 @@ const StickySection = createClass({
 			Width of section when it sticks to the top edge of the screen. When
 			omitted, it defaults to the last width of the section.
 		`,
+		topOffset: number`
+			Top offset threshold before sticking to the top. The sticky content will
+			display with this offset.
+		`,
 	},
 
 	getInitialState() {
@@ -49,14 +53,14 @@ const StickySection = createClass({
 		};
 	},
 
-	handleScroll() {
-		const { lowerBound } = this.props;
+	handleScroll(e) {
+		const { lowerBound, topOffset } = this.props;
 
 		const { isAboveFold, containerRect } = this.state;
 
 		const nextContainerRect = this.getContainerRect();
 
-		if (window.pageYOffset >= nextContainerRect.top) {
+		if (window.pageYOffset + topOffset >= nextContainerRect.top) {
 			if (!isAboveFold) {
 				this.setState({
 					isAboveFold: true,
@@ -128,6 +132,7 @@ const StickySection = createClass({
 			children,
 			className,
 			style,
+			topOffset,
 			viewportWidth,
 			...passThroughs
 		} = this.props;
@@ -142,6 +147,7 @@ const StickySection = createClass({
 					...(isAboveFold
 						? {
 								height: containerRect.height,
+								visibility: 'hidden',
 						  }
 						: {}),
 					...style,
@@ -154,8 +160,9 @@ const StickySection = createClass({
 					style={{
 						...(isAboveFold
 							? {
+									visibility: 'visible',
 									position: 'fixed',
-									top: 0,
+									top: topOffset,
 									width: _.isNumber(viewportWidth)
 										? viewportWidth
 										: containerRect.width,
@@ -191,5 +198,8 @@ const StickySection = createClass({
 		);
 	},
 });
+StickySection.defaultProps = {
+	topOffset: 0,
+};
 
 export default StickySection;

--- a/src/components/StickySection/__snapshots__/StickySection.spec.jsx.snap
+++ b/src/components/StickySection/__snapshots__/StickySection.spec.jsx.snap
@@ -104,3 +104,38 @@ exports[`StickySection [common] example testing should match snapshot(s) for 3.s
   </div>
 </div>
 `;
+
+exports[`StickySection [common] example testing should match snapshot(s) for 4.top-offset 1`] = `
+<div
+  className="lucid-StickySection"
+  style={
+    Object {
+      "backgroundColor": "#2abbb0",
+      "color": "white",
+    }
+  }
+>
+  <div
+    className="lucid-StickySection-sticky-frame"
+    style={
+      Object {
+        "backgroundColor": "#2abbb0",
+        "color": "white",
+      }
+    }
+  >
+    <div
+      className="lucid-StickySection-sticky-section"
+      style={
+        Object {
+          "backgroundColor": "#2abbb0",
+          "color": "white",
+          "position": "relative",
+        }
+      }
+    >
+      This section has no lower bounds! but has a topOffset
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/StickySection/examples/4.top-offset.jsx
+++ b/src/components/StickySection/examples/4.top-offset.jsx
@@ -17,8 +17,11 @@ export default createClass({
 				flexitarian shabby chic polaroid banjo four dollar toast four loko
 				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
 				scenester actually cornhole locavore man bun chambray.
-				<StickySection style={{ backgroundColor: '#2abbb0', color: 'white' }}>
-					This section has no lower bounds!
+				<StickySection
+					topOffset={100}
+					style={{ backgroundColor: '#2abbb0', color: 'white' }}
+				>
+					This section has no lower bounds! but has a topOffset
 				</StickySection>
 				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
 				messenger bag viral migas. Artisan freegan cold-pressed offal,


### PR DESCRIPTION
## problem

When using `StickySection`, it sticks to the top of the document, but if there is a navbar or some content above, it will overlap.

## proposal

This adds a new `topOffset` prop that will use it as a top threshold before it becomes sticky. It will display with that `topOffset` when sticky.
