### PR TITLE
initial code changes for supporting column width resizer

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -275,9 +275,12 @@ const DataTable = createClass({
 		const allSelected = _.every(data, 'isSelected');
 
 		const passActiveWidth = (childData, obj) => {
-			var activeWidth = Object.assign({}, this.state).activeWidth;
-			activeWidth[obj.props.children] = childData;
-			this.setState({ activeWidth });
+			// setting latest column width to Tbody
+			this.setState({
+				activeWidth: Object.assign({}, this.state.activeWidth, {
+					[obj.props.children]: childData,
+				}),
+			});
 		};
 		return (
 			<Thead>

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -253,7 +253,15 @@ const DataTable = createClass({
 		this.fixedHeaderUnfixedColumnsRef.scrollLeft = event.target.scrollLeft;
 		this.fixedBodyFixedColumnsRef.scrollTop = event.target.scrollTop;
 	},
-
+	handleResize(columnWidth, { props: childProps }) {
+		// setting latest column width to Tbody
+		this.setState(state => ({
+			activeWidth: {
+				...state.activeWidth,
+				[childProps.children]: columnWidth,
+			},
+		}));
+	},
 	renderHeader(
 		startColumn,
 		endColumn,
@@ -274,15 +282,6 @@ const DataTable = createClass({
 		);
 		const allSelected = _.every(data, 'isSelected');
 
-		const handleResize = (columnWidth, { props: childProps })  => {
-			// setting latest column width to Tbody
-			this.setState(state => ({
-				activeWidth: {
-					...state.activeWidth,
-					[childProps.children]: columnWidth,
-				},
-			}));
-		};
 		return (
 			<Thead>
 				<Tr>
@@ -308,7 +307,7 @@ const DataTable = createClass({
 							_.map(childComponentElements, ({ props, type }, index) =>
 								type === DataTable.Column ? (
 									<Th
-										onResize={props.isResizable ? handleResize : null}
+										onResize={props.isResizable ? this.handleResize : null}
 										{..._.omit(props, ['field', 'children', 'title'])}
 										onClick={
 											DataTable.shouldColumnHandleSort(props)

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -181,7 +181,7 @@ const DataTable = createClass({
 	getInitialState() {
 		return {
 			// Represents the actively changing width as the cell is resized.
-			activeWidth: [],
+			activeWidth: {},
 		};
 	},
 
@@ -274,13 +274,13 @@ const DataTable = createClass({
 		);
 		const allSelected = _.every(data, 'isSelected');
 
-		const passActiveWidth = (childData, obj) => {
+		const handleResize = (columnWidth, { props: childProps })  => {
 			// setting latest column width to Tbody
 			this.setState(state => ({
 				activeWidth: {
 					...state.activeWidth,
-					[obj.props.children]: childData,
-				}
+					[childProps.children]: columnWidth,
+				},
 			}));
 		};
 		return (
@@ -308,7 +308,7 @@ const DataTable = createClass({
 							_.map(childComponentElements, ({ props, type }, index) =>
 								type === DataTable.Column ? (
 									<Th
-										onResize={props.isResizable ? passActiveWidth : null}
+										onResize={props.isResizable ? handleResize : null}
 										{..._.omit(props, ['field', 'children', 'title'])}
 										onClick={
 											DataTable.shouldColumnHandleSort(props)

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -276,11 +276,12 @@ const DataTable = createClass({
 
 		const passActiveWidth = (childData, obj) => {
 			// setting latest column width to Tbody
-			this.setState({
-				activeWidth: Object.assign({}, this.state.activeWidth, {
+			this.setState(state => ({
+				activeWidth: {
+					...state.activeWidth,
 					[obj.props.children]: childData,
-				}),
-			});
+				}
+			}));
 		};
 		return (
 			<Thead>

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -178,6 +178,13 @@ const DataTable = createClass({
 		};
 	},
 
+	getInitialState() {
+		return {
+			// Represents the actively changing width as the cell is resized.
+			activeWidth: [],
+		};
+	},
+
 	components: {
 		Column: createClass({
 			displayName: 'DataTable.Column',
@@ -267,6 +274,11 @@ const DataTable = createClass({
 		);
 		const allSelected = _.every(data, 'isSelected');
 
+		const passActiveWidth = (childData, obj) => {
+			var activeWidth = Object.assign({}, this.state).activeWidth;
+			activeWidth[obj.props.children] = childData;
+			this.setState({ activeWidth });
+		};
 		return (
 			<Thead>
 				<Tr>
@@ -292,6 +304,7 @@ const DataTable = createClass({
 							_.map(childComponentElements, ({ props, type }, index) =>
 								type === DataTable.Column ? (
 									<Th
+										onResize={props.isResizable ? passActiveWidth : null}
 										{..._.omit(props, ['field', 'children', 'title'])}
 										onClick={
 											DataTable.shouldColumnHandleSort(props)
@@ -428,7 +441,9 @@ const DataTable = createClass({
 																endColumn
 												}
 												style={{
-													width: columnProps.width,
+													width:
+														this.state.activeWidth[columnProps.children] ||
+														columnProps.width,
 												}}
 												key={
 													'row' +

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import assert from 'assert';
 import { common } from '../../util/generic-tests';
@@ -8,6 +8,7 @@ import DataTable from './DataTable';
 import ScrollTable from '../ScrollTable/ScrollTable';
 import Checkbox from '../Checkbox/Checkbox';
 import EmptyStateWrapper from '../EmptyStateWrapper/EmptyStateWrapper';
+import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
 
 const { Column, ColumnGroup } = DataTable;
 
@@ -730,6 +731,24 @@ describe('DataTable', () => {
 				assert(
 					wrapper.find(ScrollTable).hasClass('lucid-DataTable-full-width')
 				);
+			});
+		});
+
+		describe('isResize', () => {
+			it('should show a `resizer` if `isResizable equals to true`', () => {
+				const onResize = jest.fn();
+				const wrapper = mount(
+					<DataTable hasFixedHeader onResize={onResize} data={testData}>
+						<Column field='id' isResizable title='ID' />
+						<Column field='first_name' isResizable title='First' />
+						<Column field='last_name' isResizable title='Last' />
+						<Column field='email' isResizable title='Email' />
+						<Column field='occupation' isResizable title='Occupation' />
+					</DataTable>
+				);
+
+				const dragCaptureZoneWrapper = wrapper.find(DragCaptureZone).at(1);
+				dragCaptureZoneWrapper.prop('onResize');
 			});
 		});
 	});

--- a/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
@@ -25,6 +25,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 01.basi
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -36,6 +37,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 01.basi
           isSorted={false}
           key="first_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -48,6 +50,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 01.basi
           isSorted={false}
           key="last_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -60,6 +63,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 01.basi
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -71,6 +75,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 01.basi
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -83,6 +88,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 01.basi
           isSorted={false}
           key="salary"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -95,6 +101,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 01.basi
           isSorted={false}
           key="status"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -1145,6 +1152,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 02.colu
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={2}
           sortDirection="up"
         >
@@ -1166,6 +1174,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 02.colu
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={2}
           sortDirection="up"
         >
@@ -1178,6 +1187,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 02.colu
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={2}
           sortDirection="up"
           width={100}
@@ -1191,6 +1201,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 02.colu
           isSorted={false}
           key="salary"
           onClick={null}
+          onResize={null}
           rowSpan={2}
           sortDirection="up"
           width={100}
@@ -1204,6 +1215,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 02.colu
           isSorted={false}
           key="status"
           onClick={null}
+          onResize={null}
           rowSpan={2}
           sortDirection="up"
           width={100}
@@ -2313,6 +2325,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 03.sele
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -2326,6 +2339,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 03.sele
           isSorted={false}
           key="first_name"
           onClick={[Function]}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -2340,6 +2354,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 03.sele
           isSorted={false}
           key="last_name"
           onClick={[Function]}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -2352,6 +2367,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 03.sele
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -2364,6 +2380,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 03.sele
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -2377,6 +2394,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 03.sele
           isSorted={false}
           key="salary"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -2390,6 +2408,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 03.sele
           isSorted={false}
           key="status"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -3598,6 +3617,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
           isSorted={true}
           key="id"
           onClick={[Function]}
+          onResize={null}
           rowSpan={null}
           sortDirection="down"
           width={41}
@@ -3614,6 +3634,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
           isSorted={false}
           key="first_name"
           onClick={[Function]}
+          onResize={[Function]}
           rowSpan={null}
           sortDirection="down"
           width={100}
@@ -3628,6 +3649,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
           isSorted={false}
           key="last_name"
           onClick={[Function]}
+          onResize={[Function]}
           rowSpan={null}
           sortDirection="down"
           width={100}
@@ -3641,6 +3663,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
           isSorted={false}
           key="email"
           onClick={[Function]}
+          onResize={null}
           rowSpan={null}
           sortDirection="down"
         >
@@ -3654,6 +3677,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
           isSorted={false}
           key="occupation"
           onClick={[Function]}
+          onResize={null}
           rowSpan={null}
           sortDirection="down"
           width={100}
@@ -3668,6 +3692,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
           isSorted={false}
           key="salary"
           onClick={[Function]}
+          onResize={null}
           rowSpan={null}
           sortDirection="down"
           width={100}
@@ -3681,6 +3706,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 04.inte
           isSorted={false}
           key="status"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -4947,6 +4973,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 05.disa
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -4958,6 +4985,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 05.disa
           isSorted={false}
           key="first_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -4970,6 +4998,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 05.disa
           isSorted={false}
           key="last_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -4982,6 +5011,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 05.disa
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -4993,6 +5023,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 05.disa
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -5005,6 +5036,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 05.disa
           isSorted={false}
           key="salary"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -5017,6 +5049,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 05.disa
           isSorted={false}
           key="status"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -6067,6 +6100,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 06.empt
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -6078,6 +6112,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 06.empt
           isSorted={false}
           key="first_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -6090,6 +6125,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 06.empt
           isSorted={false}
           key="last_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -6102,6 +6138,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 06.empt
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -6113,6 +6150,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 06.empt
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -6833,6 +6871,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 07.empt
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -6844,6 +6883,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 07.empt
           isSorted={false}
           key="first_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -6856,6 +6896,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 07.empt
           isSorted={false}
           key="last_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -6868,6 +6909,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 07.empt
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -6879,6 +6921,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 07.empt
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -7932,6 +7975,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 08.empt
           isSorted={false}
           key="id"
           onClick={[Function]}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={41}
@@ -7945,6 +7989,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 08.empt
           isSorted={false}
           key="first_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -7958,6 +8003,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 08.empt
           isSorted={false}
           key="last_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -7970,6 +8016,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 08.empt
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -7982,6 +8029,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 08.empt
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -8692,6 +8740,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 09.load
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -8703,6 +8752,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 09.load
           isSorted={false}
           key="first_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -8715,6 +8765,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 09.load
           isSorted={false}
           key="last_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -8727,6 +8778,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 09.load
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -8738,6 +8790,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 09.load
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -9464,6 +9517,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 10.min-
           isSorted={false}
           key="id"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -9475,6 +9529,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 10.min-
           isSorted={false}
           key="first_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -9487,6 +9542,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 10.min-
           isSorted={false}
           key="last_name"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -9499,6 +9555,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 10.min-
           isSorted={false}
           key="email"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
         >
@@ -9510,6 +9567,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 10.min-
           isSorted={false}
           key="occupation"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -9522,6 +9580,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 10.min-
           isSorted={false}
           key="salary"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -9534,6 +9593,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 10.min-
           isSorted={false}
           key="status"
           onClick={null}
+          onResize={null}
           rowSpan={null}
           sortDirection="up"
           width={100}
@@ -10345,6 +10405,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
                 isSorted={false}
                 key="id"
                 onClick={null}
+                onResize={null}
                 rowSpan={null}
                 sortDirection="up"
                 width={35}
@@ -10378,6 +10439,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
                 isSorted={false}
                 key="first_name"
                 onClick={null}
+                onResize={null}
                 rowSpan={null}
                 sortDirection="up"
                 width={100}
@@ -10390,6 +10452,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
                 isSorted={false}
                 key="last_name"
                 onClick={null}
+                onResize={null}
                 rowSpan={null}
                 sortDirection="up"
                 width={100}
@@ -10402,6 +10465,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
                 isSorted={false}
                 key="email"
                 onClick={null}
+                onResize={null}
                 rowSpan={null}
                 sortDirection="up"
                 width={900}
@@ -10414,6 +10478,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
                 isSorted={false}
                 key="occupation"
                 onClick={null}
+                onResize={null}
                 rowSpan={null}
                 sortDirection="up"
                 width={100}
@@ -10426,6 +10491,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
                 isSorted={false}
                 key="salary"
                 onClick={null}
+                onResize={null}
                 rowSpan={null}
                 sortDirection="up"
                 width={100}
@@ -10438,6 +10504,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 11.fixe
                 isSorted={false}
                 key="status"
                 onClick={null}
+                onResize={null}
                 rowSpan={null}
                 sortDirection="up"
                 width={100}

--- a/src/components/Table/Table.less
+++ b/src/components/Table/Table.less
@@ -50,6 +50,11 @@
 			visibility: hidden;
 		}
 	}
+	& .@{prefix}-Table-Th-inner {
+		& .@{prefix}-Table-Th-inner-resize {
+			visibility: visible;
+		}
+	}
 
 	// `Table`.`hasBorder` prop
 	&-has-border {


### PR DESCRIPTION
## PR Table Column Width Resizing

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge (Win 10)
- [x] Unit tests updated
- [x] Code coverage increased 1.08% for DataTable component
- [ ] One core team engineer approvals
- [ ] One core team UX approval

Adds a basic DataTable component that allows resizing column width by drag and drop:

![coumn resizing](https://user-images.githubusercontent.com/9532774/62880967-ace54d80-bcfc-11e9-82f9-faeec176416c.gif)
