### PR TITLE
Add teal to secondary colors for NotchedTag and improve color palette

### DIFF
--- a/docs/color-palette.jsx
+++ b/docs/color-palette.jsx
@@ -27,6 +27,18 @@ const colorList = [
 		variables: ['color-primaryLight', 'color-primary'],
 	},
 	{
+		category: 'Secondary',
+		description:
+			'Secondary colors are used to denote specific objects types. In our case we typically use these color for advertisers, insertion orders, and line items.',
+		variables: [
+			'color-secondary-1',
+			'color-secondary-2',
+			'color-secondary-3',
+			'color-secondary-4',
+			'color-secondary-5',
+		],
+	},
+	{
 		category: 'Text Colors',
 		variables: [
 			'color-textColor',
@@ -40,10 +52,15 @@ const colorList = [
 		description:
 			'Grays play an important role in lucid, and this set of grays forms the foundation for all the other variants. More prescriptive colors should be favored over these general grays when available.',
 		variables: [
-			'color-lightGray',
-			'color-gray',
-			'color-mediumGray',
-			'color-darkGray',
+			'color-neutral-1',
+			'color-neutral-2',
+			{ name: 'color-neutral-3', aliases: ['color-lightGray'] },
+			{ name: 'color-neutral-4', aliases: ['color-gray'] },
+			{ name: 'color-neutral-5', aliases: ['color-mediumGray'] },
+			'color-neutral-6',
+			'color-neutral-7',
+			'color-neutral-8',
+			{ name: 'color-neutral-9', aliases: ['color-darkGray'] },
 		],
 	},
 	{
@@ -260,20 +277,33 @@ const ColorPalette = createClass({
 
 				{_.map(colorList, (group, i) => (
 					<div key={i}>
-						<h3>{group.category}</h3>
+						<h3 style={{ marginTop: '1.5rem' }}>{group.category}</h3>
 
 						{group.description ? <p>{group.description}</p> : null}
 
-						{_.map(group.variables, (variable, j) => (
-							<div
-								key={j}
-								data-less-variable={variable}
-								className={classNames(cx('&-item', `&-${variable}`))}
-							>
-								<span>{`@${variable};`}</span>
-								<span>{hexMap[variable]}</span>
-							</div>
-						))}
+						{_.map(group.variables, (variable, j) => {
+							const hasAliases = _.isPlainObject(variable);
+							const variableName = hasAliases ? variable.name : variable;
+
+							return (
+								<div
+									key={j}
+									data-less-variable={variableName}
+									className={classNames(cx('&-item', `&-${variableName}`))}
+								>
+									<span>
+										{`@${variableName}; `}
+										{hasAliases
+											? `(aliases: ${variable.aliases
+													.map(v => `@${v};`)
+													.join(' ')})`
+											: null}
+									</span>
+
+									<span>{hexMap[variableName]}</span>
+								</div>
+							);
+						})}
 					</div>
 				))}
 			</div>

--- a/docs/color-palette.less
+++ b/docs/color-palette.less
@@ -347,24 +347,49 @@
 		color: contrast(@color-borderColor);
 	}
 
-	&-color-darkGray {
-		background-color: @color-darkGray;
-		color: contrast(@color-darkGray);
+	&-color-neutral-1 {
+		background-color: @color-neutral-1;
+		color: contrast(@color-neutral-1);
 	}
 
-	&-color-mediumGray {
-		background-color: @color-mediumGray;
-		color: contrast(@color-mediumGray);
+	&-color-neutral-2 {
+		background-color: @color-neutral-2;
+		color: contrast(@color-neutral-2);
 	}
 
-	&-color-gray {
-		background-color: @color-gray;
-		color: contrast(@color-gray);
+	&-color-neutral-3 {
+		background-color: @color-neutral-3;
+		color: contrast(@color-neutral-3);
 	}
 
-	&-color-lightGray {
-		background-color: @color-lightGray;
-		color: contrast(@color-lightGray);
+	&-color-neutral-4 {
+		background-color: @color-neutral-4;
+		color: contrast(@color-neutral-4);
+	}
+
+	&-color-neutral-5 {
+		background-color: @color-neutral-5;
+		color: contrast(@color-neutral-5);
+	}
+
+	&-color-neutral-6 {
+		background-color: @color-neutral-6;
+		color: contrast(@color-neutral-6);
+	}
+
+	&-color-neutral-7 {
+		background-color: @color-neutral-7;
+		color: contrast(@color-neutral-7);
+	}
+
+	&-color-neutral-8 {
+		background-color: @color-neutral-8;
+		color: contrast(@color-neutral-8);
+	}
+
+	&-color-neutral-9 {
+		background-color: @color-neutral-9;
+		color: contrast(@color-neutral-9);
 	}
 
 	&-color-linkColorHover {
@@ -395,6 +420,31 @@
 	&-color-primary {
 		background-color: @color-primary;
 		color: contrast(@color-primary);
+	}
+
+	&-color-secondary-1 {
+		background-color: @color-secondary-1;
+		color: contrast(@color-secondary-1);
+	}
+
+	&-color-secondary-2 {
+		background-color: @color-secondary-2;
+		color: contrast(@color-secondary-2);
+	}
+
+	&-color-secondary-3 {
+		background-color: @color-secondary-3;
+		color: contrast(@color-secondary-3);
+	}
+
+	&-color-secondary-4 {
+		background-color: @color-secondary-4;
+		color: contrast(@color-secondary-4);
+	}
+
+	&-color-secondary-5 {
+		background-color: @color-secondary-5;
+		color: contrast(@color-secondary-5);
 	}
 
 	&-color-black {

--- a/src/components/NotchedTag/NotchedTag.less
+++ b/src/components/NotchedTag/NotchedTag.less
@@ -15,7 +15,7 @@
 
 	&-no-border {
 		&.@{prefix}-NotchedTag-style-one {
-			background-color: @color-secondary-1;
+			background-color: @color-secondary-5;
 		}
 
 		&.@{prefix}-NotchedTag-style-two {
@@ -29,11 +29,11 @@
 
 	&-style-one {
 		.@{prefix}-NotchedTag-container {
-			color: @color-secondary-1;
+			color: @color-secondary-5;
 
 			&-filled {
 				color: @color-white;
-				background-color: @color-secondary-1;
+				background-color: @color-secondary-5;
 			}
 		}
 	}

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -105,10 +105,11 @@
 @color-primary-dark: #4368a1;
 
 // Secondary colors
-@color-secondary-1: #fc5047;
-@color-secondary-2: #ab52b0;
-@color-secondary-3: #009fdb;
-@color-secondary-4: #49b27b;
+@color-secondary-1: #fc5047; // coral red
+@color-secondary-2: #ab52b0; // magenta
+@color-secondary-3: #009fdb; // blue
+@color-secondary-4: #49b27b; // green
+@color-secondary-5: #00bebe; // teal
 
 @color-secondary-1-hover: shade(@color-secondary-1, 35%);
 


### PR DESCRIPTION
## PR Checklist

This PR adds a new teal color and revamps the color palette a little bit to include all our shades of gray.

- Manually tested across supported browsers
  - ~~Chrome~~
  - [X] Firefox
  - ~~Safari~~
  - ~~Edge (Win 10)~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
