### PR TITLE
Add outline-only version of Banner, defaults to filled version

### DIFF
--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -37,6 +37,11 @@ const Banner = createClass({
 			Set this to \`true\` if you want to have a \`x\` close icon.
 		`,
 
+		isFilled: bool`
+			Defaults to true.
+			If set to \`false\` the banner will not be filled in.
+		`,
+
 		isSmall: bool`
 			If set to \`true\` the banner have smaller padding on the inside.
 		`,
@@ -67,6 +72,7 @@ const Banner = createClass({
 		return {
 			icon: null,
 			isCloseable: true,
+			isFilled: true,
 			isSmall: false,
 			kind: 'default',
 			onClose: _.noop,
@@ -87,6 +93,7 @@ const Banner = createClass({
 			children,
 			isCloseable,
 			isClosed,
+			isFilled,
 			isSmall,
 			...passThroughs
 		} = this.props;
@@ -117,6 +124,7 @@ const Banner = createClass({
 								'&-danger': kind === 'danger',
 								'&-info': kind === 'info',
 								'&-small': isSmall,
+								'&-filled': isFilled,
 							},
 							className
 						)}

--- a/src/components/Banner/Banner.less
+++ b/src/components/Banner/Banner.less
@@ -9,23 +9,26 @@
 
 .@{prefix}-Banner {
 	.transition-group-animation-fade();
+
 	box-sizing: content-box;
-	border: none;
-	background-color: @color-neutral-9;
+	border: @color-darkGray 2px solid;
+	background-color: @color-white;
 	font-size: @fontSize;
 	font-weight: @font-weight-medium;
 	padding: 0 @Banner-size-spacing-rightLeft;
 	display: flex;
-	color: @color-white;
+	color: @color-darkGray;
 
 	&.@{prefix}-Banner-has-close {
 		padding-right: @Banner-size-spacing-rightLeft;
 	}
 
-	// must use this specific selector in order to override default color
 	&-close&-close&-close {
 		align-self: flex-start;
 		margin-top: 14px;
+	}
+	// must use this specific selector in order to override default color
+	&-filled &-close&-close&-close {
 		stroke: @color-white;
 
 		&:hover {
@@ -48,12 +51,16 @@
 
 	&-icon {
 		> .@{prefix}-Icon {
-			stroke: @color-white;
+			stroke: @color-darkGray;
 		}
 
 		display: flex;
 		align-self: center;
 		margin-right: @Banner-size-spacing-rightLeft;
+	}
+
+	&-filled &-icon > .@{prefix}-Icon {
+		stroke: @color-white;
 	}
 
 	&-content {
@@ -81,26 +88,46 @@
 
 	// Types
 	&-success {
-		background-color: @featured-color-success;
+		border-color: @featured-color-success;
 	}
 
 	&-info {
-		background-color: @featured-color-info;
+		border-color: @featured-color-info;
 	}
 
 	&-warning {
-		background-color: @featured-color-warning;
-		color: @color-darkGray;
+		border-color: @featured-color-warning;
 	}
 
 	&-danger {
-		background-color: @featured-color-danger;
+		border-color: @featured-color-danger;
 	}
 
+	&-filled {
+		border: none;
+		background-color: @color-neutral-9;
+		color: @color-white;
+
+		&.@{prefix}-Banner-success {
+			background-color: @featured-color-success;
+		}
+
+		&.@{prefix}-Banner-info {
+			background-color: @featured-color-info;
+		}
+
+		&.@{prefix}-Banner-warning {
+			background-color: @featured-color-warning;
+			color: @color-darkGray;
+		}
+
+		&.@{prefix}-Banner-danger {
+			background-color: @featured-color-danger;
+		}
+	}
 
 	&-small &-content {
 		padding: @Banner-size-spacing-topBottom - 6px 0;
 		height: 12px;
 	}
 }
-

--- a/src/components/Banner/__snapshots__/Banner.spec.jsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.spec.jsx.snap
@@ -10,7 +10,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 1`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -42,7 +42,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 2`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -69,7 +69,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 3`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -101,7 +101,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 4`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-success lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -128,7 +128,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 5`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -160,7 +160,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 6`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-warning lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -187,7 +187,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 7`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -219,7 +219,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 8`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-danger lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -246,7 +246,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 9`] 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -278,7 +278,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 10`]
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-info lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -305,7 +305,7 @@ exports[`Banner [common] example testing should match snapshot(s) for small 11`]
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small"
+    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -332,6 +332,166 @@ exports[`Banner [common] example testing should match snapshot(s) for small 11`]
 </CSSTransitionGroup>
 `;
 
+exports[`Banner [common] example testing should match snapshot(s) for small 12`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Default -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for small 13`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Success -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for small 14`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Warning -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for small 15`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Danger -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for small 16`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Info -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
 exports[`Banner [common] example testing should match snapshot(s) for stateful 1`] = `
 <CSSTransitionGroup
   transitionAppear={false}
@@ -342,7 +502,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateful 1
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
   >
     <span
       className="lucid-Banner-content"
@@ -369,7 +529,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -422,7 +582,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner"
+    className="lucid-Banner lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -449,7 +609,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -481,7 +641,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-success"
+    className="lucid-Banner lucid-Banner-success lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -508,7 +668,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -545,7 +705,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-warning"
+    className="lucid-Banner lucid-Banner-warning lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -572,7 +732,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -604,7 +764,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-danger"
+    className="lucid-Banner lucid-Banner-danger lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -631,7 +791,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info"
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -663,7 +823,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-info"
+    className="lucid-Banner lucid-Banner-info lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -690,7 +850,7 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
   transitionName="lucid-Banner"
 >
   <section
-    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger"
+    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
     style={
       Object {
         "marginBottom": 8,
@@ -706,6 +866,203 @@ exports[`Banner [common] example testing should match snapshot(s) for stateless 
       className="lucid-Banner-content"
     >
       Has Icon
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for stateless 12`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Default -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for stateless 13`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Success -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for stateless 14`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Warning -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for stateless 15`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Danger -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for stateless 16`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
+    >
+      Info -- Outline Only
+    </span>
+    <CloseIcon
+      className="lucid-Banner-close"
+      isClickable={true}
+      onClick={[Function]}
+      size={8}
+    />
+  </section>
+</CSSTransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for stateless 17`] = `
+<CSSTransitionGroup
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={300}
+  transitionLeave={true}
+  transitionLeaveTimeout={300}
+  transitionName="lucid-Banner"
+>
+  <section
+    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger"
+    style={
+      Object {
+        "marginBottom": 8,
+      }
+    }
+  >
+    <span
+      className="lucid-Banner-icon"
+    >
+      <ChatIcon />
+    </span>
+    <span
+      className="lucid-Banner-content"
+    >
+      Has Icon -- Outline Only
     </span>
     <CloseIcon
       className="lucid-Banner-close"

--- a/src/components/Banner/examples/small.jsx
+++ b/src/components/Banner/examples/small.jsx
@@ -97,6 +97,44 @@ export default createClass({
 						Has Custom Icon
 					</Banner>
 				</div>
+
+				<div>
+					<Banner style={{ marginBottom: 8 }} isSmall={true} isFilled={false}>
+						Default -- Outline Only
+					</Banner>
+					<Banner
+						kind='success'
+						style={{ marginBottom: 8 }}
+						isSmall={true}
+						isFilled={false}
+					>
+						Success -- Outline Only
+					</Banner>
+					<Banner
+						kind='warning'
+						style={{ marginBottom: 8 }}
+						isSmall={true}
+						isFilled={false}
+					>
+						Warning -- Outline Only
+					</Banner>
+					<Banner
+						kind='danger'
+						style={{ marginBottom: 8 }}
+						isSmall={true}
+						isFilled={false}
+					>
+						Danger -- Outline Only
+					</Banner>
+					<Banner
+						kind='info'
+						style={{ marginBottom: 8 }}
+						isSmall={true}
+						isFilled={false}
+					>
+						Info -- Outline Only
+					</Banner>
+				</div>
 			</div>
 		);
 	},

--- a/src/components/Banner/examples/stateless.jsx
+++ b/src/components/Banner/examples/stateless.jsx
@@ -96,6 +96,32 @@ export default createClass({
 						Has Icon
 					</Banner>
 				</div>
+
+				<div>
+					<Banner style={{ marginBottom: 8 }} isFilled={false}>
+						Default -- Outline Only
+					</Banner>
+					<Banner kind='success' style={{ marginBottom: 8 }} isFilled={false}>
+						Success -- Outline Only
+					</Banner>
+					<Banner kind='warning' style={{ marginBottom: 8 }} isFilled={false}>
+						Warning -- Outline Only
+					</Banner>
+					<Banner kind='danger' style={{ marginBottom: 8 }} isFilled={false}>
+						Danger -- Outline Only
+					</Banner>
+					<Banner kind='info' style={{ marginBottom: 8 }} isFilled={false}>
+						Info -- Outline Only
+					</Banner>
+					<Banner
+						style={{ marginBottom: 8 }}
+						icon={<ChatIcon />}
+						kind='danger'
+						isFilled={false}
+					>
+						Has Icon -- Outline Only
+					</Banner>
+				</div>
 			</div>
 		);
 	},


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
