### PR TITLE
Align SingleSelect with Abstract mocks

### DIFF
--- a/src/components/ContextMenu/ContextMenu.jsx
+++ b/src/components/ContextMenu/ContextMenu.jsx
@@ -53,6 +53,7 @@ const ContextMenu = createClass({
 			direction of the FlyOut relative to Target.
 		`,
 
+		// TODO: fix this mispelling, but it's a breaking change :(
 		directonOffset: number`
 			the px offset along the axis of the direction
 		`,

--- a/src/components/DropMenu/DropMenu.less
+++ b/src/components/DropMenu/DropMenu.less
@@ -43,10 +43,6 @@
 			background: @color-primaryLight;
 		}
 
-		&&-is-null {
-			color: @color-disabledText;
-		}
-
 		&&-is-wrapped {
 			white-space: normal;
 		}
@@ -81,7 +77,6 @@
 	}
 
 	&-OptionGroup-divider {
-		margin: 5px 0 1px 0;
 		border: 1px solid @color-gray;
 		border-width: 1px 0 0;
 		height: 1px;

--- a/src/components/SingleSelect/SingleSelect.jsx
+++ b/src/components/SingleSelect/SingleSelect.jsx
@@ -231,6 +231,10 @@ const SingleSelect = createClass({
 		);
 		const placeholder = _.get(placeholderProps, 'children', 'Select');
 		const isItemSelected = _.isNumber(selectedIndex);
+		const isHighlighted =
+			(!isDisabled && isItemSelected && isSelectionHighlighted) ||
+			(isExpanded && isSelectionHighlighted);
+		const isNullOptionSelected = selectedIndex === null;
 
 		return (
 			<DropMenu
@@ -245,21 +249,18 @@ const SingleSelect = createClass({
 					flyOutStyle,
 					!_.isNil(maxMenuHeight) ? { maxHeight: maxMenuHeight } : null
 				)}
+				ContextMenu={{ directonOffset: isNullOptionSelected ? -1 : 0 }}
 			>
 				<DropMenu.Control>
 					<div
 						tabIndex={0}
 						className={cx('&-Control', {
-							'&-Control-is-highlighted':
-								(!isDisabled && isItemSelected && isSelectionHighlighted) ||
-								(isExpanded && isSelectionHighlighted),
-							'&-Control-is-selected':
-								(!isDisabled && isItemSelected && isSelectionHighlighted) ||
-								(isExpanded && isSelectionHighlighted),
+							'&-Control-is-highlighted': isHighlighted,
+							'&-Control-is-selected': isHighlighted,
 							'&-Control-is-expanded': isExpanded,
 							'&-Control-is-disabled': isDisabled,
 							'&-Control-is-invisible': isInvisible,
-							'&-Control-is-null-option': selectedIndex === null,
+							'&-Control-is-null-option': isNullOptionSelected,
 						})}
 					>
 						<span

--- a/src/components/SingleSelect/SingleSelect.less
+++ b/src/components/SingleSelect/SingleSelect.less
@@ -77,10 +77,6 @@
 			z-index: @zindex-tooltip;
 		}
 
-		&-is-expanded&-is-null-option {
-			border-bottom-width: 0;
-		}
-
 		&-is-selected&-is-expanded {
 			background-color: @featured-color-default-backgroundColor;
 		}

--- a/src/components/SingleSelect/SingleSelect.less
+++ b/src/components/SingleSelect/SingleSelect.less
@@ -18,7 +18,7 @@
 		font-weight: @font-weight-medium;
 		color: @color-darkGray;
 		line-height: @size-standard-height;
-		padding: 0 @size-standard;
+		padding: 0 @size-S;
 		align-items: center;
 		white-space: nowrap;
 
@@ -29,6 +29,7 @@
 			&.@{prefix}-SingleSelect-Control-is-selected {
 				border: 1px solid @featured-color-primary-borderColor;
 			}
+
 			&.@{prefix}-SingleSelect-Control-is-expanded {
 				background-color: transparent;
 
@@ -45,7 +46,7 @@
 		&-content {
 			display: flex;
 			align-items: center;
-			margin-right: @size-standard;
+			margin-right: @size-S;
 		}
 
 		.@{prefix}-ChevronIcon {
@@ -56,8 +57,8 @@
 			.opacity(@opacity-disabled);
 		}
 
-		&:not(.@{prefix}-SingleSelect-Control-is-disabled)&:not(.@{prefix}-SingleSelect-Control-is-expanded){
-			&:hover{
+		&:not(.@{prefix}-SingleSelect-Control-is-disabled)&:not(.@{prefix}-SingleSelect-Control-is-expanded) {
+			&:hover {
 				background-color: @color-neutral-3;
 			}
 
@@ -75,8 +76,9 @@
 		&-is-expanded {
 			z-index: @zindex-tooltip;
 		}
+
 		&-is-expanded&-is-null-option {
-			border-bottom-width: 0px;
+			border-bottom-width: 0;
 		}
 
 		&-is-selected&-is-expanded {

--- a/src/components/SingleSelect/__snapshots__/SingleSelect.spec.jsx.snap
+++ b/src/components/SingleSelect/__snapshots__/SingleSelect.spec.jsx.snap
@@ -4,14 +4,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 01.b
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -80,14 +73,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 02.n
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -159,14 +145,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 03.d
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -235,14 +214,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 04.d
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -311,14 +283,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 05.g
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -452,14 +417,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 06.n
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -528,14 +486,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 07.m
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -1708,14 +1659,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 08.r
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -1812,14 +1756,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 09.n
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -1888,14 +1825,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 10.a
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -1964,14 +1894,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 11.s
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
       "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
     }
   }
   alignment="start"
@@ -2082,14 +2005,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 12.i
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -2158,14 +2074,7 @@ exports[`SingleSelect [common] example testing should match snapshot(s) for 13.i
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
-      "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
+      "directonOffset": -1,
     }
   }
   alignment="start"
@@ -2234,14 +2143,7 @@ exports[`SingleSelect child elements Option should render Option.Selected in the
 <DropMenu
   ContextMenu={
     Object {
-      "alignment": "start",
-      "direction": "down",
       "directonOffset": 0,
-      "getAlignmentOffset": [Function],
-      "isExpanded": true,
-      "minWidthOffset": 0,
-      "onClickOut": null,
-      "portalId": null,
     }
   }
   alignment="start"


### PR DESCRIPTION
Found several inconsistencies with the mock while working on this ticket:

- some margins/padding were 12px instead of 9px
- using a `border-bottom-width: 0` caused jitter when opening/closing the single select so I instead started using the offset prop that `ContextMenu` supports
- other code formatting stuff

### Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - ~~Edge (Win 10)~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

Preview for Xandr employees only: https://docspot.adnxs.net/projects/lucid/single-select-styling-fix/?selectedKind=SingleSelect&selectedStory=basic&full=0&addons=1&stories=1&panelRight=1&addonPanel=lucid-docs-panel-props
