### PR TITLE
1027 fix prop warning on data table

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -295,7 +295,7 @@ const DataTable = createClass({
 								>
 									<Checkbox
 										isDisabled={!data || !data.length}
-										isSelected={data && data.length && allSelected}
+										isSelected={!!data && data.length > 0 && allSelected}
 										isIndeterminate={
 											!allSelected && !!data.find(d => d.isSelected)
 										}

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -289,7 +289,7 @@ describe('DataTable', () => {
 				});
 			});
 
-			it('should render without prop warning for isSelectable when data is empty array', () => {
+			it('should render without prop warning for isSelected when data is empty array', () => {
 				const emptyData = [];
 				
 				const wrapper = shallow(<DataTable isSelectable data={emptyData}/>);

--- a/src/components/DataTable/DataTable.spec.jsx
+++ b/src/components/DataTable/DataTable.spec.jsx
@@ -288,6 +288,14 @@ describe('DataTable', () => {
 					}
 				});
 			});
+
+			it('should render without prop warning for isSelectable when data is empty array', () => {
+				const emptyData = [];
+				
+				const wrapper = shallow(<DataTable isSelectable data={emptyData}/>);
+
+				expect(wrapper.find(Checkbox).props().isSelected).toEqual(false);
+			});
 		});
 
 		describe('minRows', () => {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
