### PR TITLE
CXP-719: #1031 fixed tooltip default carat border styling

### DIFF
--- a/src/components/ToolTip/ToolTip.less
+++ b/src/components/ToolTip/ToolTip.less
@@ -69,7 +69,7 @@
 	}
 
 	&-default&-up::before {
-		border-top-color: @color-borderColor;
+		border-top-color: @color-darkGray;
 	}
 
 	&-default&-left::after {
@@ -77,7 +77,7 @@
 	}
 
 	&-default&-left::before {
-		border-left-color: @color-borderColor;
+		border-left-color: @color-darkGray;
 	}
 
 	&-default&-right::after {
@@ -85,7 +85,7 @@
 	}
 
 	&-default&-right::before {
-		border-right-color: @color-borderColor;
+		border-right-color: @color-darkGray;
 	}
 
 	&-default&-down::after {
@@ -93,7 +93,7 @@
 	}
 
 	&-default&-down::before {
-		border-bottom-color: @color-borderColor;
+		border-bottom-color: @color-darkGray;
 	}
 
 	// light before/after styles


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
