### PR TITLE
pass the data point to the xFormatter and yFormatter functions

### DIFF
--- a/src/components/Bars/Bars.jsx
+++ b/src/components/Bars/Bars.jsx
@@ -181,7 +181,7 @@ const Bars = createClass({
 					>
 						{yTooltipFormatter(
 							_.get(legend, field, field),
-							yFormatter(dataPoint[field]),
+							yFormatter(dataPoint[field], dataPoint),
 							dataPoint[field]
 						)}
 					</Legend.Item>
@@ -376,7 +376,9 @@ export const PureToolTip = createClass({
 					/>
 				</ToolTip.Target>
 
-				<ToolTip.Title>{xFormatter(data[seriesIndex][xField])}</ToolTip.Title>
+				<ToolTip.Title>
+					{xFormatter(data[seriesIndex][xField], data[seriesIndex])}
+				</ToolTip.Title>
 
 				<ToolTip.Body>{renderBody(data[seriesIndex])}</ToolTip.Body>
 			</ToolTip>

--- a/src/components/Bars/Bars.spec.jsx
+++ b/src/components/Bars/Bars.spec.jsx
@@ -313,6 +313,43 @@ describe('Bars', () => {
 					'SEE'
 				);
 			});
+
+			it('should have access to the full datum', () => {
+				const wrapper = shallow(
+					<Bars
+						data={defaultData}
+						xScale={defaultXScale}
+						yScale={defaultYScale}
+						hasToolTips
+						xFormatter={(str, d) => `${str.toUpperCase()} ${d.y2}`}
+					/>
+				).find(PureToolTip);
+
+				assert.equal(
+					wrapper
+						.at(0)
+						.shallow()
+						.find(ToolTip.Title)
+						.prop('children'),
+					'AYE 20'
+				);
+				assert.equal(
+					wrapper
+						.at(1)
+						.shallow()
+						.find(ToolTip.Title)
+						.prop('children'),
+					'BEE 35'
+				);
+				assert.equal(
+					wrapper
+						.at(2)
+						.shallow()
+						.find(ToolTip.Title)
+						.prop('children'),
+					'SEE 3'
+				);
+			});
 		});
 
 		describe('yScale', () => {


### PR DESCRIPTION
when formatting x or y for a bar, it can be useful for the formatter function to have access to the full data object.

This is useful when the bar is a sum of a range of data that has been grouped. for example a datum might look like: `{x: 1, y: 10, min: 0, max: 2}` we may want to format the display to show `0-2`.