### PR TITLE
Fix Banner warning close icon color

### DIFF
--- a/src/components/Banner/Banner.less
+++ b/src/components/Banner/Banner.less
@@ -119,6 +119,10 @@
 		&.@{prefix}-Banner-warning {
 			background-color: @featured-color-warning;
 			color: @color-darkGray;
+
+			.@{prefix}-Banner-close.@{prefix}-Banner-close.@{prefix}-Banner-close {
+				stroke: @color-darkGray;
+			}
 		}
 
 		&.@{prefix}-Banner-danger {


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
