### PR TITLE
Normalize the size of the eligibility icons

### DIFF
--- a/src/components/Icon/EligibilityIcon/EligibilityIcon.less
+++ b/src/components/Icon/EligibilityIcon/EligibilityIcon.less
@@ -4,11 +4,11 @@
 .@{prefix}-EligibilityIcon {
 	&-half-circle {
 		fill: @featured-color-danger;
-		stroke: @color-transparent;
+		stroke: @featured-color-danger;
 	}
 
 	&-is-selected {
 		fill: @featured-color-success;
-		stroke: @color-transparent;
+		stroke: @featured-color-success;
 	}
 }

--- a/src/components/Icon/EligibilityIcon/EligibilityIcon.tsx
+++ b/src/components/Icon/EligibilityIcon/EligibilityIcon.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import PropTypes from 'react-peek/prop-types'
+import PropTypes from 'react-peek/prop-types';
 import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
 import { FC, omitProps } from '../../../util/component-types';
@@ -25,40 +25,48 @@ const EligibilityIcon: FC<IEligibilityIconProps> = ({
 	eligibility = EligibilityOptions.neither,
 	...passThroughs
 }): React.ReactElement => {
-
 	return (
 		<Icon
-			{...omitProps(passThroughs, undefined, _.keys(EligibilityIcon.propTypes), false)}
+			{...omitProps(
+				passThroughs,
+				undefined,
+				_.keys(EligibilityIcon.propTypes),
+				false
+			)}
 			{..._.pick(passThroughs, _.keys(Icon.propTypes))}
 			className={cx('&', className)}
 		>
 			<g>
 				<path
 					className={cx('&-half-circle', {
-						'&-is-selected': eligibility === EligibilityOptions.left || eligibility === EligibilityOptions.both,
+						'&-is-selected':
+							eligibility === EligibilityOptions.left ||
+							eligibility === EligibilityOptions.both,
 					})}
-					d='M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z'
+					d='M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z'
 				/>
 				<path
 					className={cx('&-half-circle', {
-						'&-is-selected': eligibility === EligibilityOptions.right || eligibility === EligibilityOptions.both,
+						'&-is-selected':
+							eligibility === EligibilityOptions.right ||
+							eligibility === EligibilityOptions.both,
 					})}
-					d='M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z'
+					d='M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z'
 				/>
 			</g>
 		</Icon>
 	);
 };
 
-EligibilityIcon.displayName = 'EligibilityIcon',
-EligibilityIcon.peek = {
-	description: `
+(EligibilityIcon.displayName = 'EligibilityIcon'),
+	(EligibilityIcon.peek = {
+		description: `
 		An eligibility icon.
 	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+		categories: ['visual design', 'icons'],
+		extend: 'Icon',
+		madeFrom: ['Icon'],
+	});
 EligibilityIcon.propTypes = {
 	...Icon.propTypes,
 	eligibility: oneOf(_.values(EligibilityOptions))`

--- a/src/components/Icon/EligibilityIcon/EligibilityIcon.tsx
+++ b/src/components/Icon/EligibilityIcon/EligibilityIcon.tsx
@@ -58,15 +58,15 @@ const EligibilityIcon: FC<IEligibilityIconProps> = ({
 	);
 };
 
-(EligibilityIcon.displayName = 'EligibilityIcon'),
-	(EligibilityIcon.peek = {
-		description: `
+EligibilityIcon.displayName = 'EligibilityIcon';
+EligibilityIcon.peek = {
+	description: `
 		An eligibility icon.
 	`,
-		categories: ['visual design', 'icons'],
-		extend: 'Icon',
-		madeFrom: ['Icon'],
-	});
+	categories: ['visual design', 'icons'],
+	extend: 'Icon',
+	madeFrom: ['Icon'],
+};
 EligibilityIcon.propTypes = {
 	...Icon.propTypes,
 	eligibility: oneOf(_.values(EligibilityOptions))`

--- a/src/components/Icon/EligibilityIcon/__snapshots__/EligibilityIcon.spec.jsx.snap
+++ b/src/components/Icon/EligibilityIcon/__snapshots__/EligibilityIcon.spec.jsx.snap
@@ -7,11 +7,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -24,11 +24,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -41,11 +41,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -58,11 +58,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -75,11 +75,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -93,11 +93,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -111,11 +111,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -129,11 +129,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -147,11 +147,11 @@ exports[`EligibilityIcon [common] example testing should match snapshot(s) for 1
   <g>
     <path
       className="lucid-EligibilityIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityIcon-half-circle lucid-EligibilityIcon-is-selected"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>

--- a/src/components/Icon/EligibilityLightIcon/EligibilityLightIcon.tsx
+++ b/src/components/Icon/EligibilityLightIcon/EligibilityLightIcon.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import PropTypes from 'react-peek/prop-types'
+import PropTypes from 'react-peek/prop-types';
 import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
 import { FC, omitProps } from '../../../util/component-types';
@@ -26,10 +26,14 @@ const EligibilityLightIcon: FC<IEligibilityLightIconProps> = ({
 	isDisabled = false,
 	...passThroughs
 }): React.ReactElement => {
-
 	return (
 		<Icon
-			{...omitProps(passThroughs, undefined, _.keys(EligibilityLightIcon.propTypes), false)}
+			{...omitProps(
+				passThroughs,
+				undefined,
+				_.keys(EligibilityLightIcon.propTypes),
+				false
+			)}
 			{..._.pick(passThroughs, _.keys(Icon.propTypes))}
 			isDisabled={isDisabled}
 			className={cx('&', className)}
@@ -37,17 +41,21 @@ const EligibilityLightIcon: FC<IEligibilityLightIconProps> = ({
 			<g>
 				<path
 					className={cx('&-half-circle', {
-						'&-is-selected': eligibility === EligibilityOptions.left || eligibility === EligibilityOptions.both,
+						'&-is-selected':
+							eligibility === EligibilityOptions.left ||
+							eligibility === EligibilityOptions.both,
 						'&-half-circle-is-disabled': isDisabled,
 					})}
-					d='M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z'
+					d='M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z'
 				/>
 				<path
 					className={cx('&-half-circle', {
-						'&-is-selected': eligibility === EligibilityOptions.right || eligibility === EligibilityOptions.both,
+						'&-is-selected':
+							eligibility === EligibilityOptions.right ||
+							eligibility === EligibilityOptions.both,
 						'&-half-circle-is-disabled': isDisabled,
 					})}
-					d='M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z'
+					d='M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z'
 				/>
 			</g>
 		</Icon>

--- a/src/components/Icon/EligibilityLightIcon/__snapshots__/EligibilityLightIcon.spec.jsx.snap
+++ b/src/components/Icon/EligibilityLightIcon/__snapshots__/EligibilityLightIcon.spec.jsx.snap
@@ -8,11 +8,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -26,11 +26,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -44,11 +44,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -62,11 +62,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -80,11 +80,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -98,11 +98,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -116,11 +116,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -134,11 +134,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>
@@ -152,11 +152,11 @@ exports[`EligibilityLightIcon [common] example testing should match snapshot(s) 
   <g>
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M6.98.928C3.51 1.424.844 4.398.844 8c0 3.604 2.666 6.576 6.133 7.072V.928z"
+      d="M6 14.71A7.003 7.003 0 0 1 6 1.29v13.42z"
     />
     <path
       className="lucid-EligibilityLightIcon-half-circle lucid-EligibilityLightIcon-is-selected lucid-EligibilityLightIcon-half-circle-is-disabled"
-      d="M9.022.928c3.465.496 6.133 3.47 6.133 7.072 0 3.604-2.668 6.576-6.133 7.072V.928z"
+      d="M10 1.29a7.003 7.003 0 0 1 0 13.42V1.29z"
     />
   </g>
 </Icon>


### PR DESCRIPTION
## PR Checklist
![image](https://user-images.githubusercontent.com/3290587/64999864-365ce200-d89e-11e9-99c4-923d80af83a0.png)
![image](https://user-images.githubusercontent.com/3290587/64999872-3a88ff80-d89e-11e9-9b5d-1d2903955030.png)

- Manually tested across supported browsers
  - ~Chrome~
  - [ ] Firefox
  - ~Safari~
  - ~Edge (Win 10)~
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
