### PR TITLE
Selection should maintain the order of children passed in. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lucid-ui",
-  "version": "5.1.0",
+  "version": "5.1.1-beta0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucid-ui",
-  "version": "5.1.0",
+  "version": "5.1.1-beta0",
   "description": "A UI component library from AppNexus.",
   "main": "dist/index.js",
   "module": "lib/index.js",

--- a/src/components/Selection/Selection.jsx
+++ b/src/components/Selection/Selection.jsx
@@ -11,8 +11,6 @@ import {
 	createClass,
 	omitProps,
 	getFirst,
-	filterTypes,
-	rejectTypes,
 } from '../../util/component-types';
 
 const { createElement } = React;
@@ -163,8 +161,6 @@ const Selection = createClass({
 		const responsiveMode = responsiveMap[responsiveModeInput];
 		const isSmall = responsiveMode === 'small';
 
-		const selectionChildren = filterTypes(children, Selection);
-		const otherChildren = rejectTypes(children, Selection);
 		const labelProps = _.get(
 			getFirst(this.props, Selection.Label),
 			'props',
@@ -217,24 +213,27 @@ const Selection = createClass({
 							/>
 						) : null}
 					</div>
-
-					{_.isEmpty(selectionChildren) ? null : (
+					{!_.isEmpty(children) &&
 						<div className={cx('&-children-container')}>
-							{_.map(selectionChildren, ({ props }, i) => (
-								<Selection
-									key={
-										_.get(
-											getFirst(props, Selection.Label),
-											['props', 'children'],
-											{}
-										) + i
-									}
-									{...props}
-								/>
-							))}
+							{_.map(children, (child, i) => {
+								if (React.isValidElement(child) && child.type === Selection) {
+									return (
+										<Selection
+											key={
+												_.get(
+													getFirst(child.props, Selection.Label),
+													['props', 'children'],
+													{}
+												) + i
+											}
+											{...child.props}
+										/>
+									);
+								}
+								return child;
+							})}
 						</div>
-					)}
-					{otherChildren}
+					}
 				</div>
 			</div>
 		);

--- a/src/components/Selection/Selection.jsx
+++ b/src/components/Selection/Selection.jsx
@@ -215,7 +215,7 @@ const Selection = createClass({
 					</div>
 					{!_.isEmpty(children) &&
 						<div className={cx('&-children-container')}>
-							{_.map(children, (child, i) => {
+							{_.map(React.Children.toArray(children), (child, i) => {
 								if (React.isValidElement(child) && child.type === Selection) {
 									return (
 										<Selection

--- a/src/components/Selection/__snapshots__/Selection.spec.jsx.snap
+++ b/src/components/Selection/__snapshots__/Selection.spec.jsx.snap
@@ -20,7 +20,14 @@ exports[`Selection render should match snapshot for container 1`] = `
         size={8}
       />
     </div>
-    cont
+    <div
+      className="lucid-Selection-children-container"
+    >
+      c
+      o
+      n
+      t
+    </div>
   </div>
 </div>
 `;
@@ -48,13 +55,14 @@ exports[`Selection render should match snapshot for custom icons 1`] = `
         size={8}
       />
     </div>
-    <Selection.Icon
-      key=".0"
+    <div
+      className="lucid-Selection-children-container"
     >
-      <div
-        className="fake-icon"
-      />
-    </Selection.Icon>
+      <Component />
+      <Component />
+      <Component />
+      <Component />
+    </div>
   </div>
 </div>
 `;
@@ -82,7 +90,14 @@ exports[`Selection render should match snapshot for danger 1`] = `
         size={8}
       />
     </div>
-    cont
+    <div
+      className="lucid-Selection-children-container"
+    >
+      c
+      o
+      n
+      t
+    </div>
   </div>
 </div>
 `;
@@ -110,7 +125,14 @@ exports[`Selection render should match snapshot for info 1`] = `
         size={8}
       />
     </div>
-    cont
+    <div
+      className="lucid-Selection-children-container"
+    >
+      c
+      o
+      n
+      t
+    </div>
   </div>
 </div>
 `;
@@ -138,11 +160,12 @@ exports[`Selection render should match snapshot for nested selections 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
+      Hello
       <Selection
         hasBackground={false}
         isBold={false}
         isRemovable={true}
-        key="[object Object]0"
+        key="[object Object]1"
         kind="default"
         onRemove={[Function]}
         responsiveMode="large"
@@ -150,7 +173,6 @@ exports[`Selection render should match snapshot for nested selections 1`] = `
         There
       </Selection>
     </div>
-    Hello
   </div>
 </div>
 `;
@@ -193,7 +215,14 @@ exports[`Selection render should match snapshot for responsiveMode small 1`] = `
         size={16}
       />
     </div>
-    Yolo
+    <div
+      className="lucid-Selection-children-container"
+    >
+      Y
+      o
+      l
+      o
+    </div>
   </div>
 </div>
 `;
@@ -221,7 +250,14 @@ exports[`Selection render should match snapshot for success 1`] = `
         size={8}
       />
     </div>
-    cont
+    <div
+      className="lucid-Selection-children-container"
+    >
+      c
+      o
+      n
+      t
+    </div>
   </div>
 </div>
 `;
@@ -249,7 +285,14 @@ exports[`Selection render should match snapshot for warning 1`] = `
         size={8}
       />
     </div>
-    cont
+    <div
+      className="lucid-Selection-children-container"
+    >
+      c
+      o
+      n
+      t
+    </div>
   </div>
 </div>
 `;

--- a/src/components/Selection/__snapshots__/Selection.spec.jsx.snap
+++ b/src/components/Selection/__snapshots__/Selection.spec.jsx.snap
@@ -23,10 +23,7 @@ exports[`Selection render should match snapshot for container 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
-      c
-      o
-      n
-      t
+      cont
     </div>
   </div>
 </div>
@@ -58,10 +55,13 @@ exports[`Selection render should match snapshot for custom icons 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
-      <Component />
-      <Component />
-      <Component />
-      <Component />
+      <Selection.Icon
+        key=".0"
+      >
+        <div
+          className="fake-icon"
+        />
+      </Selection.Icon>
     </div>
   </div>
 </div>
@@ -93,10 +93,7 @@ exports[`Selection render should match snapshot for danger 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
-      c
-      o
-      n
-      t
+      cont
     </div>
   </div>
 </div>
@@ -128,10 +125,7 @@ exports[`Selection render should match snapshot for info 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
-      c
-      o
-      n
-      t
+      cont
     </div>
   </div>
 </div>
@@ -218,10 +212,7 @@ exports[`Selection render should match snapshot for responsiveMode small 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
-      Y
-      o
-      l
-      o
+      Yolo
     </div>
   </div>
 </div>
@@ -253,10 +244,7 @@ exports[`Selection render should match snapshot for success 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
-      c
-      o
-      n
-      t
+      cont
     </div>
   </div>
 </div>
@@ -288,10 +276,7 @@ exports[`Selection render should match snapshot for warning 1`] = `
     <div
       className="lucid-Selection-children-container"
     >
-      c
-      o
-      n
-      t
+      cont
     </div>
   </div>
 </div>


### PR DESCRIPTION
 Passing nested children is the intended use-case, but if a consumer wants to to pass other children for special styling we shouldn't jumble up the order of the children on them.

I could put this change behind a prop flag, but I really feel like it's bug fix more than a breaking change.

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
