### PR TITLE
set OverlayWrapper z-index to zindex-modal

### DIFF
--- a/src/components/OverlayWrapper/OverlayWrapper.less
+++ b/src/components/OverlayWrapper/OverlayWrapper.less
@@ -22,7 +22,7 @@
 
 	&-has-overlay {
 		background-color: @color-transparent-gray-60;
-		z-index: 1;
+		z-index: @zindex-modal;
 	}
 
 	&-kind-light {


### PR DESCRIPTION
Set z-index for `OverlayWrapper` to `@zindex-modal` so it is consistent with `Dialog` and `Overlay`.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
