### PR TITLE
set padding-right on SearchField

### DIFF
--- a/src/components/SearchField/SearchField.less
+++ b/src/components/SearchField/SearchField.less
@@ -5,6 +5,7 @@
 	position: relative;
 
 	.@{prefix}-TextField {
+		padding-right: 28px;
 		border-radius: @size-standard-height / 2;
 		color: @color-neutral-9;
 

--- a/src/components/TextField/TextField.less
+++ b/src/components/TextField/TextField.less
@@ -18,8 +18,6 @@
 
 	&:focus {
 		border: @size-borderWidthFocused solid @color-primary;
-		padding-left: @size-S;
-		padding-right: @size-S;
 		outline: none;
 		border-color: @color-primary;
 	}


### PR DESCRIPTION
## Problem:

search texts overlaps the search icon on the `SearchField` component

![Screen Shot 2019-09-27 at 12 58 03 PM](https://user-images.githubusercontent.com/648/65799377-d7625d00-e128-11e9-8457-81e0f1caa415.png)

## Solution:

add a padding-right to the input

![Screen Shot 2019-09-27 at 1 13 42 PM](https://user-images.githubusercontent.com/648/65799423-f103a480-e128-11e9-9dec-6cc9f2c9ad37.png)
