### PR TITLE
onClick is still triggered when a disabled  IconSelect item is clicked

### DIFF
--- a/src/components/IconSelect/IconSelect.tsx
+++ b/src/components/IconSelect/IconSelect.tsx
@@ -163,20 +163,20 @@ const IconSelect: FC<IIconSelectProps> = (props): React.ReactElement => {
 			{_.map(
 				items,
 				(childItem, index): React.ReactElement => {
+					const itemDisabled = isDisabled || childItem.isDisabled;
 					return (
 						<figure
 							key={`iconselectitem_${index}`}
 							className={cx('&-Item', childItem.className, {
 								[`${className}-Item`]: className,
-								'&-Item-is-disabled': isDisabled || childItem.isDisabled,
+								'&-Item-is-disabled': itemDisabled,
 								'&-Item-is-partial': childItem.isPartial,
 								'&-Item-is-selected': childItem.isSelected,
 								'&-Item-multi': kind === 'multiple',
 								'&-Item-single': kind === 'single',
 							})}
 							data-id={childItem.id}
-							onClick={handleClick}
-							// disabled={isDisabled || childItem.isDisabled}
+							onClick={itemDisabled ? undefined : handleClick}
 						>
 							{childItem.icon && getChildIcon(childItem.icon)}
 							<figcaption className={cx('&-Item-figcaption')}>

--- a/src/components/IconSelect/__snapshots__/IconSelect.spec.js.snap
+++ b/src/components/IconSelect/__snapshots__/IconSelect.spec.js.snap
@@ -147,7 +147,6 @@ exports[`IconSelect [common] example testing should match snapshot(s) for 4.disa
     className="lucid-IconSelect-Item lucid-IconSelect-Item-is-disabled lucid-IconSelect-Item-multi"
     data-id="item1"
     key="iconselectitem_0"
-    onClick={[Function]}
   >
     <ClockIcon />
     <figcaption
@@ -167,7 +166,6 @@ exports[`IconSelect [common] example testing should match snapshot(s) for 4.disa
     className="lucid-IconSelect-Item lucid-IconSelect-Item-is-disabled lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-multi"
     data-id="item2"
     key="iconselectitem_1"
-    onClick={[Function]}
   >
     <ClockIcon />
     <figcaption


### PR DESCRIPTION
when an item is marked as disabled (`isDisabled` on the item), you can still click on it to trigger the select event.

Instead, if an item is disabled, use `undefined` for `onClick`.