### PR TITLE
Fix redux util regression where `identity` was set to `noop`

### DIFF
--- a/src/util/redux.spec.js
+++ b/src/util/redux.spec.js
@@ -128,6 +128,18 @@ describe('redux utils', () => {
 					assert.equal(viewState.foo.uppercase, 'FOO', 'must equal "FOO"');
 				});
 
+				it('should pass state through unharmed if selectors are undefined', () => {
+					const {
+						connectors: [mapStateToProps],
+					} = getReduxPrimitives({
+						reducers,
+						initialState,
+					});
+
+					const viewState = mapStateToProps(initialState);
+					assert.deepEqual(viewState, initialState);
+				});
+
 				describe('rootPath', () => {
 					const {
 						connectors: [mapStateToProps],

--- a/src/util/redux.ts
+++ b/src/util/redux.ts
@@ -71,7 +71,7 @@ Components should have an \`initialState\` property or a \`getDefaultProps\` def
 	let dispatchTree: object;
 
 	const reducer = createReduxReducer(reducers, initialState, rootPath);
-	const selector = selectors ? reduceSelectors(selectors) : _.noop;
+	const selector = selectors ? reduceSelectors(selectors) : _.identity;
 	const rootPathSelector = (state: object) =>
 		_.isEmpty(rootPath) ? state : _.get(state, rootPath);
 


### PR DESCRIPTION
## PR Checklist

- ~Manually tested across supported browsers~
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
