### PR TITLE
Improved warning icon path to handle smaller sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22965,12 +22965,6 @@
         "mime-types": "~2.1.24"
       }
     },
-    "type-zoo": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/type-zoo/-/type-zoo-3.4.1.tgz",
-      "integrity": "sha512-jwdBsJmFK9QJdD5Hb0ovFYl5Kz8SLfzNiNmPNRZYA+B9O22MiQma2qG39JBap/FSDWuPUJP9ISlf7kV8h82+FA==",
-      "dev": true
-    },
     "typed-styles": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",

--- a/src/components/Icon/WarningIcon/WarningIcon.tsx
+++ b/src/components/Icon/WarningIcon/WarningIcon.tsx
@@ -33,7 +33,7 @@ const WarningIcon: FC<IWarningIconProps> = ({
 			)}
 		>
 			<path className={cx('&-background')} d='M.5 15h15L8 .5z' />
-			<path className={cx('&-mark')} d='M7.99 6v4' />
+			<path className={cx('&-mark')} d='M7.99 5v4' />
 			<circle className={cx('&-mark')} cx='7.99' cy='12' r='.293' />
 		</Icon>
 	);

--- a/src/components/Icon/WarningIcon/__snapshots__/WarningIcon.spec.jsx.snap
+++ b/src/components/Icon/WarningIcon/__snapshots__/WarningIcon.spec.jsx.snap
@@ -18,7 +18,7 @@ exports[`WarningIcon [common] example testing should match snapshot(s) for 1.def
   />
   <path
     className="lucid-WarningIcon-mark"
-    d="M7.99 6v4"
+    d="M7.99 5v4"
   />
   <circle
     className="lucid-WarningIcon-mark"

--- a/src/components/Icon/WarningLightIcon/WarningLightIcon.tsx
+++ b/src/components/Icon/WarningLightIcon/WarningLightIcon.tsx
@@ -33,7 +33,7 @@ const WarningLightIcon: FC<IWarningLightIconProps> = ({
 			)}
 		>
 			<path className={cx('&-background')} d='M.5 15h15L8 .5z' />
-			<path className={cx('&-mark')} d='M7.99 6v4' />
+			<path className={cx('&-mark')} d='M7.99 5v4' />
 			<circle className={cx('&-mark')} cx='7.99' cy='12' r='.293' />
 		</Icon>
 	);

--- a/src/components/Icon/WarningLightIcon/__snapshots__/WarningLightIcon.spec.jsx.snap
+++ b/src/components/Icon/WarningLightIcon/__snapshots__/WarningLightIcon.spec.jsx.snap
@@ -18,7 +18,7 @@ exports[`WarningLightIcon [common] example testing should match snapshot(s) for 
   />
   <path
     className="lucid-WarningLightIcon-mark"
-    d="M7.99 6v4"
+    d="M7.99 5v4"
   />
   <circle
     className="lucid-WarningLightIcon-mark"


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] ~Edge (Win 10)~
- [ ] ~Unit tests written (`common` at minimum)~
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
