### PR TITLE
Docs consistent props order

### DIFF
--- a/.storybook/lucid-docs-addon/util.js
+++ b/.storybook/lucid-docs-addon/util.js
@@ -30,9 +30,15 @@ export const formatSource = source =>
 // then falls back on propTypes for non-TS components
 // in addition, it handles setting default values based on defaultProps
 export const getPropDefs = component =>
-	_.has(component, '__docgenInfo')
-		? getPropsFromDocgen(component)
-		: getPropsFromPropTypes(component);
+	_.sortBy(
+		_.sortBy(
+			_.has(component, '__docgenInfo')
+				? getPropsFromDocgen(component)
+				: getPropsFromPropTypes(component),
+			prop => prop.name
+		),
+		prop => !prop.required
+	);
 
 const getPropsFromDocgen = component =>
 	_.map(

--- a/.storybook/lucid-docs-addon/util.js
+++ b/.storybook/lucid-docs-addon/util.js
@@ -73,7 +73,7 @@ const mergePropwithDefaults = (
 	return {
 		name,
 		type,
-		required: required && _.isNil(defaultValueValue),
+		required: required && _.isUndefined(defaultValueValue),
 		description,
 		defaultValue: defaultValueValue,
 	};


### PR DESCRIPTION
This PR creates a consistent props table order in docs pages.   There will be three groups -- required props, child components, and the rest of the props.  Each group will be sorted alphabetically.

This PR also fixes a bug where `null` default props were not shown in the the props table.

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
