### PR TITLE
adjust hover colors for SuccessLightIcon and MinusCircleLightIcon

### DIFF
--- a/src/components/Icon/MinusCircleIcon/MinusCircleIcon.less
+++ b/src/components/Icon/MinusCircleIcon/MinusCircleIcon.less
@@ -14,7 +14,7 @@
 	}
 
 	&-is-clickable:not(&-is-disabled):hover &-background {
-		stroke: shade(@color-secondary-1, 20%);
-		fill: shade(@color-secondary-1, 20%);
+		stroke: @color-secondary-1-hover;
+		fill: @color-secondary-1-hover;
 	}
 }

--- a/src/components/Icon/MinusCircleLightIcon/MinusCircleLightIcon.less
+++ b/src/components/Icon/MinusCircleLightIcon/MinusCircleLightIcon.less
@@ -5,7 +5,7 @@
 	stroke: @color-secondary-1;
 
 	&-is-clickable:not(&-is-disabled):hover &-dash,
-	&-is-active:hover &-dash {
+	&-is-active &-dash {
 		stroke: @color-white;
 	}
 
@@ -13,8 +13,13 @@
 		stroke: @color-secondary-1;
 	}
 
+	&-is-clickable&-is-active:not(&-is-disabled):hover &-background {
+		fill: @color-secondary-1-hover;
+		stroke: @color-secondary-1-hover;
+	}
+
 	&-is-clickable:not(&-is-disabled):hover &-background,
-	&-is-active:hover &-background {
+	&-is-active &-background {
 		stroke: @color-secondary-1;
 		fill: @color-secondary-1;
 	}

--- a/src/components/Icon/MinusCircleLightIcon/MinusCircleLightIcon.less
+++ b/src/components/Icon/MinusCircleLightIcon/MinusCircleLightIcon.less
@@ -5,7 +5,7 @@
 	stroke: @color-secondary-1;
 
 	&-is-clickable:not(&-is-disabled):hover &-dash,
-	&-is-active &-dash {
+	&-is-active:hover &-dash {
 		stroke: @color-white;
 	}
 
@@ -14,9 +14,8 @@
 	}
 
 	&-is-clickable:not(&-is-disabled):hover &-background,
-	&-is-active &-background {
-		stroke: shade(@color-secondary-1, 20%);
-		fill: shade(@color-secondary-1, 20%);
+	&-is-active:hover &-background {
+		stroke: @color-secondary-1;
+		fill: @color-secondary-1;
 	}
 }
-

--- a/src/components/Icon/MinusCircleLightIcon/__snapshots__/MinusCircleLightIcon.spec.jsx.snap
+++ b/src/components/Icon/MinusCircleLightIcon/__snapshots__/MinusCircleLightIcon.spec.jsx.snap
@@ -149,3 +149,28 @@ exports[`MinusCircleLightIcon [common] example testing should match snapshot(s) 
   />
 </Icon>
 `;
+
+exports[`MinusCircleLightIcon [common] example testing should match snapshot(s) for 1.default 7`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-MinusCircleLightIcon lucid-MinusCircleLightIcon-is-clickable lucid-MinusCircleLightIcon-is-active"
+  color="primary"
+  isClickable={true}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-MinusCircleLightIcon-background"
+    cx="8"
+    cy="8"
+    r="7.5"
+  />
+  <path
+    className="lucid-MinusCircleLightIcon-dash"
+    d="M4.5 8h7"
+  />
+</Icon>
+`;

--- a/src/components/Icon/MinusCircleLightIcon/examples/1.default.jsx
+++ b/src/components/Icon/MinusCircleLightIcon/examples/1.default.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MinusCircleLightIcon } from '../../../../index';
 
-export default () => (
-	<>
-		<MinusCircleLightIcon />
-		<MinusCircleLightIcon isClickable />
-		<MinusCircleLightIcon isClickable isDisabled />
-		<MinusCircleLightIcon isActive />
-		<MinusCircleLightIcon isClickable isActive />
-		<MinusCircleLightIcon isClickable isActive isDisabled />
-	</>
-);
+export default () => {
+	const [iconIsActive, setIconIsActive] = useState(true);
+	return (
+		<>
+			<MinusCircleLightIcon />
+			<MinusCircleLightIcon isClickable />
+			<MinusCircleLightIcon isClickable isDisabled />
+			<MinusCircleLightIcon isActive />
+			<MinusCircleLightIcon isClickable isActive />
+			<MinusCircleLightIcon isClickable isActive isDisabled />
+			<MinusCircleLightIcon
+				onClick={() => setIconIsActive(!iconIsActive)}
+				isClickable
+				isActive={iconIsActive}
+			/>
+		</>
+	);
+};

--- a/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
+++ b/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
@@ -5,14 +5,13 @@
 	stroke: @featured-color-success;
 
 	&-is-clickable:not(&-is-disabled):hover &-background,
-	&-is-active &-background {
-		stroke: @featured-color-success-colorHover;
-		fill: @featured-color-success-colorHover;
+	&-is-active:hover &-background {
+		stroke: @featured-color-success;
+		fill: @featured-color-success;
 	}
 
 	&-is-clickable:not(&-is-disabled):hover &-check,
-	&-is-active &-check {
+	&-is-active:hover &-check {
 		stroke: @color-white;
 	}
 }
-

--- a/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
+++ b/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
@@ -5,13 +5,18 @@
 	stroke: @featured-color-success;
 
 	&-is-clickable:not(&-is-disabled):hover &-background,
-	&-is-active:hover &-background {
+	&-is-active &-background {
 		stroke: @featured-color-success;
 		fill: @featured-color-success;
 	}
 
+	&-is-active:not(&-is-disabled):hover &-background {
+		fill: @featured-color-success-colorHover;
+		stroke: @featured-color-success-colorHover;
+	}
+
 	&-is-clickable:not(&-is-disabled):hover &-check,
-	&-is-active:hover &-check {
+	&-is-active &-check {
 		stroke: @color-white;
 	}
 }

--- a/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
+++ b/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
@@ -10,7 +10,7 @@
 		fill: @featured-color-success;
 	}
 
-	&-is-active:not(&-is-disabled):hover &-background {
+	&-is-clickable&-is-active:not(&-is-disabled):hover &-background {
 		fill: @featured-color-success-colorHover;
 		stroke: @featured-color-success-colorHover;
 	}

--- a/src/components/Icon/SuccessLightIcon/__snapshots__/SuccessLightIcon.spec.jsx.snap
+++ b/src/components/Icon/SuccessLightIcon/__snapshots__/SuccessLightIcon.spec.jsx.snap
@@ -103,6 +103,31 @@ exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 
 exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 1.default 5`] = `
 <Icon
   aspectRatio="xMidYMid meet"
+  className="lucid-SuccessLightIcon lucid-SuccessLightIcon-is-disabled"
+  color="primary"
+  isClickable={false}
+  isDisabled={true}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-SuccessLightIcon-background"
+    cx="8"
+    cy="8"
+    r="7.5"
+  />
+  <path
+    className="lucid-SuccessLightIcon-check"
+    d="M4.5 8L7 10.5 11.5 6"
+  />
+</Icon>
+`;
+
+exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 1.default 6`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
   className="lucid-SuccessLightIcon lucid-SuccessLightIcon-is-clickable lucid-SuccessLightIcon-is-active"
   color="primary"
   isClickable={true}
@@ -125,13 +150,38 @@ exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 
 </Icon>
 `;
 
-exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 1.default 6`] = `
+exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 1.default 7`] = `
 <Icon
   aspectRatio="xMidYMid meet"
   className="lucid-SuccessLightIcon lucid-SuccessLightIcon-is-disabled lucid-SuccessLightIcon-is-clickable lucid-SuccessLightIcon-is-active"
   color="primary"
   isClickable={true}
   isDisabled={true}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-SuccessLightIcon-background"
+    cx="8"
+    cy="8"
+    r="7.5"
+  />
+  <path
+    className="lucid-SuccessLightIcon-check"
+    d="M4.5 8L7 10.5 11.5 6"
+  />
+</Icon>
+`;
+
+exports[`SuccessLightIcon [common] example testing should match snapshot(s) for 1.default 8`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-SuccessLightIcon lucid-SuccessLightIcon-is-clickable lucid-SuccessLightIcon-is-active"
+  color="primary"
+  isClickable={true}
+  isDisabled={false}
   onClick={[Function]}
   onSelect={[Function]}
   size={16}

--- a/src/components/Icon/SuccessLightIcon/examples/1.default.jsx
+++ b/src/components/Icon/SuccessLightIcon/examples/1.default.jsx
@@ -1,13 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { SuccessLightIcon } from '../../../../index';
 
-export default () => (
-	<>
-		<SuccessLightIcon />
-		<SuccessLightIcon isClickable />
-		<SuccessLightIcon isClickable isDisabled />
-		<SuccessLightIcon isActive />
-		<SuccessLightIcon isClickable isActive />
-		<SuccessLightIcon isClickable isActive isDisabled />
-	</>
-);
+export default () => {
+	const [iconIsActive, setIconIsActive] = useState(true);
+	return (
+		<>
+			<SuccessLightIcon />
+			<SuccessLightIcon isClickable />
+			<SuccessLightIcon isClickable isDisabled />
+			<SuccessLightIcon isActive />
+			<SuccessLightIcon isDisabled />
+			<SuccessLightIcon isClickable isActive />
+			<SuccessLightIcon isClickable isActive isDisabled />
+			<SuccessLightIcon
+				onClick={() => setIconIsActive(!iconIsActive)}
+				isClickable
+				isActive={iconIsActive}
+			/>
+		</>
+	);
+};

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -20,16 +20,16 @@
 // 600    | Inter           | italic
 
 @fontSize: 12px;
-@fontFamily: GalanoGrotesque, "Helvetica Neue", Helvetica, Arial, sans-serif;
-@font-family-tabular: Inter, "Helvetica Neue", Helvetica, Arial, sans-serif;
+@fontFamily: GalanoGrotesque, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+@font-family-tabular: Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif;
 @font-feature-settings-tabular: 'tnum' 1;
 @font: @fontSize @fontFamily;
 @font-chart: 11px sans-serif;
 
 // Our designers have agreed to keep the number of font weight variants to
 // what's outlined in these variables.
-@font-weight-regular: 400;  // Available with GalanoGrotesque and Inter
-@font-weight-medium: 500;   // Available with GalanoGrotesque
+@font-weight-regular: 400; // Available with GalanoGrotesque and Inter
+@font-weight-medium: 500; // Available with GalanoGrotesque
 @font-weight-semiBold: 600; // Available with GalanoGrotesque and Inter
 
 // -----------------------------------------------------------------------------
@@ -94,7 +94,12 @@
 // General colors
 @color-white: #fff;
 @color-black: #000;
-@color-transparent: rgba(255, 255, 255, 0); // normalize transparent due to Safari bug
+@color-transparent: rgba(
+	255,
+	255,
+	255,
+	0
+); // normalize transparent due to Safari bug
 
 // Primary colors
 @color-primary: #587eba;
@@ -111,7 +116,7 @@
 @color-secondary-4: #49b27b; // green
 @color-secondary-5: #00bebe; // teal
 
-@color-secondary-1-hover: shade(@color-secondary-1, 35%);
+@color-secondary-1-hover: shade(@color-secondary-1, 20%);
 
 //neutral colors
 @color-neutral-1: #fff;
@@ -244,53 +249,21 @@
 // counterparts in sync.
 
 // This list should always be in sync with the full set of chart colors
-@color-chart-variables:
-	color-chart-0,
-	color-chart-0-lightest,
-	color-chart-0-light,
-	color-chart-0-dark,
-	color-chart-0-darkest,
-	color-chart-1,
-	color-chart-1-lightest,
-	color-chart-1-light,
-	color-chart-1-dark,
-	color-chart-1-darkest,
-	color-chart-2,
-	color-chart-2-lightest,
-	color-chart-2-light,
-	color-chart-2-dark,
-	color-chart-2-darkest,
-	color-chart-3,
-	color-chart-3-lightest,
-	color-chart-3-light,
-	color-chart-3-dark,
-	color-chart-3-darkest,
-	color-chart-4,
-	color-chart-4-lightest,
-	color-chart-4-light,
-	color-chart-4-dark,
-	color-chart-4-darkest,
-	color-chart-5,
-	color-chart-5-lightest,
-	color-chart-5-light,
-	color-chart-5-dark,
-	color-chart-5-darkest,
-	color-chart-6,
-	color-chart-6-lightest,
-	color-chart-6-light,
-	color-chart-6-dark,
-	color-chart-6-darkest,
-	color-chart-good,
-	color-chart-good-lightest,
-	color-chart-good-light,
-	color-chart-good-dark,
-	color-chart-good-darkest,
-	color-chart-bad,
-	color-chart-bad-lightest,
-	color-chart-bad-light,
-	color-chart-bad-dark,
-	color-chart-bad-darkest,
-	color-chart-neutral;
+@color-chart-variables: color-chart-0, color-chart-0-lightest,
+	color-chart-0-light, color-chart-0-dark, color-chart-0-darkest, color-chart-1,
+	color-chart-1-lightest, color-chart-1-light, color-chart-1-dark,
+	color-chart-1-darkest, color-chart-2, color-chart-2-lightest,
+	color-chart-2-light, color-chart-2-dark, color-chart-2-darkest, color-chart-3,
+	color-chart-3-lightest, color-chart-3-light, color-chart-3-dark,
+	color-chart-3-darkest, color-chart-4, color-chart-4-lightest,
+	color-chart-4-light, color-chart-4-dark, color-chart-4-darkest, color-chart-5,
+	color-chart-5-lightest, color-chart-5-light, color-chart-5-dark,
+	color-chart-5-darkest, color-chart-6, color-chart-6-lightest,
+	color-chart-6-light, color-chart-6-dark, color-chart-6-darkest,
+	color-chart-good, color-chart-good-lightest, color-chart-good-light,
+	color-chart-good-dark, color-chart-good-darkest, color-chart-bad,
+	color-chart-bad-lightest, color-chart-bad-light, color-chart-bad-dark,
+	color-chart-bad-darkest, color-chart-neutral;
 
 @color-chart-0: @color-secondary-2;
 @color-chart-0-lightest: tint(@color-chart-0, 90%);
@@ -354,14 +327,15 @@
 // Borders
 // -----------------------------------------------------------------------------
 
-@border-standardBorder: @size-borderWidth solid @featured-color-default-borderColor;
+@border-standardBorder: @size-borderWidth solid
+	@featured-color-default-borderColor;
 @border-lightBorder: @size-borderWidth solid @color-borderColorLight;
 
 // -----------------------------------------------------------------------------
 // Patterns
 // -----------------------------------------------------------------------------
 
-@pattern-diagonal-striped: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0IiBoZWlnaHQ9IjQiPgo8cGF0aCBkPSJNLTEgNUw1IC0xWk01IDNMMyA1Wk0tMSAxTDEgLTEiIHN0cm9rZT0iI2UzZTNlMyIgc3Ryb2tlLXdpZHRoPSIxIj48L3BhdGg+Cjwvc3ZnPg==");
+@pattern-diagonal-striped: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0IiBoZWlnaHQ9IjQiPgo8cGF0aCBkPSJNLTEgNUw1IC0xWk01IDNMMyA1Wk0tMSAxTDEgLTEiIHN0cm9rZT0iI2UzZTNlMyIgc3Ryb2tlLXdpZHRoPSIxIj48L3BhdGg+Cjwvc3ZnPg==');
 
 @opacity-hover: 0.8;
 @opacity-disabled: 0.35;


### PR DESCRIPTION
Xandr employees can preview changes [here](https://docspot.adnxs.net/projects/lucid/light-icon-hover/?path=/docs/icons-icons-successlighticon--default)

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
