### PR TITLE
Add the less file back as an entrypoint for our bundle build

### DIFF
--- a/webpack.config.bundle.js
+++ b/webpack.config.bundle.js
@@ -8,7 +8,10 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
 	mode: isProduction ? 'production' : 'development',
-	entry: path.join(__dirname, 'src', 'index.ts'),
+	entry: [
+		path.join(__dirname, 'src', 'index.ts'),
+		path.join(__dirname, 'src', 'index.less'),
+	],
 	output: {
 		path: path.join(__dirname, 'dist'),
 		filename: isProduction ? 'lucid.min.js' : 'lucid.js',
@@ -44,10 +47,6 @@ module.exports = {
 	plugins: [
 		new MiniCssExtractPlugin({
 			filename: 'lucid.css',
-			disable: !isProduction,
-		}),
-		new MiniCssExtractPlugin({
-			filename: 'index.css',
 			disable: !isProduction,
 		}),
 	],


### PR DESCRIPTION
I found that we accidentally stopped building a bundled CSS file when we removed the `import ... "index.less"` a while back. This really only affects our ability to use codepen, etc.