### PR TITLE
add peek.notes property to functional component interface

### DIFF
--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -47,6 +47,11 @@ export type Overwrite<T, U> = Omit<T, keyof T & keyof U> & U;
 export interface FC<P> extends React.FC<P> {
 	peek: {
 		description: string;
+		notes?: {
+			overview: string;
+			intendedUse: string;
+			technicalRecommendations: string;
+		};
 		categories?: string[];
 		extend?: string;
 		madeFrom?: string[];


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

Allow the notes property on FCs. Class components don't need any changes right now because they extend React.Component, so we don't have any specific type checking. That should be added in a later PR once we nail down the exact class component structure for hybrid components (for example, should the `peek`info be a property on the class or part of `statics`, will also depend on whether we use the existing createClass util or start to use a different pattern, etc.)