### PR TITLE
[proposal] annotate Dialog FC prop argument

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -90,7 +90,9 @@ export interface IDialogFC extends FC<IDialogProps> {
 	Footer: FC<IDialogFooterProps>;
 }
 
-export const Dialog: IDialogFC = (props): React.ReactElement => {
+export const Dialog = (
+	props: FixDefaults<IDialogProps, typeof defaultProps>
+) => {
 	const {
 		className,
 		size,
@@ -99,7 +101,7 @@ export const Dialog: IDialogFC = (props): React.ReactElement => {
 		isShown,
 		isComplex,
 		...passThroughs
-	} = props as FixDefaults<IDialogProps, typeof defaultProps>;
+	} = props;
 
 	const headerChildProp = _.get(getFirst(props, Dialog.Header), 'props', {});
 	const footerChildProp = _.get(getFirst(props, Dialog.Footer), 'props', null);


### PR DESCRIPTION
When using lucid components in a typescript application, there are errors when using functional components that have default props.

annotating react function components are weird with typescript and defaultProps.

Instead of casting props as a type inside the function, annotate the prop argument and remove `React.FC` to get the correct prop annotation that takes `defaultProps` into account when rendering the component.

see example of `React.FC` vs annotating the prop argument.:
https://codesandbox.io/s/relaxed-cori-6cyds

typescript issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30695