### PR TITLE
Potential fix for FC type signatures

### DIFF
--- a/src/components/Dialog/Dialog.spec.jsx
+++ b/src/components/Dialog/Dialog.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { common } from '../../util/generic-tests';
+import { common, functionalComponents } from '../../util/generic-tests';
 import assert from 'assert';
 
 import Dialog from './Dialog';
@@ -13,6 +13,8 @@ describe('Dialog', () => {
 		},
 		selectRoot: wrapper => wrapper.find('.lucid-Dialog'),
 	});
+
+	functionalComponents(Dialog);
 
 	it('should pass `isModal` to underlying Overlay', () => {
 		const wrapper = shallow(<Dialog isModal={false} />);

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -8,7 +8,6 @@ import {
 	StandardProps,
 	getFirst,
 	omitProps,
-	FixDefaults,
 } from '../../util/component-types';
 import Button, { IButtonProps } from '../Button/Button';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
@@ -59,7 +58,7 @@ export interface IDialogProps extends IOverlayProps {
 	/** Size variations that only affect the width of the dialog. All the sizes
 		will grow in height until they get too big, at which point they will
 		scroll inside. */
-	size?: Size;
+	size: Size;
 
 	/** If this is truthy (if a function is provided). the close button will show.
 		The function that is called when the close button is triggered. */
@@ -73,10 +72,10 @@ export interface IDialogProps extends IOverlayProps {
 
 	/** Provides a more segregated design to organize more content in the Dialog.
 	 * @default = false */
-	isComplex?: boolean;
+	isComplex: boolean;
 
 	/** A true or false value that dictates whether or not the Body has padding. */
-	hasGutters?: boolean;
+	hasGutters: boolean;
 
 	/** *Child Element* - Header contents. Only one \`Header\` is used. */
 	Header?: string | React.ReactNode & { props: IDialogHeaderProps };
@@ -90,7 +89,7 @@ export interface IDialogFC extends FC<IDialogProps> {
 	Footer: FC<IDialogFooterProps>;
 }
 
-export const Dialog: IDialogFC = (props): React.ReactElement => {
+export const Dialog = (props: IDialogProps): React.ReactElement => {
 	const {
 		className,
 		size,
@@ -99,7 +98,7 @@ export const Dialog: IDialogFC = (props): React.ReactElement => {
 		isShown,
 		isComplex,
 		...passThroughs
-	} = props as FixDefaults<IDialogProps, typeof defaultProps>;
+	} = props;
 
 	const headerChildProp = _.get(getFirst(props, Dialog.Header), 'props', {});
 	const footerChildProp = _.get(getFirst(props, Dialog.Footer), 'props', null);

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -32,6 +32,8 @@ export interface StandardProps {
 //
 // This helper allows us to cast props used _within_ the component to consider
 // properties found on defaultProps to be required.
+//
+// TODO: `MakeDefaultsRequired` and fix usage across the library.
 export type FixDefaults<P, D extends Partial<P>> = Pick<
 	P,
 	Exclude<keyof P, keyof D>

--- a/src/util/generic-tests.jsx
+++ b/src/util/generic-tests.jsx
@@ -248,6 +248,41 @@ export function controls(
 	});
 }
 
+// Common tests for all Functional Components
+//
+// These tests are intended to help us make sure our FCs are shaped corrected.
+// They are necessary because there isn't a perfect way to get the defaultProps
+// to be factored in correctly yet with React/TypeScript:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30695#issuecomment-474780159
+export function functionalComponents(FC) {
+	// Use DOM tests here since some of our controls use dom events under the hood
+	describe('[functionalComponent]', () => {
+		it('should have the correct `peek` properties', () => {
+			expect(FC.propName === undefined || typeof FC.propName === 'string').toBe(
+				true
+			);
+			expect(
+				FC._isPrivate === undefined || typeof FC._isPrivate === 'boolean'
+			).toBe(true);
+
+			expect(typeof FC.peek).toBe('object');
+			expect(typeof FC.peek.description).toBe('string');
+			expect(
+				FC.peek.extend === undefined || typeof FC.peek.extend === 'string'
+			).toBe(true);
+			expect(
+				FC.peek.extend === undefined || typeof FC.peek.extend === 'string'
+			).toBe(true);
+			expect(
+				FC.peek.categories === undefined || Array.isArray(FC.peek.categories)
+			).toBe(true);
+			expect(
+				FC.peek.madeFrom === undefined || Array.isArray(FC.peek.madeFrom)
+			).toBe(true);
+		});
+	});
+}
+
 const NativeDate = global.Date;
 const createMockDateClass = (...args) =>
 	_.assign(


### PR DESCRIPTION
This moves the type checking for additional props we tack onto
functional components to our runtime unit tests.
