### PR TITLE
Hide from docs: DangerLightIcon, InfoLightIcon, WarningLightIcon

### DIFF
--- a/src/components/Icon/DangerLightIcon/DangerLightIcon.tsx
+++ b/src/components/Icon/DangerLightIcon/DangerLightIcon.tsx
@@ -38,9 +38,12 @@ export const DangerLightIcon: FC<IDangerLightIconProps> = ({
 	);
 };
 
+DangerLightIcon._isPrivate = true;
 DangerLightIcon.displayName = 'DangerLightIcon';
 DangerLightIcon.peek = {
 	description: `
+		DEPRECATED: this component should not be used and will be removed from the library in a future release.
+		
 		DANGER WILL ROBINSON DANGER (but lighter)
 	`,
 	categories: ['visual design', 'icons'],

--- a/src/components/Icon/InfoLightIcon/InfoLightIcon.tsx
+++ b/src/components/Icon/InfoLightIcon/InfoLightIcon.tsx
@@ -39,9 +39,12 @@ export const InfoLightIcon: FC<IInfoLightIconProps> = ({
 	);
 };
 
+InfoLightIcon._isPrivate = true;
 InfoLightIcon.displayName = 'InfoLightIcon';
 InfoLightIcon.peek = {
 	description: `
+		DEPRECATED: this component should not be used and will be removed from the library in a future release.
+		
 		A light info icon.
 	`,
 	categories: ['visual design', 'icons'],

--- a/src/components/Icon/WarningLightIcon/WarningLightIcon.tsx
+++ b/src/components/Icon/WarningLightIcon/WarningLightIcon.tsx
@@ -39,9 +39,12 @@ export const WarningLightIcon: FC<IWarningLightIconProps> = ({
 	);
 };
 
+WarningLightIcon._isPrivate = true;
 WarningLightIcon.displayName = 'WarningLightIcon';
 WarningLightIcon.peek = {
 	description: `
+		DEPRECATED: this component should not be used and will be removed from the library in a future release.
+		
 		Diet version.
 	`,
 	categories: ['visual design', 'icons'],


### PR DESCRIPTION
## PR Checklist

- Manually tested across supported browsers
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
