### PR TITLE
Avoid adding kind border styles on parent tags

### DIFF
--- a/src/components/Tag/Tag.less
+++ b/src/components/Tag/Tag.less
@@ -117,9 +117,9 @@
 	// ---------------
 	// kind props
 	// ---------------
-	@kind-colors: default @color-neutral-5, success @featured-color-success,
-		info @featured-color-info, warning @featured-color-warning,
-		danger @featured-color-danger;
+	@kind-colors: default @color-neutral-5, primary @color-primary,
+		success @featured-color-success, info @featured-color-info,
+		warning @featured-color-warning, danger @featured-color-danger;
 
 	.setLeafBorder(@kind-colors);
 

--- a/src/components/Tag/Tag.less
+++ b/src/components/Tag/Tag.less
@@ -3,7 +3,6 @@
 
 .@{prefix}-Tag {
 	.no-firefox-svg-aliasing();
-	.kind-border(0, @color-neutral-5);
 
 	background: @color-neutral-4;
 
@@ -77,7 +76,6 @@
 
 		// border
 		border-radius: @size-tag / 2;
-		.kind-border(1px, @color-neutral-5);
 
 		// margin/padding
 		// margin-right: @size-XXS;
@@ -102,9 +100,6 @@
 	&-is-leaf&-is-removable,
 	& > &-is-leaf&-is-removable,
 	& > & > &-is-leaf&-is-removable {
-		// border
-		.kind-border(1px, @color-primary);
-
 		// margin/padding
 		padding: 0 0 0 @size-XS;
 
@@ -119,33 +114,32 @@
 		}
 	}
 
-	.kind-border (@defaultBorderWidth, @defaultColor) {
-		border-width: @defaultBorderWidth;
+	// ---------------
+	// kind props
+	// ---------------
+	@kind-colors: default @color-neutral-5, success @featured-color-success,
+		info @featured-color-info, warning @featured-color-warning,
+		danger @featured-color-danger;
 
-		&-default&-is-leaf&-is-removable,
-		& > &-default&-is-leaf&-is-removable,
-		& > & > &-default&-is-leaf&-is-removable {
-			border: 1px solid @color-primary;
+	.setLeafBorder(@kind-colors);
+
+	.setLeafBorder(@list, @i: 1) when(@i <= length(@list)) {
+		@pair: extract(@list, @i);
+		@label: extract(@pair, 1);
+		@color: extract(@pair, 2);
+
+		&-@{label}&-is-leaf,
+		& > &-@{label}&-is-leaf,
+		& > & > &-@{label}&-is-leaf {
+			border: 1px solid @color;
 		}
 
-		&-default {
-			border: @defaultBorderWidth solid @defaultColor;
-		}
-
-		&-success {
-			border: 1px solid @featured-color-success;
-		}
-
-		&-info {
-			border: 1px solid @featured-color-info;
-		}
-
-		&-warning {
-			border: 1px solid @featured-color-warning;
-		}
-
-		&-danger {
-			border: 1px solid @featured-color-danger;
-		}
+		.setLeafBorder(@list, @i + 1);
+	}
+	// override the default border for removable tags
+	&-default&-is-leaf&-is-removable,
+	& > &-default&-is-leaf&-is-removable,
+	& > & > &-default&-is-leaf&-is-removable {
+		border: 1px solid @color-primary;
 	}
 }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -34,7 +34,7 @@ export interface ITagProps
 	isRemovable: boolean;
 
 	/** Style variations of the `Tag`. */
-	kind?: 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'default';
+	kind?: 'success' | 'warning' | 'danger' | 'info' | 'default';
 
 	/** Called when the user clicks to remove a tag. */
 	onRemove: ({
@@ -143,7 +143,7 @@ Tag.propTypes = {
 		Shows or hides the little "x" for a given tag.
 	`,
 
-	kind: oneOf(['primary', 'success', 'warning', 'danger', 'info', 'default'])`
+	kind: oneOf(['success', 'warning', 'danger', 'info', 'default'])`
 		Style variations of the \`Tag\`.
 	`,
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -34,7 +34,7 @@ export interface ITagProps
 	isRemovable: boolean;
 
 	/** Style variations of the `Tag`. */
-	kind?: 'success' | 'warning' | 'danger' | 'info' | 'default';
+	kind?: 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'default';
 
 	/** Called when the user clicks to remove a tag. */
 	onRemove: ({
@@ -89,6 +89,7 @@ export const Tag = (props: ITagProps): React.ReactElement => {
 					'&-is-removable': isRemovable,
 					'&-has-light-background': hasLightBackground,
 					'&-default': kind === 'default',
+					'&-primary': kind === 'primary',
 					'&-success': kind === 'success',
 					'&-warning': kind === 'warning',
 					'&-danger': kind === 'danger',
@@ -143,7 +144,7 @@ Tag.propTypes = {
 		Shows or hides the little "x" for a given tag.
 	`,
 
-	kind: oneOf(['success', 'warning', 'danger', 'info', 'default'])`
+	kind: oneOf(['primary', 'success', 'warning', 'danger', 'info', 'default'])`
 		Style variations of the \`Tag\`.
 	`,
 


### PR DESCRIPTION
Avoid activating kind props on parent tags by using a recursive function to set the kind border color on leaves.

- Also removed the kind type of primary; since it isn't being assigned a style/used.

## PR Checklist

- Manually tested across supported browsers
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (Win 10)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
