### PR TITLE
Feature cxp 923 run report icon

### DIFF
--- a/docs/load-icons.js
+++ b/docs/load-icons.js
@@ -925,6 +925,22 @@ module.exports = [
 	},
 
 	{
+		name: 'RunReportIcon',
+		component: getDefaultExport(
+			require('../src/components/Icon/RunReportIcon/RunReportIcon')
+		),
+		examplesContext: require.context(
+			'../src/components/Icon/RunReportIcon/examples',
+			true,
+			/\.(t|j)sx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../src/components/Icon/RunReportIcon/examples',
+			true,
+			/\.(t|j)sx?$/
+		),
+	},
+	{
 		name: 'SaveIcon',
 		component: getDefaultExport(
 			require('../src/components/Icon/SaveIcon/SaveIcon')

--- a/src/components/Icon/RunReportIcon/RunReportIcon.tsx
+++ b/src/components/Icon/RunReportIcon/RunReportIcon.tsx
@@ -23,7 +23,7 @@ export const RunReportIcon = ({
 			{..._.pick(passThroughs, _.keys(iconPropTypes))}
 			className={cx('&', className)}
 		>
-			<path d='M7 10.75h8.5' />
+			<path d='M7 10.75h8' />
 			<path d='M13.5 12.75l2-2-2-2M13.5 15.5h-11v-13h3M10.5 2.5h3V6' />
 			<path d='M9 1.5a1 1 0 00-2 0H5.5V4h5V1.5H9z' />
 		</Icon>

--- a/src/components/Icon/RunReportIcon/RunReportIcon.tsx
+++ b/src/components/Icon/RunReportIcon/RunReportIcon.tsx
@@ -4,7 +4,7 @@ import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
 import { omitProps } from '../../../util/component-types';
 
-const cx = lucidClassNames.bind('&-ShoppingCartIcon');
+const cx = lucidClassNames.bind('&-RunReportIcon');
 
 interface IRunReportIconProps extends IIconProps {}
 
@@ -23,9 +23,9 @@ export const RunReportIcon = ({
 			{..._.pick(passThroughs, _.keys(iconPropTypes))}
 			className={cx('&', className)}
 		>
-			<path d='M13.5 14a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zM7 13.5a.5.5 0 1 0 0 1 .5.5 0 0 0 0-1z' />
-			<path d='M14.5 11.5h-9l-2-7h12z' />
-			<path d='M3.5 4.5l-1-2h-2' />
+			<path d='M7 10.75h8.5' />
+			<path d='M13.5 12.75l2-2-2-2M13.5 15.5h-11v-13h3M10.5 2.5h3V6' />
+			<path d='M9 1.5a1 1 0 00-2 0H5.5V4h5V1.5H9z' />
 		</Icon>
 	);
 };
@@ -33,7 +33,7 @@ export const RunReportIcon = ({
 RunReportIcon.displayName = 'RunReportIcon';
 RunReportIcon.peek = {
 	description: `
-		Buy buy buy!
+		Run a report.
 	`,
 	categories: ['visual design', 'icons'],
 	extend: 'Icon',

--- a/src/components/Icon/RunReportIcon/RunReportIcon.tsx
+++ b/src/components/Icon/RunReportIcon/RunReportIcon.tsx
@@ -1,0 +1,45 @@
+import _ from 'lodash';
+import React from 'react';
+import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import { lucidClassNames } from '../../../util/style-helpers';
+import { omitProps } from '../../../util/component-types';
+
+const cx = lucidClassNames.bind('&-ShoppingCartIcon');
+
+interface IRunReportIconProps extends IIconProps {}
+
+export const RunReportIcon = ({
+	className,
+	...passThroughs
+}: IRunReportIconProps) => {
+	return (
+		<Icon
+			{...omitProps(
+				passThroughs,
+				undefined,
+				_.keys(RunReportIcon.propTypes),
+				false
+			)}
+			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			className={cx('&', className)}
+		>
+			<path d='M13.5 14a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zM7 13.5a.5.5 0 1 0 0 1 .5.5 0 0 0 0-1z' />
+			<path d='M14.5 11.5h-9l-2-7h12z' />
+			<path d='M3.5 4.5l-1-2h-2' />
+		</Icon>
+	);
+};
+
+RunReportIcon.displayName = 'RunReportIcon';
+RunReportIcon.peek = {
+	description: `
+		Buy buy buy!
+	`,
+	categories: ['visual design', 'icons'],
+	extend: 'Icon',
+	madeFrom: ['Icon'],
+};
+RunReportIcon.propTypes = iconPropTypes;
+RunReportIcon.defaultProps = Icon.defaultProps;
+
+export default RunReportIcon;

--- a/src/components/Icon/RunReportIcon/RunRepotIcon.spec.jsx
+++ b/src/components/Icon/RunReportIcon/RunRepotIcon.spec.jsx
@@ -1,0 +1,8 @@
+import { icons, common } from '../../../util/generic-tests';
+
+import RunReportIcon from './RunReportIcon';
+
+describe('RunReportIcon', () => {
+	common(RunReportIcon);
+	icons(RunReportIcon);
+});

--- a/src/components/Icon/RunReportIcon/__snapshots__/RunRepotIcon.spec.jsx.snap
+++ b/src/components/Icon/RunReportIcon/__snapshots__/RunRepotIcon.spec.jsx.snap
@@ -13,7 +13,7 @@ exports[`RunReportIcon [common] example testing should match snapshot(s) for 1de
   viewBox="0 0 16 16"
 >
   <path
-    d="M7 10.75h8.5"
+    d="M7 10.75h8"
   />
   <path
     d="M13.5 12.75l2-2-2-2M13.5 15.5h-11v-13h3M10.5 2.5h3V6"

--- a/src/components/Icon/RunReportIcon/__snapshots__/RunRepotIcon.spec.jsx.snap
+++ b/src/components/Icon/RunReportIcon/__snapshots__/RunRepotIcon.spec.jsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RunReportIcon [common] example testing should match snapshot(s) for 1default 1`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-RunReportIcon"
+  color="primary"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  viewBox="0 0 16 16"
+>
+  <path
+    d="M7 10.75h8.5"
+  />
+  <path
+    d="M13.5 12.75l2-2-2-2M13.5 15.5h-11v-13h3M10.5 2.5h3V6"
+  />
+  <path
+    d="M9 1.5a1 1 0 00-2 0H5.5V4h5V1.5H9z"
+  />
+</Icon>
+`;

--- a/src/components/Icon/RunReportIcon/examples/1default.jsx
+++ b/src/components/Icon/RunReportIcon/examples/1default.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { RunReportIcon } from '../../../../index';
+
+export default () => <RunReportIcon />;

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,7 @@ import RadioButtonLabeled from './components/RadioButtonLabeled/RadioButtonLabel
 import RefreshIcon from './components/Icon/RefreshIcon/RefreshIcon';
 import ResizeIcon from './components/Icon/ResizeIcon/ResizeIcon';
 import Resizer from './components/Resizer/Resizer';
+import RunReportIcon from './components/Icon/RunReportIcon/RunReportIcon';
 import SaveIcon from './components/Icon/SaveIcon/SaveIcon';
 // @ts-ignore: not converted yet
 import ScrollTable from './components/ScrollTable/ScrollTable';
@@ -326,6 +327,7 @@ export {
 	RefreshIcon,
 	ResizeIcon,
 	Resizer,
+	RunReportIcon,
 	SaveIcon,
 	ScrollTable,
 	SearchableMultiSelect,


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/feature_cxp-923_run-report-icon/?path=/docs/icons-icons-runreporticon--default)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
