### PR TITLE
remove getInitialState from SingleSelect, SearchableSelect

### DIFF
--- a/src/components/DropMenu/DropMenu.tsx
+++ b/src/components/DropMenu/DropMenu.tsx
@@ -139,7 +139,7 @@ Option.propTypes = {
 Option.defaultProps = {
 	isDisabled: false,
 	isHidden: false,
-	isWrapped: true
+	isWrapped: true,
 };
 
 export interface IDropMenuNullOptionProps extends StandardProps {

--- a/src/components/SearchableSelect/SearchableSelect.tsx
+++ b/src/components/SearchableSelect/SearchableSelect.tsx
@@ -305,15 +305,6 @@ class SearchableSelect extends React.Component<
 		`,
 	};
 
-	getInitialState() {
-		return {
-			optionGroups: [],
-			flattenedOptionsData: [],
-			ungroupedOptionData: [],
-			optionGroupDataLookup: {},
-		};
-	}
-
 	componentWillMount() {
 		// preprocess the options data before rendering
 		this.setState(DropMenu.preprocessOptionData(this.props, SearchableSelect));

--- a/src/components/SingleSelect/SingleSelect.tsx
+++ b/src/components/SingleSelect/SingleSelect.tsx
@@ -147,7 +147,6 @@ export interface ISingleSelectState {
 	flattenedOptionsData: IOptionsData[];
 	ungroupedOptionData: IOptionsData[];
 	optionGroupDataLookup: { [key: number]: IOptionsData[] };
-
 	DropMenu: IDropMenuState;
 }
 

--- a/src/components/SingleSelect/SingleSelect.tsx
+++ b/src/components/SingleSelect/SingleSelect.tsx
@@ -14,6 +14,7 @@ import {
 	DropMenuDumb as DropMenu,
 	IDropMenuNullOptionProps,
 	IDropMenuFixedOptionProps,
+	IOptionsData,
 } from '../DropMenu/DropMenu';
 import ChevronIcon from '../Icon/ChevronIcon/ChevronIcon';
 
@@ -41,8 +42,8 @@ const Placeholder = (_props: ISingleSelectPlaceholderProps): null => null;
 Placeholder.displayName = 'SingleSelect.Placeholder';
 Placeholder.peek = {
 	description: `
-		Content this is displayed when nothing is selected.
-	`,
+        Content this is displayed when nothing is selected.
+    `,
 };
 Placeholder.propName = 'Placeholder';
 
@@ -59,9 +60,9 @@ const Selected = (_props: { children?: React.ReactNode }): null => null;
 Selected.displayName = 'SingleSelect.Option.Selected';
 Selected.peek = {
 	description: `
-		Customizes the rendering of the Option when it is selected
-		and is displayed instead of the Placeholder.
-	`,
+        Customizes the rendering of the Option when it is selected
+        and is displayed instead of the Placeholder.
+    `,
 };
 Selected.propName = 'Selected';
 Selected.propTypes = {};
@@ -71,16 +72,16 @@ const Option = (_props: ISingleSelectOptionProps): null => null;
 Option.displayName = 'SingleSelect.Option';
 Option.peek = {
 	description: `
-		A selectable option in the list.
-	`,
+        A selectable option in the list.
+    `,
 };
 Option.Selected = Selected;
 Option.propName = 'Option';
 Option.propTypes = {
 	Selected: any`
-		Customizes the rendering of the Option when it is selected and is
-		displayed instead of the Placeholder.
-	`,
+        Customizes the rendering of the Option when it is selected and is
+        displayed instead of the Placeholder.
+    `,
 	...DropMenu.Option.propTypes,
 };
 Option.defaultProps = DropMenu.Option.defaultProps;
@@ -90,8 +91,8 @@ const OptionGroup = (_props: IDropMenuOptionGroupProps): null => null;
 OptionGroup.displayName = 'SingleSelect.OptionGroup';
 OptionGroup.peek = {
 	description: `
-		Groups \`Option\`s together with a non-selectable heading.
-	`,
+        Groups \`Option\`s together with a non-selectable heading.
+    `,
 };
 OptionGroup.propName = 'OptionGroup';
 OptionGroup.propTypes = DropMenu.OptionGroup.propTypes;
@@ -140,8 +141,13 @@ export interface ISingleSelectProps extends StandardProps {
 	) => void;
 }
 
-export interface ISingleSelectState extends IDropMenuState {
+export interface ISingleSelectState {
 	selectedIndex: number | null;
+	optionGroups: IDropMenuOptionGroupProps[];
+	flattenedOptionsData: IOptionsData[];
+	ungroupedOptionData: IOptionsData[];
+	optionGroupDataLookup: { [key: number]: IOptionsData[] };
+
 	DropMenu: IDropMenuState;
 }
 
@@ -162,23 +168,23 @@ class SingleSelect extends React.Component<
 
 	static peek = {
 		description: `
-				\`SingleSelect\` is a dropdown list. 
-				`,
+                \`SingleSelect\` is a dropdown list. 
+                `,
 		notes: {
 			overview: `
-						A dropdown list. A dropdown menu appears when you click on the trigger and allows you to choose one option and execute relevant actions.
-					`,
+                        A dropdown list. A dropdown menu appears when you click on the trigger and allows you to choose one option and execute relevant actions.
+                    `,
 			intendedUse: `
-						Allow users to select a single item from a list of 3-10 options.
-											
-						**Styling notes**
-						
-						- Use \`basic\` in forms. The blue outline helps users clearly see that a selection has been made.
-						- Use \`no selection highlighting\` if the default selection is All or a null state. The grey outline indicates that this selection does not need users' attention.
-						- Use \`invisible\` for filters within a full page table header. The lack of outline allows the dropdown to have a lighter visual weight within a data-intense layout.
-					`,
+                        Allow users to select a single item from a list of 3-10 options.
+                                            
+                        **Styling notes**
+                        
+                        - Use \`basic\` in forms. The blue outline helps users clearly see that a selection has been made.
+                        - Use \`no selection highlighting\` if the default selection is All or a null state. The grey outline indicates that this selection does not need users' attention.
+                        - Use \`invisible\` for filters within a full page table header. The lack of outline allows the dropdown to have a lighter visual weight within a data-intense layout.
+                    `,
 			technicalRecommendations: `
-					`,
+                    `,
 		},
 		categories: ['controls', 'selectors'],
 		madeFrom: ['DropMenu'],
@@ -195,117 +201,128 @@ class SingleSelect extends React.Component<
 
 	static propTypes = {
 		children: node`
-			Should be instances of: \`SingleSelect.Placeholder\`,
-			\`SingleSelect.Option\`, \`SingleSelect.OptionGroup\`. Other direct
-			child elements will not render.
-		`,
+            Should be instances of: \`SingleSelect.Placeholder\`,
+            \`SingleSelect.Option\`, \`SingleSelect.OptionGroup\`. Other direct
+            child elements will not render.
+        `,
 
 		className: string`
-			Appended to the component-specific class names set on the root elements.
-			Applies to *both* the control and the flyout menu.
-		`,
+            Appended to the component-specific class names set on the root elements.
+            Applies to *both* the control and the flyout menu.
+        `,
 
 		style: object`
-			Styles that are passed through to root element.
-		`,
+            Styles that are passed through to root element.
+        `,
 
 		isSelectionHighlighted: bool`
-			Applies primary color styling to the control when an item is selected.
-		`,
+            Applies primary color styling to the control when an item is selected.
+        `,
 
 		hasReset: bool`
-			Allows user to reset the \`optionIndex\` to \`null\` if they select the
-			placeholder at the top of the options list.  If \`false\`, it will not
-			render the placeholder in the menu.
-		`,
+            Allows user to reset the \`optionIndex\` to \`null\` if they select the
+            placeholder at the top of the options list.  If \`false\`, it will not
+            render the placeholder in the menu.
+        `,
 
 		isDisabled: bool`
-			Disables the \`SingleSelect\` from being clicked or focused.
-		`,
+            Disables the \`SingleSelect\` from being clicked or focused.
+        `,
 
 		isInvisible: bool`
-			Gives the effect of an 'invisible button'. Essentially, there is no grey border,
-			but there is still a blue border on a selection.
-		`,
+            Gives the effect of an 'invisible button'. Essentially, there is no grey border,
+            but there is still a blue border on a selection.
+        `,
 
 		selectedIndex: number`
-			The currently selected \`SingleSelect.Option\` index or \`null\` if
-			nothing is selected.
-		`,
+            The currently selected \`SingleSelect.Option\` index or \`null\` if
+            nothing is selected.
+        `,
 
 		maxMenuHeight: oneOfType([number, string])`
-			The max height of the fly-out menu.
-		`,
+            The max height of the fly-out menu.
+        `,
 
 		DropMenu: shape(DropMenu.propTypes)`
-			Object of \`DropMenu\` props which are passed thru to the underlying \`DropMenu\`
-			component.
-		`,
+            Object of \`DropMenu\` props which are passed thru to the underlying \`DropMenu\`
+            component.
+        `,
 
 		onSelect: func`
-			Called when an option is selected.  Has the signature \`(optionIndex,
-			{props, event}) => {}\` where \`optionIndex\` is the new
-			\`selectedIndex\` or \`null\` and \`props\` are the \`props\` for the
-			selected \`Option\`.
-		`,
+            Called when an option is selected.  Has the signature \`(optionIndex,
+            {props, event}) => {}\` where \`optionIndex\` is the new
+            \`selectedIndex\` or \`null\` and \`props\` are the \`props\` for the
+            selected \`Option\`.
+        `,
 
 		Placeholder: any`
-			*Child Element* - The content rendered in the control when there is no
-			option is selected. Also rendered in the option list to remove current
-			selection.
-		`,
+            *Child Element* - The content rendered in the control when there is no
+            option is selected. Also rendered in the option list to remove current
+            selection.
+        `,
 
 		Option: any`
-			*Child Element* - These are menu options. The \`optionIndex\` is in-order
-			of rendering regardless of group nesting, starting with index \`0\`.
-			Each \`Option\` may be passed a prop called \`isDisabled\` to disable
-			selection of that \`Option\`.  Any other props pass to Option will be
-			available from the \`onSelect\` handler.
-		`,
+            *Child Element* - These are menu options. The \`optionIndex\` is in-order
+            of rendering regardless of group nesting, starting with index \`0\`.
+            Each \`Option\` may be passed a prop called \`isDisabled\` to disable
+            selection of that \`Option\`.  Any other props pass to Option will be
+            available from the \`onSelect\` handler.
+        `,
 
 		OptionGroup: any`
-			*Child Element* - Used to group \`Option\`s within the menu. Any
-			non-\`Option\`s passed in will be rendered as a label for the group.
-		`,
+            *Child Element* - Used to group \`Option\`s within the menu. Any
+            non-\`Option\`s passed in will be rendered as a label for the group.
+        `,
 	};
-
-	getInitialState() {
-		return {
-			optionGroups: [],
-			flattenedOptionsData: [],
-			ungroupedOptionData: [],
-			optionGroupDataLookup: {},
-		};
-	}
 
 	componentWillMount() {
 		// preprocess the options data before rendering
-		this.setState(
-			DropMenu.preprocessOptionData(
-				this.props,
-				SingleSelect as IHasOptionChildren<
-					IDropMenuOptionGroupProps,
-					ISingleSelectOptionProps,
-					IDropMenuNullOptionProps,
-					IDropMenuFixedOptionProps
-				>
-			)
+		const {
+			optionGroups,
+			flattenedOptionsData,
+			ungroupedOptionData,
+			optionGroupDataLookup,
+		} = DropMenu.preprocessOptionData(
+			this.props,
+			SingleSelect as IHasOptionChildren<
+				IDropMenuOptionGroupProps,
+				ISingleSelectOptionProps,
+				IDropMenuNullOptionProps,
+				IDropMenuFixedOptionProps
+			>
 		);
+
+		this.setState({
+			optionGroups,
+			flattenedOptionsData,
+			ungroupedOptionData,
+			optionGroupDataLookup,
+		});
 	}
 
 	componentWillReceiveProps(nextProps: ISingleSelectProps): void {
 		// only preprocess options data when it changes (via new props) - better performance than doing this each render
-		this.setState(
-			DropMenu.preprocessOptionData(
-				nextProps,
-				SingleSelect as IHasOptionChildren<
-					IDropMenuOptionGroupProps,
-					ISingleSelectOptionProps,
-					IDropMenuNullOptionProps,
-					IDropMenuFixedOptionProps
-				>
-			)
+		const {
+			optionGroups,
+			flattenedOptionsData,
+			ungroupedOptionData,
+			optionGroupDataLookup,
+		} = DropMenu.preprocessOptionData(
+			nextProps,
+			SingleSelect as IHasOptionChildren<
+				IDropMenuOptionGroupProps,
+				ISingleSelectOptionProps,
+				IDropMenuNullOptionProps,
+				IDropMenuFixedOptionProps
+			>
 		);
+
+		this.setState({
+			optionGroups,
+			flattenedOptionsData,
+			ungroupedOptionData,
+			optionGroupDataLookup,
+		});
 	}
 
 	render(): React.ReactNode {


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/CXP-938_replace-getInitialState-SingleSelect-SearchableSelect/)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
