### PR TITLE
Fix font loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ or yarn
 
     import React from 'react';
     import ReactDOM from 'react-dom';
-    import Button from 'lucid-ui/Button';
-    // `import { Button } from 'lucid-ui'` also works but will result in larger bundle sizes
+    import { Button } from 'lucid-ui';
 
     ReactDOM.render(
       <Button>Hello World</Button>,
@@ -30,7 +29,7 @@ styles like so:
     @import "node_modules/lucid-ui/src/index.less";
 
 If you don't use `less`, you can use the precompiled css file
-`node_modules/lucid-ui/dist/index.css`.
+`node_modules/lucid-ui/dist/lucid.css`.
 
 ### Custom CSS Scope
 

--- a/docs/index.less
+++ b/docs/index.less
@@ -1,3 +1,6 @@
+// This URL is only available internally at Xandr and it simply provides some
+// optional font faces that can't be made public since the font is licensed.
+@import url('https://docspot.adnxs.net/projects/anx-react/xandr-font-faces/xandr-font-faces.css');
 @import '../src/index.less';
 
 html, body {

--- a/src/index.less
+++ b/src/index.less
@@ -1,4 +1,1 @@
-// This URL is only available internally at Xandr and will be removed eventually.
-@import url('https://docspot.adnxs.net/projects/anx-react/xandr-font-faces/xandr-font-faces.css');
 @import './styles/components';
-


### PR DESCRIPTION
This should have never been put in the main less file and was causing
blocking loading for external consumers of the library. I moved it into
the main less file for the docs page so we can continue to see the
custom font on the docs when we're on our VPN.

## PR Checklist

Storybook can be viewed [here]()

- ~~Manually tested across supported browsers~~
- ~~Unit tests written (`common` at minimum)~~
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- ~~One core team UX approval~~
