### PR TITLE
Bug/cxp 886 chart tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - #1114 [minor] Add `RunReportIcon` to the component icon library.
 - #1113 [none] Add instructions on how to release Lucid UI in `RELEASING.md` doc.
 
-https://github.com/appnexus/lucid/compare/v5.5.0...v5.6.0
+https://github.com/appnexus/lucid/compare/v5.5.0...v5.6.1
 
 ## 5.5.0
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ In your webpack config use the [`DefinePlugin`][dp] to specify
       LUCID_CSS_NAMESPACE: "'something-custom'",
     });
 
-
-When you render the less, make sure to [set the `prefix` variable][lmv] to the
+When you render the `less`, make sure to [set the `prefix` variable][lmv] to the
 same thing you set in in your webpack config. E.g.
 
     lessc node_modules/lucid-ui/src/index.less --modify-var='prefix=something-custom'
@@ -60,7 +59,7 @@ Example package.json:
 
     {
       "dependencies": {
-        "lucid-ui": "^2.0.0",
+        "lucid-ui": "^5.0.0",
         "react": "^16.0.0",
         "react-dom": "^16.0.0",
       }
@@ -74,9 +73,9 @@ To contribute to lucid, please see `CONTRIBUTING.md`.
 - [Travis CI] for providing continuous integration infrastructure.
 - [CodeCov] for providing code coverage analysis infrastructure.
 
-[BrowserStack]: https://www.browserstack.com/
-[Travis CI]: https://travis-ci.org/
-[CodeCov]: https://codecov.io
+[browserstack]: https://www.browserstack.com/
+[travis ci]: https://travis-ci.org/
+[codecov]: https://codecov.io
 [bpi]: https://github.com/ant-design/babel-plugin-import
 [dp]: https://webpack.js.org/plugins/define-plugin/
 [lmv]: http://lesscss.org/usage/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,6 @@ Lucid UI is released to NPM as a public module.
 
 - An authorized corporate npm account.
 - `ssh` setup on GitHub. To check your credentials: `git remote -v`.
-- `.npmrc` file in your `\$HOME directory`. The `.npmrc` file is what tells `npm` _where_ the registry is.
 
 ## Prerelease check
 
@@ -34,19 +33,17 @@ We follow [semver](https://semver.org/), which prescribes that:
 - `semver-patch`: Fixes are a "patch" version (the right-most number).
 - `semver-none`: Changes to documentation, or other changes that don't impact the api or consumers get a "none" label.
 
-Document the changes contained in the release:
+Document, stage and push the changes contained in the release:
 
 1. `git log`. Find and add each merged pull request (PR) since the last release and add it to the changelog.
 2. `CHANGELOG.md`: Add details about the release--each PR gets a GitHub PR label, semver label, and short description.
+3. Update the value of the `"version"` field for Lucid UI in `package-json` and `package-lock.json`.
+4. Commit the documentation and `package-` changes. For example: `git commit -a -m "release v5.4.0"`
+5. Push the release to GitHub: `git push origin master`.
 
 ## Update version number
 
-One option is to update the version number manually:
-
-1. `package-json` and `package-lock.json`: Update the value of the `"version"` field for Lucid UI.
-2. `git tag {version number}`: Create a tag. For example, `git tag v5.4.0`.
-
-The other option is to update the version number using `npm version`:
+The recommended option is to update the version number using `npm version`:
 
 1. Use `npm` to publish the new NPM version that matches the version number and type of change (major, minor or patch) in `package.json`--this process creates a tag automatically.
 
@@ -54,7 +51,13 @@ The other option is to update the version number using `npm version`:
 - `npm version minor`
 - `npm version patch`
 
+2. Push the changes and tags: `git push origin master --follow-tags`. Note that by default, the `git push` command doesn't transfer tags to remote serves.
+
+Another option is to update the version number manually:
+
+1. Create a tag: `git tag {version number}`. For example: `git tag v5.4.0`.
+2. Push the tags. For example: `git push origin v5.4.0`.
+
 ## Publish Lucid UI to npm
 
-1. Add and commit the changes, and then push the changes and tags: `git push origin master --follow-tags`. Note that by default, the `git push` command doesn't transfer tags to remote serves.
-2. `npm publish`: Publish the new version to npm.
+1. Publish the new version to npm: `npm publish`.

--- a/src/components/BarChart/examples/01.basic.jsx
+++ b/src/components/BarChart/examples/01.basic.jsx
@@ -9,11 +9,20 @@ const data = [
 	{ x: '2015-01-04', y: 5 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
-				<BarChart width={750} data={data} yAxisTitle='Revenue' margin={{ top: 20 }} />
+			<div style={style}>
+				<BarChart
+					width={750}
+					data={data}
+					yAxisTitle='Revenue'
+					margin={{ top: 20 }}
+				/>
 			</div>
 		);
 	},

--- a/src/components/BarChart/examples/02.basic-responsive.jsx
+++ b/src/components/BarChart/examples/02.basic-responsive.jsx
@@ -9,10 +9,14 @@ const data = [
 	{ x: '2015-01-04', y: 5 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<Resizer>
 					{(width /*, height */) => (
 						<BarChart

--- a/src/components/BarChart/examples/03.grouped.jsx
+++ b/src/components/BarChart/examples/03.grouped.jsx
@@ -17,10 +17,14 @@ const data = [
 	},
 ];
 
+const style = {
+	paddingTop: '10rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<BarChart
 					width={750}
 					data={data}

--- a/src/components/BarChart/examples/04.grouped-with-legend.jsx
+++ b/src/components/BarChart/examples/04.grouped-with-legend.jsx
@@ -20,10 +20,14 @@ const data = [
 const yAxisFields = ['apples', 'pears', 'peaches', 'bananas', 'oranges'];
 const palette = chartConstants.PALETTE_7;
 
+const style = {
+	paddingTop: '10rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<BarChart
 					width={750}
 					data={data}

--- a/src/components/BarChart/examples/05.limited-ticks.jsx
+++ b/src/components/BarChart/examples/05.limited-ticks.jsx
@@ -22,10 +22,14 @@ const data = [
 	{ x: '2015-01-17', y: 6 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<BarChart
 					width={750}
 					data={data}

--- a/src/components/BarChart/examples/06.all-the-things.jsx
+++ b/src/components/BarChart/examples/06.all-the-things.jsx
@@ -13,25 +13,31 @@ const data = [
 const yFormatter = d => `${d / 1000}k`;
 const xFormatter = d => d.toUpperCase().slice(0, 3);
 
+const style = {
+	paddingTop: '6rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<BarChart
-				width={750}
-				data={data}
-				colorMap={{
-					apples: chartConstants.COLOR_GOOD,
-					oranges: chartConstants.COLOR_1,
-				}}
-				xAxisField='day'
-				xAxisFormatter={xFormatter}
-				xAxisTickCount={5}
-				xAxisTitle='Weekdays'
-				yAxisFields={['apples', 'oranges']}
-				yAxisFormatter={yFormatter}
-				yAxisTitle='Fruit Count'
-				yAxisTickCount={4}
-			/>
+			<div style={style}>
+				<BarChart
+					width={750}
+					data={data}
+					colorMap={{
+						apples: chartConstants.COLOR_GOOD,
+						oranges: chartConstants.COLOR_1,
+					}}
+					xAxisField='day'
+					xAxisFormatter={xFormatter}
+					xAxisTickCount={5}
+					xAxisTitle='Weekdays'
+					yAxisFields={['apples', 'oranges']}
+					yAxisFormatter={yFormatter}
+					yAxisTitle='Fruit Count'
+					yAxisTickCount={4}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/BarChart/examples/07.stacked.jsx
+++ b/src/components/BarChart/examples/07.stacked.jsx
@@ -8,10 +8,14 @@ const data = [
 	{ x: 'Wednesday', apples: 5, pears: 15, peaches: 5 },
 ];
 
+const style = {
+	paddingTop: '7rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<BarChart
 					width={750}
 					data={data}

--- a/src/components/BarChart/examples/08.unformatted-tooltips.jsx
+++ b/src/components/BarChart/examples/08.unformatted-tooltips.jsx
@@ -9,10 +9,14 @@ const data = [
 	{ x: '2015-01-04', y: 3000 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<BarChart
 					width={750}
 					data={data}

--- a/src/components/BarChart/examples/09.formatted-tooltip-values.jsx
+++ b/src/components/BarChart/examples/09.formatted-tooltip-values.jsx
@@ -9,10 +9,14 @@ const data = [
 	{ x: '2015-01-04', y: 3000 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<BarChart
 					width={750}
 					data={data}

--- a/src/components/BarChart/examples/10.formatted-tooltips.jsx
+++ b/src/components/BarChart/examples/10.formatted-tooltips.jsx
@@ -9,10 +9,14 @@ const data = [
 	{ x: '2015-01-04', y: 3000 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<BarChart
 					width={750}
 					data={data}

--- a/src/components/BarChart/examples/13.many-bars.jsx
+++ b/src/components/BarChart/examples/13.many-bars.jsx
@@ -8,18 +8,24 @@ const data = _.map(_.range(0, 70), n => ({
 	y: n,
 }));
 
+const style = {
+	paddingTop: '5rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<BarChart
-				data={data}
-				xAxisTextOrientation='diagonal'
-				yAxisTextOrientation='horizontal'
-				xAxisTickCount={20}
-				height={600}
-				width={750}
-				margin={{ bottom: 300, left: 300 }}
-			/>
+			<div style={style}>
+				<BarChart
+					data={data}
+					xAxisTextOrientation='diagonal'
+					yAxisTextOrientation='horizontal'
+					xAxisTickCount={20}
+					height={600}
+					width={750}
+					margin={{ bottom: 300, left: 300 }}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/Bars/__snapshots__/Bars.spec.jsx.snap
+++ b/src/components/Bars/__snapshots__/Bars.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = `
+exports[`Bars [common] example testing should match snapshot(s) for 01.basic 1`] = `
 <g
   className="lucid-Bars"
 >
@@ -10,38 +10,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={20}
+      height={36.363636363636374}
       key="0"
-      width={38}
+      width={28}
       x={1}
-      y={380}
+      y={363.6363636363636}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={40}
+      height={72.72727272727275}
       key="1"
-      width={38}
-      x={39}
-      y={360}
+      width={28}
+      x={29}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={60}
+      height={109.09090909090907}
       key="2"
-      width={38}
-      x={77}
-      y={340}
+      width={28}
+      x={57}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={100}
+      height={181.8181818181818}
       key="3"
-      width={38}
-      x={115}
-      y={300}
+      width={28}
+      x={85}
+      y={218.1818181818182}
     />
     <Component
       data={
@@ -83,14 +83,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={100}
+      height={181.8181818181818}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -116,11 +116,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
         ]
       }
       seriesIndex={0}
-      width={152}
-      x={1}
+      width={114}
+      x={0}
       xField="x"
       xFormatter={[Function]}
-      y={300}
+      y={218.1818181818182}
     />
   </g>
   <g
@@ -129,38 +129,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={40}
+      height={72.72727272727275}
       key="0"
-      width={38}
-      x={170}
-      y={360}
+      width={28}
+      x={128}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={60}
+      height={109.09090909090907}
       key="1"
-      width={38}
-      x={208}
-      y={340}
+      width={28}
+      x={156}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={80}
+      height={145.45454545454547}
       key="2"
-      width={38}
-      x={246}
-      y={320}
+      width={28}
+      x={184}
+      y={254.54545454545453}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={120}
+      height={218.18181818181816}
       key="3"
-      width={38}
-      x={284}
-      y={280}
+      width={28}
+      x={212}
+      y={181.81818181818184}
     />
     <Component
       data={
@@ -202,14 +202,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={120}
+      height={218.18181818181816}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -235,11 +235,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
         ]
       }
       seriesIndex={1}
-      width={152}
-      x={170}
+      width={114}
+      x={127}
       xField="x"
       xFormatter={[Function]}
-      y={280}
+      y={181.81818181818184}
     />
   </g>
   <g
@@ -248,38 +248,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={40}
+      height={72.72727272727275}
       key="0"
-      width={38}
-      x={339}
-      y={360}
+      width={28}
+      x={255}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={80}
+      height={145.45454545454547}
       key="1"
-      width={38}
-      x={377}
-      y={320}
+      width={28}
+      x={283}
+      y={254.54545454545453}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={100}
+      height={181.8181818181818}
       key="2"
-      width={38}
-      x={415}
-      y={300}
+      width={28}
+      x={311}
+      y={218.1818181818182}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={120}
+      height={218.18181818181816}
       key="3"
-      width={38}
-      x={453}
-      y={280}
+      width={28}
+      x={339}
+      y={181.81818181818184}
     />
     <Component
       data={
@@ -321,14 +321,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={120}
+      height={218.18181818181816}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -354,11 +354,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
         ]
       }
       seriesIndex={2}
-      width={152}
-      x={339}
+      width={114}
+      x={254}
       xField="x"
       xFormatter={[Function]}
-      y={280}
+      y={181.81818181818184}
     />
   </g>
   <g
@@ -367,38 +367,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={60}
+      height={109.09090909090907}
       key="0"
-      width={38}
-      x={508}
-      y={340}
+      width={28}
+      x={382}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={120}
+      height={218.18181818181816}
       key="1"
-      width={38}
-      x={546}
-      y={280}
+      width={28}
+      x={410}
+      y={181.81818181818184}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={140}
+      height={254.54545454545453}
       key="2"
-      width={38}
-      x={584}
-      y={260}
+      width={28}
+      x={438}
+      y={145.45454545454547}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={140}
+      height={254.54545454545453}
       key="3"
-      width={38}
-      x={622}
-      y={260}
+      width={28}
+      x={466}
+      y={145.45454545454547}
     />
     <Component
       data={
@@ -440,14 +440,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={140}
+      height={254.54545454545453}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -473,11 +473,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
         ]
       }
       seriesIndex={3}
-      width={152}
-      x={508}
+      width={114}
+      x={381}
       xField="x"
       xFormatter={[Function]}
-      y={260}
+      y={145.45454545454547}
     />
   </g>
   <g
@@ -486,38 +486,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={80}
+      height={145.45454545454547}
       key="0"
-      width={38}
-      x={677}
-      y={320}
+      width={28}
+      x={509}
+      y={254.54545454545453}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={160}
+      height={290.90909090909093}
       key="1"
-      width={38}
-      x={715}
-      y={240}
+      width={28}
+      x={537}
+      y={109.09090909090907}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={180}
+      height={327.2727272727273}
       key="2"
-      width={38}
-      x={753}
-      y={220}
+      width={28}
+      x={565}
+      y={72.72727272727269}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={160}
+      height={290.90909090909093}
       key="3"
-      width={38}
-      x={791}
-      y={240}
+      width={28}
+      x={593}
+      y={109.09090909090907}
     />
     <Component
       data={
@@ -559,14 +559,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={180}
+      height={327.2727272727273}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -592,11 +592,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
         ]
       }
       seriesIndex={4}
-      width={152}
-      x={677}
+      width={114}
+      x={508}
       xField="x"
       xFormatter={[Function]}
-      y={220}
+      y={72.72727272727269}
     />
   </g>
   <g
@@ -607,36 +607,36 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
       hasStroke={false}
       height={400}
       key="0"
-      width={38}
-      x={846}
+      width={28}
+      x={636}
       y={0}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={160}
+      height={290.90909090909093}
       key="1"
-      width={38}
-      x={884}
-      y={240}
+      width={28}
+      x={664}
+      y={109.09090909090907}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={180}
+      height={327.2727272727273}
       key="2"
-      width={38}
-      x={922}
-      y={220}
+      width={28}
+      x={692}
+      y={72.72727272727269}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={20}
+      height={181.8181818181818}
       key="3"
-      width={38}
-      x={960}
-      y={380}
+      width={28}
+      x={720}
+      y={218.1818181818182}
     />
     <Component
       data={
@@ -678,10 +678,10 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
@@ -694,7 +694,7 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
         Array [
           Array [
             0,
-            20,
+            11,
           ],
           Array [
             0,
@@ -706,13 +706,13 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
           ],
           Array [
             0,
-            1,
+            5,
           ],
         ]
       }
       seriesIndex={5}
-      width={152}
-      x={846}
+      width={114}
+      x={635}
       xField="x"
       xFormatter={[Function]}
       y={0}
@@ -721,7 +721,7 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 1`] = 
 </g>
 `;
 
-exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = `
+exports[`Bars [common] example testing should match snapshot(s) for 01.basic 2`] = `
 <g
   className="lucid-Bars"
 >
@@ -731,38 +731,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={10.5263157894737}
+      height={12.121212121212125}
       key="0"
-      width={152}
-      x={1}
-      y={389.4736842105263}
+      width={114}
+      x={0}
+      y={387.8787878787879}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={21.05263157894734}
+      height={24.24242424242425}
       key="1"
-      width={152}
-      x={1}
-      y={368.42105263157896}
+      width={114}
+      x={0}
+      y={363.6363636363636}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={31.57894736842104}
+      height={36.363636363636374}
       key="2"
-      width={152}
-      x={1}
-      y={336.8421052631579}
+      width={114}
+      x={0}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={52.63157894736844}
+      height={60.606060606060566}
       key="3"
-      width={152}
-      x={1}
-      y={284.2105263157895}
+      width={114}
+      x={0}
+      y={266.6666666666667}
     />
     <Component
       data={
@@ -804,14 +804,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={115.78947368421052}
+      height={133.33333333333331}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -837,11 +837,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
         ]
       }
       seriesIndex={0}
-      width={152}
-      x={1}
+      width={114}
+      x={0}
       xField="x"
       xFormatter={[Function]}
-      y={284.2105263157895}
+      y={266.6666666666667}
     />
   </g>
   <g
@@ -850,38 +850,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={21.05263157894734}
+      height={24.24242424242425}
       key="0"
-      width={152}
-      x={170}
-      y={378.94736842105266}
+      width={114}
+      x={127}
+      y={375.75757575757575}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={31.578947368421098}
+      height={36.363636363636374}
       key="1"
-      width={152}
-      x={170}
-      y={347.36842105263156}
+      width={114}
+      x={127}
+      y={339.3939393939394}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={42.10526315789468}
+      height={48.48484848484844}
       key="2"
-      width={152}
-      x={170}
-      y={305.2631578947369}
+      width={114}
+      x={127}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={63.15789473684214}
+      height={72.72727272727275}
       key="3"
-      width={152}
-      x={170}
-      y={242.10526315789474}
+      width={114}
+      x={127}
+      y={218.1818181818182}
     />
     <Component
       data={
@@ -923,14 +923,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={157.89473684210526}
+      height={181.8181818181818}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -956,11 +956,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
         ]
       }
       seriesIndex={1}
-      width={152}
-      x={170}
+      width={114}
+      x={127}
       xField="x"
       xFormatter={[Function]}
-      y={242.10526315789474}
+      y={218.1818181818182}
     />
   </g>
   <g
@@ -969,38 +969,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={21.05263157894734}
+      height={24.24242424242425}
       key="0"
-      width={152}
-      x={339}
-      y={378.94736842105266}
+      width={114}
+      x={254}
+      y={375.75757575757575}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={42.10526315789474}
+      height={48.4848484848485}
       key="1"
-      width={152}
-      x={339}
-      y={336.8421052631579}
+      width={114}
+      x={254}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={52.63157894736844}
+      height={60.606060606060566}
       key="2"
-      width={152}
-      x={339}
-      y={284.2105263157895}
+      width={114}
+      x={254}
+      y={266.6666666666667}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={63.15789473684211}
+      height={72.72727272727275}
       key="3"
-      width={152}
-      x={339}
-      y={221.05263157894737}
+      width={114}
+      x={254}
+      y={193.93939393939394}
     />
     <Component
       data={
@@ -1042,14 +1042,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={178.94736842105263}
+      height={206.06060606060606}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -1075,11 +1075,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
         ]
       }
       seriesIndex={2}
-      width={152}
-      x={339}
+      width={114}
+      x={254}
       xField="x"
       xFormatter={[Function]}
-      y={221.05263157894737}
+      y={193.93939393939394}
     />
   </g>
   <g
@@ -1088,38 +1088,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={31.57894736842104}
+      height={36.363636363636374}
       key="0"
-      width={152}
-      x={508}
-      y={368.42105263157896}
+      width={114}
+      x={381}
+      y={363.6363636363636}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={63.15789473684208}
+      height={72.72727272727269}
       key="1"
-      width={152}
-      x={508}
-      y={305.2631578947369}
+      width={114}
+      x={381}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={73.68421052631581}
+      height={84.84848484848487}
       key="2"
-      width={152}
-      x={508}
-      y={231.57894736842107}
+      width={114}
+      x={381}
+      y={206.06060606060606}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={73.68421052631581}
+      height={84.84848484848487}
       key="3"
-      width={152}
-      x={508}
-      y={157.89473684210526}
+      width={114}
+      x={381}
+      y={121.21212121212119}
     />
     <Component
       data={
@@ -1161,14 +1161,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={242.10526315789474}
+      height={278.7878787878788}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -1194,11 +1194,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
         ]
       }
       seriesIndex={3}
-      width={152}
-      x={508}
+      width={114}
+      x={381}
       xField="x"
       xFormatter={[Function]}
-      y={157.89473684210526}
+      y={121.21212121212119}
     />
   </g>
   <g
@@ -1207,38 +1207,38 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={42.10526315789474}
+      height={48.4848484848485}
       key="0"
-      width={152}
-      x={677}
-      y={357.89473684210526}
+      width={114}
+      x={508}
+      y={351.5151515151515}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={84.21052631578948}
+      height={96.96969696969697}
       key="1"
-      width={152}
-      x={677}
-      y={273.6842105263158}
+      width={114}
+      x={508}
+      y={254.54545454545453}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={94.73684210526318}
+      height={109.09090909090907}
       key="2"
-      width={152}
-      x={677}
-      y={178.9473684210526}
+      width={114}
+      x={508}
+      y={145.45454545454547}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={84.21052631578948}
+      height={96.96969696969697}
       key="3"
-      width={152}
-      x={677}
-      y={94.73684210526312}
+      width={114}
+      x={508}
+      y={48.4848484848485}
     />
     <Component
       data={
@@ -1280,14 +1280,14 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={305.2631578947369}
+      height={351.5151515151515}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -1313,11 +1313,11 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
         ]
       }
       seriesIndex={4}
-      width={152}
-      x={677}
+      width={114}
+      x={508}
       xField="x"
       xFormatter={[Function]}
-      y={94.73684210526312}
+      y={48.4848484848485}
     />
   </g>
   <g
@@ -1326,37 +1326,37 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
     <Bar
       color="color-chart-3"
       hasStroke={false}
-      height={210.52631578947367}
+      height={133.33333333333331}
       key="0"
-      width={152}
-      x={846}
-      y={189.47368421052633}
+      width={114}
+      x={635}
+      y={266.6666666666667}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={84.21052631578945}
+      height={96.969696969697}
       key="1"
-      width={152}
-      x={846}
-      y={105.26315789473688}
+      width={114}
+      x={635}
+      y={169.6969696969697}
     />
     <Bar
       color="color-chart-2"
       hasStroke={false}
-      height={94.73684210526318}
+      height={109.09090909090907}
       key="2"
-      width={152}
-      x={846}
-      y={10.5263157894737}
+      width={114}
+      x={635}
+      y={60.60606060606062}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={10.5263157894737}
+      height={60.60606060606062}
       key="3"
-      width={152}
-      x={846}
+      width={114}
+      x={635}
       y={0}
     />
     <Component
@@ -1399,10 +1399,10 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
@@ -1415,25 +1415,25 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
         Array [
           Array [
             0,
-            20,
+            11,
           ],
           Array [
-            20,
+            11,
+            19,
+          ],
+          Array [
+            19,
             28,
           ],
           Array [
             28,
-            37,
-          ],
-          Array [
-            37,
-            38,
+            33,
           ],
         ]
       }
       seriesIndex={5}
-      width={152}
-      x={846}
+      width={114}
+      x={635}
       xField="x"
       xFormatter={[Function]}
       y={0}
@@ -1442,7 +1442,7 @@ exports[`Bars [common] example testing should match snapshot(s) for basic 2`] = 
 </g>
 `;
 
-exports[`Bars [common] example testing should match snapshot(s) for custom-colors 1`] = `
+exports[`Bars [common] example testing should match snapshot(s) for 02.custom-colors 1`] = `
 <g
   className="lucid-Bars"
 >
@@ -1452,38 +1452,38 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
     <Bar
       color="color-chart-good"
       hasStroke={false}
-      height={20}
+      height={36.363636363636374}
       key="0"
-      width={38}
+      width={28}
       x={1}
-      y={380}
+      y={363.6363636363636}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={40}
+      height={72.72727272727275}
       key="1"
-      width={38}
-      x={39}
-      y={360}
+      width={28}
+      x={29}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-bad"
       hasStroke={false}
-      height={60}
+      height={109.09090909090907}
       key="2"
-      width={38}
-      x={77}
-      y={340}
+      width={28}
+      x={57}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={100}
+      height={181.8181818181818}
       key="3"
-      width={38}
-      x={115}
-      y={300}
+      width={28}
+      x={85}
+      y={218.1818181818182}
     />
     <Component
       data={
@@ -1525,14 +1525,14 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={100}
+      height={181.8181818181818}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -1558,11 +1558,11 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
         ]
       }
       seriesIndex={0}
-      width={152}
-      x={1}
+      width={114}
+      x={0}
       xField="x"
       xFormatter={[Function]}
-      y={300}
+      y={218.1818181818182}
     />
   </g>
   <g
@@ -1571,38 +1571,38 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
     <Bar
       color="color-chart-good"
       hasStroke={false}
-      height={40}
+      height={72.72727272727275}
       key="0"
-      width={38}
-      x={170}
-      y={360}
+      width={28}
+      x={128}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={60}
+      height={109.09090909090907}
       key="1"
-      width={38}
-      x={208}
-      y={340}
+      width={28}
+      x={156}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-bad"
       hasStroke={false}
-      height={80}
+      height={145.45454545454547}
       key="2"
-      width={38}
-      x={246}
-      y={320}
+      width={28}
+      x={184}
+      y={254.54545454545453}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={120}
+      height={218.18181818181816}
       key="3"
-      width={38}
-      x={284}
-      y={280}
+      width={28}
+      x={212}
+      y={181.81818181818184}
     />
     <Component
       data={
@@ -1644,14 +1644,14 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={120}
+      height={218.18181818181816}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -1677,11 +1677,11 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
         ]
       }
       seriesIndex={1}
-      width={152}
-      x={170}
+      width={114}
+      x={127}
       xField="x"
       xFormatter={[Function]}
-      y={280}
+      y={181.81818181818184}
     />
   </g>
   <g
@@ -1690,38 +1690,38 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
     <Bar
       color="color-chart-good"
       hasStroke={false}
-      height={40}
+      height={72.72727272727275}
       key="0"
-      width={38}
-      x={339}
-      y={360}
+      width={28}
+      x={255}
+      y={327.27272727272725}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={80}
+      height={145.45454545454547}
       key="1"
-      width={38}
-      x={377}
-      y={320}
+      width={28}
+      x={283}
+      y={254.54545454545453}
     />
     <Bar
       color="color-chart-bad"
       hasStroke={false}
-      height={100}
+      height={181.8181818181818}
       key="2"
-      width={38}
-      x={415}
-      y={300}
+      width={28}
+      x={311}
+      y={218.1818181818182}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={120}
+      height={218.18181818181816}
       key="3"
-      width={38}
-      x={453}
-      y={280}
+      width={28}
+      x={339}
+      y={181.81818181818184}
     />
     <Component
       data={
@@ -1763,14 +1763,14 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={120}
+      height={218.18181818181816}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -1796,11 +1796,11 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
         ]
       }
       seriesIndex={2}
-      width={152}
-      x={339}
+      width={114}
+      x={254}
       xField="x"
       xFormatter={[Function]}
-      y={280}
+      y={181.81818181818184}
     />
   </g>
   <g
@@ -1809,38 +1809,38 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
     <Bar
       color="color-chart-good"
       hasStroke={false}
-      height={60}
+      height={109.09090909090907}
       key="0"
-      width={38}
-      x={508}
-      y={340}
+      width={28}
+      x={382}
+      y={290.90909090909093}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={120}
+      height={218.18181818181816}
       key="1"
-      width={38}
-      x={546}
-      y={280}
+      width={28}
+      x={410}
+      y={181.81818181818184}
     />
     <Bar
       color="color-chart-bad"
       hasStroke={false}
-      height={140}
+      height={254.54545454545453}
       key="2"
-      width={38}
-      x={584}
-      y={260}
+      width={28}
+      x={438}
+      y={145.45454545454547}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={140}
+      height={254.54545454545453}
       key="3"
-      width={38}
-      x={622}
-      y={260}
+      width={28}
+      x={466}
+      y={145.45454545454547}
     />
     <Component
       data={
@@ -1882,14 +1882,14 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={140}
+      height={254.54545454545453}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -1915,11 +1915,11 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
         ]
       }
       seriesIndex={3}
-      width={152}
-      x={508}
+      width={114}
+      x={381}
       xField="x"
       xFormatter={[Function]}
-      y={260}
+      y={145.45454545454547}
     />
   </g>
   <g
@@ -1928,38 +1928,38 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
     <Bar
       color="color-chart-good"
       hasStroke={false}
-      height={80}
+      height={145.45454545454547}
       key="0"
-      width={38}
-      x={677}
-      y={320}
+      width={28}
+      x={509}
+      y={254.54545454545453}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={160}
+      height={290.90909090909093}
       key="1"
-      width={38}
-      x={715}
-      y={240}
+      width={28}
+      x={537}
+      y={109.09090909090907}
     />
     <Bar
       color="color-chart-bad"
       hasStroke={false}
-      height={180}
+      height={327.2727272727273}
       key="2"
-      width={38}
-      x={753}
-      y={220}
+      width={28}
+      x={565}
+      y={72.72727272727269}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={160}
+      height={290.90909090909093}
       key="3"
-      width={38}
-      x={791}
-      y={240}
+      width={28}
+      x={593}
+      y={109.09090909090907}
     />
     <Component
       data={
@@ -2001,14 +2001,14 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
-      height={180}
+      height={327.2727272727273}
       isExpanded={false}
       onMouseEnter={[Function]}
       onMouseOut={[Function]}
@@ -2034,11 +2034,11 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
         ]
       }
       seriesIndex={4}
-      width={152}
-      x={677}
+      width={114}
+      x={508}
       xField="x"
       xFormatter={[Function]}
-      y={220}
+      y={72.72727272727269}
     />
   </g>
   <g
@@ -2049,36 +2049,36 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
       hasStroke={false}
       height={400}
       key="0"
-      width={38}
-      x={846}
+      width={28}
+      x={636}
       y={0}
     />
     <Bar
       color="color-chart-0-darkest"
       hasStroke={false}
-      height={160}
+      height={290.90909090909093}
       key="1"
-      width={38}
-      x={884}
-      y={240}
+      width={28}
+      x={664}
+      y={109.09090909090907}
     />
     <Bar
       color="color-chart-bad"
       hasStroke={false}
-      height={180}
+      height={327.2727272727273}
       key="2"
-      width={38}
-      x={922}
-      y={220}
+      width={28}
+      x={692}
+      y={72.72727272727269}
     />
     <Bar
       color="color-chart-4-lightest"
       hasStroke={false}
-      height={20}
+      height={181.8181818181818}
       key="3"
-      width={38}
-      x={960}
-      y={380}
+      width={28}
+      x={720}
+      y={218.1818181818182}
     />
     <Component
       data={
@@ -2120,10 +2120,10 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
           },
           Object {
             "x": "six",
-            "y0": 20,
+            "y0": 11,
             "y1": 8,
             "y2": 9,
-            "y3": 1,
+            "y3": 5,
           },
         ]
       }
@@ -2136,7 +2136,7 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
         Array [
           Array [
             0,
-            20,
+            11,
           ],
           Array [
             0,
@@ -2148,13 +2148,13 @@ exports[`Bars [common] example testing should match snapshot(s) for custom-color
           ],
           Array [
             0,
-            1,
+            5,
           ],
         ]
       }
       seriesIndex={5}
-      width={152}
-      x={846}
+      width={114}
+      x={635}
       xField="x"
       xFormatter={[Function]}
       y={0}

--- a/src/components/Bars/examples/01.basic.jsx
+++ b/src/components/Bars/examples/01.basic.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import createClass from 'create-react-class';
 import { Bars, d3Scale } from '../../../index';
 
-const width = 1000;
+const width = 750;
 const height = 400;
 
 const data = [
@@ -14,7 +14,7 @@ const data = [
 	{ x: 'three', y0: 2, y1: 4, y2: 5, y3: 6 },
 	{ x: 'four', y0: 3, y1: 6, y2: 7, y3: 7 },
 	{ x: 'five', y0: 4, y1: 8, y2: 9, y3: 8 },
-	{ x: 'six', y0: 20, y1: 8, y2: 9, y3: 1 },
+	{ x: 'six', y0: 11, y1: 8, y2: 9, y3: 5 },
 ];
 
 const yFields = ['y0', 'y1', 'y2', 'y3'];
@@ -40,10 +40,14 @@ const yScale = d3Scale
 	.domain([0, yMax])
 	.range([height, 0]);
 
+const style = {
+	paddingTop: '9rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<svg width={width} height={height}>
 					<Bars
 						data={data}

--- a/src/components/Bars/examples/02.custom-colors.jsx
+++ b/src/components/Bars/examples/02.custom-colors.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import createClass from 'create-react-class';
 import { Bars, d3Scale, chartConstants } from '../../../index';
 
-const width = 1000;
+const width = 750;
 const height = 400;
 
 const data = [
@@ -14,7 +14,7 @@ const data = [
 	{ x: 'three', y0: 2, y1: 4, y2: 5, y3: 6 },
 	{ x: 'four', y0: 3, y1: 6, y2: 7, y3: 7 },
 	{ x: 'five', y0: 4, y1: 8, y2: 9, y3: 8 },
-	{ x: 'six', y0: 20, y1: 8, y2: 9, y3: 1 },
+	{ x: 'six', y0: 11, y1: 8, y2: 9, y3: 5 },
 ];
 
 const yFields = ['y0', 'y1', 'y2', 'y3'];
@@ -40,10 +40,14 @@ const yScale = d3Scale
 	.domain([0, yMax])
 	.range([height, 0]);
 
+const style = {
+	paddingTop: '9rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<svg width={width} height={height}>
 					<Bars
 						data={data}

--- a/src/components/LineChart/__snapshots__/LineChart.spec.jsx.snap
+++ b/src/components/LineChart/__snapshots__/LineChart.spec.jsx.snap
@@ -4,7 +4,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 01.basi
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -142,7 +142,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 01.basi
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -152,7 +152,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 03.mult
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -621,7 +621,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 03.mult
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -631,7 +631,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 04.mult
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -796,7 +796,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 04.mult
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -806,7 +806,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 05.stac
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -1041,7 +1041,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 05.stac
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -1051,7 +1051,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 06.dual
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -1096,7 +1096,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 06.dual
     />
   </g>
   <g
-    transform="translate(920, 10)"
+    transform="translate(720, 10)"
   >
     <Axis
       innerTickSize={6}
@@ -1110,7 +1110,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 06.dual
     />
   </g>
   <g
-    transform="translate(920, 10)"
+    transform="translate(720, 10)"
   >
     <AxisLabel
       color="color-chart-2"
@@ -1362,7 +1362,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 06.dual
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -1372,7 +1372,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -1399,7 +1399,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
       height={65}
       label="Date"
       orient="bottom"
-      width={840}
+      width={640}
     />
   </g>
   <g
@@ -1428,7 +1428,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
     />
   </g>
   <g
-    transform="translate(920, 10)"
+    transform="translate(720, 10)"
   >
     <Axis
       innerTickSize={6}
@@ -1442,7 +1442,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
     />
   </g>
   <g
-    transform="translate(920, 10)"
+    transform="translate(720, 10)"
   >
     <AxisLabel
       color="color-chart-1"
@@ -1662,7 +1662,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 07.all-
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -1672,7 +1672,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 08.stac
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -1810,7 +1810,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 08.stac
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -1820,7 +1820,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 09.stac
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -1954,7 +1954,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 09.stac
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -1964,7 +1964,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 10.abbr
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -2110,7 +2110,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 10.abbr
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -2120,7 +2120,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 11.colo
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -2154,7 +2154,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 11.colo
         <rect
           className="lucid-LineChart-invisible"
           height={65}
-          width={840}
+          width={640}
         />
       </ContextMenu.Target>
       <ContextMenu.FlyOut
@@ -2202,7 +2202,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 11.colo
     />
   </g>
   <g
-    transform="translate(920, 10)"
+    transform="translate(720, 10)"
   >
     <Axis
       innerTickSize={6}
@@ -2653,7 +2653,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 11.colo
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>
@@ -2667,7 +2667,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 12.empt
   <svg
     className="lucid-LineChart"
     height={400}
-    width={1000}
+    width={800}
   >
     <g
       transform="translate(80, 10)"
@@ -2719,7 +2719,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 13.empt
   <svg
     className="lucid-LineChart"
     height={400}
-    width={1000}
+    width={800}
   >
     <g
       transform="translate(80, 10)"
@@ -2779,7 +2779,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 14.empt
   <svg
     className="lucid-LineChart"
     height={400}
-    width={1000}
+    width={800}
   >
     <g
       transform="translate(80, 10)"
@@ -2821,7 +2821,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 15.load
   <svg
     className="lucid-LineChart"
     height={400}
-    width={1000}
+    width={800}
   >
     <g
       transform="translate(80, 10)"
@@ -2858,7 +2858,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 16.fine
 <svg
   className="lucid-LineChart"
   height={400}
-  width={1000}
+  width={800}
 >
   <g
     transform="translate(80, 10)"
@@ -2995,7 +2995,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for 16.fine
       height={325}
       onMouseMove={[Function]}
       onMouseOut={[Function]}
-      width={840}
+      width={640}
     />
   </g>
 </svg>

--- a/src/components/LineChart/examples/01.basic.jsx
+++ b/src/components/LineChart/examples/01.basic.jsx
@@ -9,8 +9,16 @@ const data = [
 	{ x: new Date('2015-01-04T00:00:00-08:00'), y: 5 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
-		return <LineChart data={data} />;
+		return (
+			<div style={style}>
+				<LineChart data={data} width={800} />
+			</div>
+		);
 	},
 });

--- a/src/components/LineChart/examples/02.responsive.jsx
+++ b/src/components/LineChart/examples/02.responsive.jsx
@@ -9,14 +9,20 @@ const data = [
 	{ x: new Date('2015-01-04T00:00:00-08:00'), y: 5 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<Resizer>
-				{(width /*, height */) => (
-					<LineChart width={width} height={width * 0.3} data={data} />
-				)}
-			</Resizer>
+			<div style={style}>
+				<Resizer>
+					{(width /*, height */) => (
+						<LineChart width={width} height={width * 0.3} data={data} />
+					)}
+				</Resizer>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/03.multi.jsx
+++ b/src/components/LineChart/examples/03.multi.jsx
@@ -179,14 +179,21 @@ const data = [
 	},
 ];
 
+const style = {
+	paddingTop: '8rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				data={data}
-				yAxisFields={['apples', 'oranges', 'pears']}
-				yAxisTitle='Fruit Count'
-			/>
+			<div style={style}>
+				<LineChart
+					data={data}
+					yAxisFields={['apples', 'oranges', 'pears']}
+					yAxisTitle='Fruit Count'
+					width={800}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/04.multi-with-legend.jsx
+++ b/src/components/LineChart/examples/04.multi-with-legend.jsx
@@ -12,15 +12,20 @@ const data = [
 const yAxisFields = ['apples', 'oranges', 'pears'];
 const palette = chartConstants.PALETTE_MONOCHROME_2_5;
 
+const style = {
+	paddingTop: '8rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<LineChart
 					data={data}
 					yAxisFields={yAxisFields}
 					yAxisTitle='Fruit Count'
 					palette={palette}
+					width={800}
 				/>
 
 				<Legend style={{ verticalAlign: 'top' }}>

--- a/src/components/LineChart/examples/05.stacked.jsx
+++ b/src/components/LineChart/examples/05.stacked.jsx
@@ -59,22 +59,29 @@ const data = [
 	},
 ];
 
+const style = {
+	paddingTop: '11rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				data={data}
-				yAxisFields={[
-					'apples',
-					'oranges',
-					'pears',
-					'bananas',
-					'kiwis',
-					'cherries',
-				]}
-				yAxisIsStacked={true}
-				yAxisTitle='Fruit Count'
-			/>
+			<div style={style}>
+				<LineChart
+					data={data}
+					yAxisFields={[
+						'apples',
+						'oranges',
+						'pears',
+						'bananas',
+						'kiwis',
+						'cherries',
+					]}
+					yAxisIsStacked={true}
+					yAxisTitle='Fruit Count'
+					width={800}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/06.dual-axis.jsx
+++ b/src/components/LineChart/examples/06.dual-axis.jsx
@@ -9,25 +9,32 @@ const data = [
 	{ x: new Date('2015-07-04T00:00:00-08:00'), bananas: 5, cherries: 6 },
 ];
 
+const style = {
+	paddingTop: '5rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				data={data}
-				margin={{
-					right: 80,
-				}}
-				colorMap={{
-					bananas: chartConstants.COLOR_4,
-					cherries: chartConstants.COLOR_2,
-				}}
-				yAxisFields={['bananas']}
-				yAxisTitle='Number of Bananas'
-				yAxisTitleColor={chartConstants.COLOR_4}
-				y2AxisFields={['cherries']}
-				y2AxisTitle='Number of Cherries'
-				y2AxisTitleColor={chartConstants.COLOR_2}
-			/>
+			<div style={style}>
+				<LineChart
+					data={data}
+					margin={{
+						right: 80,
+					}}
+					width={800}
+					colorMap={{
+						bananas: chartConstants.COLOR_4,
+						cherries: chartConstants.COLOR_2,
+					}}
+					yAxisFields={['bananas']}
+					yAxisTitle='Number of Bananas'
+					yAxisTitleColor={chartConstants.COLOR_4}
+					y2AxisFields={['cherries']}
+					y2AxisTitle='Number of Cherries'
+					y2AxisTitleColor={chartConstants.COLOR_2}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/07.all-the-things.jsx
+++ b/src/components/LineChart/examples/07.all-the-things.jsx
@@ -33,36 +33,43 @@ const data = [
 const yFormatter = d => `${d / 1000}k`;
 const xFormatter = d => `${d.getMonth() + 1}-${d.getDate()}`;
 
+const style = {
+	paddingTop: '5rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				margin={{
-					right: 80,
-				}}
-				data={data}
-				colorMap={{
-					blueberries: chartConstants.COLOR_0,
-					oranges: chartConstants.COLOR_1,
-				}}
-				xAxisField='date'
-				xAxisFormatter={xFormatter}
-				xAxisMin={new Date('2014-12-31T00:00-08:00')}
-				xAxisMax={new Date('2015-01-07T00:00-08:00')}
-				xAxisTickCount={5}
-				xAxisTitle='Date'
-				yAxisFields={['blueberries']}
-				yAxisFormatter={yFormatter}
-				yAxisTickCount={5}
-				yAxisTitle='Number of Blueberries'
-				yAxisTitleColor={chartConstants.COLOR_0}
-				y2AxisFields={['oranges']}
-				y2AxisFormatter={yFormatter}
-				y2AxisTickCount={5}
-				y2AxisTitle='Number of Oranges'
-				y2AxisHasPoints={false}
-				y2AxisTitleColor={chartConstants.COLOR_1}
-			/>
+			<div style={style}>
+				<LineChart
+					margin={{
+						right: 80,
+					}}
+					width={800}
+					data={data}
+					colorMap={{
+						blueberries: chartConstants.COLOR_0,
+						oranges: chartConstants.COLOR_1,
+					}}
+					xAxisField='date'
+					xAxisFormatter={xFormatter}
+					xAxisMin={new Date('2014-12-31T00:00-08:00')}
+					xAxisMax={new Date('2015-01-07T00:00-08:00')}
+					xAxisTickCount={5}
+					xAxisTitle='Date'
+					yAxisFields={['blueberries']}
+					yAxisFormatter={yFormatter}
+					yAxisTickCount={5}
+					yAxisTitle='Number of Blueberries'
+					yAxisTitleColor={chartConstants.COLOR_0}
+					y2AxisFields={['oranges']}
+					y2AxisFormatter={yFormatter}
+					y2AxisTickCount={5}
+					y2AxisTitle='Number of Oranges'
+					y2AxisHasPoints={false}
+					y2AxisTitleColor={chartConstants.COLOR_1}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/08.stacked-single-series-with-formatters.jsx
+++ b/src/components/LineChart/examples/08.stacked-single-series-with-formatters.jsx
@@ -9,15 +9,22 @@ const data = [
 	{ x: new Date('2015-01-04T00:00:00-08:00'), y: 5.99 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				yAxisIsStacked
-				yAxisFormatter={yValue => `$ ${yValue}`}
-				yAxisTooltipFormatter={(yField, yValueFormatted) => yValueFormatted}
-				data={data}
-			/>
+			<div style={style}>
+				<LineChart
+					yAxisIsStacked
+					yAxisFormatter={yValue => `$ ${yValue}`}
+					yAxisTooltipFormatter={(yField, yValueFormatted) => yValueFormatted}
+					data={data}
+					width={800}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/09.stacked-monochrome-no-shapes.jsx
+++ b/src/components/LineChart/examples/09.stacked-monochrome-no-shapes.jsx
@@ -53,17 +53,24 @@ const data = [
 	},
 ];
 
+const style = {
+	paddingTop: '10rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				data={data}
-				yAxisFields={['apples', 'oranges', 'pears', 'bananas', 'kiwis']}
-				yAxisIsStacked={true}
-				yAxisHasPoints={false}
-				yAxisTitle='Fruit Count'
-				palette={chartConstants.PALETTE_MONOCHROME_0_5}
-			/>
+			<div style={style}>
+				<LineChart
+					data={data}
+					width={800}
+					yAxisFields={['apples', 'oranges', 'pears', 'bananas', 'kiwis']}
+					yAxisIsStacked={true}
+					yAxisHasPoints={false}
+					yAxisTitle='Fruit Count'
+					palette={chartConstants.PALETTE_MONOCHROME_0_5}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/10.abbreviated-numbers.jsx
+++ b/src/components/LineChart/examples/10.abbreviated-numbers.jsx
@@ -10,15 +10,22 @@ const data = [
 	{ x: new Date('2015-01-11T00:00:00-08:00'), blueberries: 4230872156 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				data={data}
-				yAxisFields={['blueberries']}
-				yAxisFormatter={formatters.formatAbbreviatedNumber}
-				yAxisTooltipDataFormatter={formatters.formatThousands}
-			/>
+			<div style={style}>
+				<LineChart
+					data={data}
+					width={800}
+					yAxisFields={['blueberries']}
+					yAxisFormatter={formatters.formatAbbreviatedNumber}
+					yAxisTooltipDataFormatter={formatters.formatThousands}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/11.color-offset.jsx
+++ b/src/components/LineChart/examples/11.color-offset.jsx
@@ -20,20 +20,27 @@ const data = [
 	{ x: new Date('2015-01-15T00:00:00-08:00'), apples: 165, pears: 113 },
 ];
 
+const style = {
+	paddingTop: '5rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				data={data}
-				margin={{
-					right: 80,
-				}}
-				hasLegend
-				yAxisFields={['apples']}
-				yAxisColorOffset={3}
-				y2AxisFields={['pears']}
-				y2AxisColorOffset={4}
-			/>
+			<div style={style}>
+				<LineChart
+					data={data}
+					margin={{
+						right: 80,
+					}}
+					width={800}
+					hasLegend
+					yAxisFields={['apples']}
+					yAxisColorOffset={3}
+					y2AxisFields={['pears']}
+					y2AxisColorOffset={4}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/LineChart/examples/12.empty.jsx
+++ b/src/components/LineChart/examples/12.empty.jsx
@@ -4,6 +4,6 @@ import { LineChart } from '../../../index';
 
 export default createClass({
 	render() {
-		return <LineChart data={[]} yAxisFields={['blueberries']} />;
+		return <LineChart data={[]} yAxisFields={['blueberries']} width={800} />;
 	},
 });

--- a/src/components/LineChart/examples/13.empty-with-custom-title-and-body.jsx
+++ b/src/components/LineChart/examples/13.empty-with-custom-title-and-body.jsx
@@ -10,7 +10,7 @@ const {
 export default createClass({
 	render() {
 		return (
-			<LineChart data={[]} yAxisFields={['blueberries']}>
+			<LineChart data={[]} yAxisFields={['blueberries']} width={800}>
 				<EmptyStateWrapper>
 					<Title>Something went wrong.</Title>
 					<Body

--- a/src/components/LineChart/examples/14.empty-with-button.jsx
+++ b/src/components/LineChart/examples/14.empty-with-button.jsx
@@ -10,7 +10,7 @@ const {
 export default createClass({
 	render() {
 		return (
-			<LineChart data={[]} yAxisFields={['blueberries']}>
+			<LineChart data={[]} yAxisFields={['blueberries']} width={800}>
 				<EmptyStateWrapper>
 					<Title>Something went wrong.</Title>
 					<Body

--- a/src/components/LineChart/examples/15.loading.jsx
+++ b/src/components/LineChart/examples/15.loading.jsx
@@ -4,6 +4,6 @@ import { LineChart } from '../../../index';
 
 export default createClass({
 	render() {
-		return <LineChart data={[]} isLoading />;
+		return <LineChart data={[]} width={800} isLoading />;
 	},
 });

--- a/src/components/LineChart/examples/16.fine-grained-ticks.jsx
+++ b/src/components/LineChart/examples/16.fine-grained-ticks.jsx
@@ -9,14 +9,21 @@ const data = [
 	{ x: new Date('2018-01-03T00:00:00-0800'), y: 3 },
 ];
 
+const style = {
+	paddingTop: '5rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<LineChart
-				data={data}
-				xAxisTicks={_.map(data, 'x')}
-				xAxisFormatter={date => date.toLocaleDateString()}
-			/>
+			<div style={style}>
+				<LineChart
+					data={data}
+					width={800}
+					xAxisTicks={_.map(data, 'x')}
+					xAxisFormatter={date => date.toLocaleDateString()}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/PieChart/__snapshots__/PieChart.spec.jsx.snap
+++ b/src/components/PieChart/__snapshots__/PieChart.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 1`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 01.basic 1`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -140,7 +140,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 2`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 01.basic 2`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -280,7 +280,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 3`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 01.basic 3`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -420,7 +420,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 4`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 01.basic 4`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -560,7 +560,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 5`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 01.basic 5`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -700,7 +700,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 6`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 01.basic 6`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -840,7 +840,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 7`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 01.basic 7`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -980,7 +980,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 1.basic 
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-donuts 1`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 02.basic-donuts 1`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -1120,7 +1120,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-donuts 2`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 02.basic-donuts 2`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -1260,7 +1260,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-donuts 3`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 02.basic-donuts 3`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -1400,7 +1400,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-donuts 4`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 02.basic-donuts 4`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -1540,7 +1540,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-donuts 5`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 02.basic-donuts 5`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -1680,7 +1680,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-donuts 6`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 02.basic-donuts 6`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -1820,7 +1820,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-donuts 7`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 02.basic-donuts 7`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -1960,7 +1960,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 2.basic-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 3.legend 1`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 03.legend 1`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -2080,7 +2080,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 3.legend
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 4.color-map 1`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 04.color-map 1`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -2220,7 +2220,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 4.color-
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 5.percents 1`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 05.percents 1`] = `
 <svg
   className="lucid-PieChart"
   height={200}
@@ -2360,7 +2360,7 @@ exports[`PieChart [common] example testing should match snapshot(s) for 5.percen
 </svg>
 `;
 
-exports[`PieChart [common] example testing should match snapshot(s) for 6.small-with-no-stroke-or-hover 1`] = `
+exports[`PieChart [common] example testing should match snapshot(s) for 06.small-with-no-stroke-or-hover 1`] = `
 <svg
   className="lucid-PieChart"
   height={25}

--- a/src/components/PieChart/examples/01.basic.tsx
+++ b/src/components/PieChart/examples/01.basic.tsx
@@ -12,10 +12,14 @@ const data = [
 	{ x: 'Ben', y: 15 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<PieChart data={data} />
 				<PieChart data={data} palette={chartConstants.PALETTE_MONOCHROME_0_5} />
 				<PieChart data={data} palette={chartConstants.PALETTE_MONOCHROME_1_5} />

--- a/src/components/PieChart/examples/02.basic-donuts.tsx
+++ b/src/components/PieChart/examples/02.basic-donuts.tsx
@@ -12,10 +12,14 @@ const data = [
 	{ x: 'Ben', y: 15 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<PieChart data={data} isDonut />
 				<PieChart
 					data={data}

--- a/src/components/PieChart/examples/03.legend.tsx
+++ b/src/components/PieChart/examples/03.legend.tsx
@@ -12,15 +12,16 @@ const data = [
 
 const palette = chartConstants.PALETTE_7;
 
+const style = {
+	display: 'flex',
+	alignItems: 'center',
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-				}}
-			>
+			<div style={style}>
 				<PieChart data={data} palette={palette} />
 				<Legend>
 					{_.map(data, (d, index) => (

--- a/src/components/PieChart/examples/04.color-map.tsx
+++ b/src/components/PieChart/examples/04.color-map.tsx
@@ -12,16 +12,22 @@ const data = [
 	{ x: 'Tammy', y: 40 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<PieChart
-				data={data}
-				colorMap={{
-					Tammy: chartConstants.COLOR_BAD,
-					Leslie: chartConstants.COLOR_GOOD,
-				}}
-			/>
+			<div style={style}>
+				<PieChart
+					data={data}
+					colorMap={{
+						Tammy: chartConstants.COLOR_BAD,
+						Leslie: chartConstants.COLOR_GOOD,
+					}}
+				/>
+			</div>
 		);
 	},
 });

--- a/src/components/PieChart/examples/05.percents.tsx
+++ b/src/components/PieChart/examples/05.percents.tsx
@@ -15,10 +15,14 @@ const data = [
 
 const total = _.sum(_.map(data, 'y'));
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<div>
+			<div style={style}>
 				<PieChart
 					data={data}
 					yAxisFormatter={(value: number) => {

--- a/src/components/PieChart/examples/06.small-with-no-stroke-or-hover.tsx
+++ b/src/components/PieChart/examples/06.small-with-no-stroke-or-hover.tsx
@@ -12,22 +12,28 @@ const data = [
 	{ x: 'Ben', y: 15 },
 ];
 
+const style = {
+	paddingTop: '4rem',
+};
+
 export default createClass({
 	render() {
 		return (
-			<PieChart
-				margin={{
-					top: 0,
-					right: 0,
-					bottom: 0,
-					left: 0,
-				}}
-				width={25}
-				height={25}
-				data={data}
-				hasStroke={false}
-				isHovering={false}
-			/>
+			<div style={style}>
+				<PieChart
+					margin={{
+						top: 0,
+						right: 0,
+						bottom: 0,
+						left: 0,
+					}}
+					width={25}
+					height={25}
+					data={data}
+					hasStroke={false}
+					isHovering={false}
+				/>
+			</div>
 		);
 	},
 });


### PR DESCRIPTION
## PR Checklist

Add some padding to the top of the Chart items so that the Legend is visible in Storybook in the Canvas tab. The overflow had been cutting off.

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/bug_cxp-886-chart-tooltips)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
