### PR TITLE
TXP-127 add vertical orientation to dots icon

### DIFF
--- a/src/components/DraggableList/__snapshots__/DraggableList.spec.jsx.snap
+++ b/src/components/DraggableList/__snapshots__/DraggableList.spec.jsx.snap
@@ -29,6 +29,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -39,6 +40,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -73,6 +75,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -83,6 +86,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -117,6 +121,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -127,6 +132,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -161,6 +167,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -171,6 +178,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -205,6 +213,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -215,6 +224,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 1.b
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -394,6 +404,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -404,6 +415,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -454,6 +466,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -464,6 +477,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -514,6 +528,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -524,6 +539,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -574,6 +590,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -584,6 +601,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -634,6 +652,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}
@@ -644,6 +663,7 @@ exports[`DraggableList [common] example testing should match snapshot(s) for 3.w
         <DotsIcon
           aspectRatio="xMidYMid meet"
           color="primary"
+          direction="horizontal"
           isClickable={false}
           isDisabled={false}
           onClick={[Function]}

--- a/src/components/Icon/DotsIcon/DotsIcon.tsx
+++ b/src/components/Icon/DotsIcon/DotsIcon.tsx
@@ -61,7 +61,7 @@ DotsIcon.peek = {
 DotsIcon.propTypes = {
 	...iconPropTypes,
 	direction: oneOf(_.values(Orientation))`
-		Sets the orientation of how the dots are displayed. 
+		Sets the orientation of how the dots are displayed. Defaults to 'horizontal'. 
 	`,
 };
 

--- a/src/components/Icon/DotsIcon/DotsIcon.tsx
+++ b/src/components/Icon/DotsIcon/DotsIcon.tsx
@@ -65,4 +65,9 @@ DotsIcon.propTypes = {
 	`,
 };
 
+DotsIcon.defaultProps = {
+	...Icon.defaultProps,
+	direction: Orientation.horizontal,
+};
+
 export default DotsIcon;

--- a/src/components/Icon/DotsIcon/DotsIcon.tsx
+++ b/src/components/Icon/DotsIcon/DotsIcon.tsx
@@ -9,22 +9,17 @@ import PropTypes from 'react-peek/prop-types';
 const cx = lucidClassNames.bind('&-DotsIcon');
 
 const { oneOf } = PropTypes;
-
-enum Orientation {
-	vertical = 'vertical',
-	horizontal = 'horizontal'
-}
 interface IDotsIconProps extends IIconProps {
-	direction?: keyof typeof Orientation;
+	direction?: 'vertical' | 'horizontal';
 }
 
 export const DotsIcon = ({
 	className,
-	direction = Orientation.horizontal,
+	direction = 'horizontal',
 	color = Color.primary,
 	...passThroughs
 }: IDotsIconProps) => {
-	const isVerticalOrientation = direction === Orientation.vertical;
+	const isVerticalOrientation = direction === 'vertical';
 	const leftOrTopPosition = {
 		cx: isVerticalOrientation ? '8' : '14.5',
 		cy: isVerticalOrientation ? '14.5' : '8',
@@ -60,14 +55,14 @@ DotsIcon.peek = {
 
 DotsIcon.propTypes = {
 	...iconPropTypes,
-	direction: oneOf(_.values(Orientation))`
+	direction: oneOf(['vertical', 'horizontal'])`
 		Sets the orientation of how the dots are displayed. Defaults to 'horizontal'. 
 	`,
 };
 
 DotsIcon.defaultProps = {
 	...Icon.defaultProps,
-	direction: Orientation.horizontal,
+	direction: 'horizontal',
 };
 
 export default DotsIcon;

--- a/src/components/Icon/DotsIcon/DotsIcon.tsx
+++ b/src/components/Icon/DotsIcon/DotsIcon.tsx
@@ -4,16 +4,36 @@ import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
 import { omitProps } from '../../../util/component-types';
 import { Color } from '../Icon';
+import PropTypes from 'react-peek/prop-types';
 
 const cx = lucidClassNames.bind('&-DotsIcon');
 
-interface IDotsIconProps extends IIconProps {}
+const { oneOf } = PropTypes;
+
+enum Orientation {
+	vertical = 'vertical',
+	horizontal = 'horizontal'
+}
+interface IDotsIconProps extends IIconProps {
+	direction?: keyof typeof Orientation;
+}
 
 export const DotsIcon = ({
 	className,
+	direction = Orientation.horizontal,
 	color = Color.primary,
 	...passThroughs
 }: IDotsIconProps) => {
+	const isVerticalOrientation = _.isEqual(direction, Orientation.vertical);
+	const leftOrTopPosition = {
+		cx: isVerticalOrientation ? '8' : '14.5',
+		cy: isVerticalOrientation ? '14.5' : '8',
+	};
+	const rightOrBottomPosition = {
+		cx: isVerticalOrientation ? '8' : '1.5',
+		cy: isVerticalOrientation ? '1.5' : '8',
+	};
+	
 	return (
 		<Icon
 			{...omitProps(passThroughs, undefined, _.keys(DotsIcon.propTypes), false)}
@@ -22,8 +42,8 @@ export const DotsIcon = ({
 			className={cx('&', className)}
 		>
 			<circle className={cx(`&-color-${color}`)} cx='8' cy='8' r='1' />
-			<circle className={cx(`&-color-${color}`)} cx='14.5' cy='8' r='1' />
-			<circle className={cx(`&-color-${color}`)} cx='1.5' cy='8' r='1' />
+			<circle className={cx(`&-color-${color}`)} {...leftOrTopPosition} r='1' />
+			<circle className={cx(`&-color-${color}`)} {...rightOrBottomPosition} r='1' />
 		</Icon>
 	);
 };
@@ -37,7 +57,12 @@ DotsIcon.peek = {
 	extend: 'Icon',
 	madeFrom: ['Icon'],
 };
-DotsIcon.propTypes = iconPropTypes;
-DotsIcon.defaultProps = Icon.defaultProps;
+
+DotsIcon.propTypes = {
+	...iconPropTypes,
+	direction: oneOf(_.values(Orientation))`
+		Sets the orientation of how the dots are displayed. 
+	`,
+};
 
 export default DotsIcon;

--- a/src/components/Icon/DotsIcon/DotsIcon.tsx
+++ b/src/components/Icon/DotsIcon/DotsIcon.tsx
@@ -24,7 +24,7 @@ export const DotsIcon = ({
 	color = Color.primary,
 	...passThroughs
 }: IDotsIconProps) => {
-	const isVerticalOrientation = _.isEqual(direction, Orientation.vertical);
+	const isVerticalOrientation = direction === Orientation.vertical;
 	const leftOrTopPosition = {
 		cx: isVerticalOrientation ? '8' : '14.5',
 		cy: isVerticalOrientation ? '14.5' : '8',

--- a/src/components/Icon/DotsIcon/__snapshots__/DotsIcon.spec.jsx.snap
+++ b/src/components/Icon/DotsIcon/__snapshots__/DotsIcon.spec.jsx.snap
@@ -272,3 +272,276 @@ exports[`DotsIcon [common] example testing should match snapshot(s) for 1.defaul
   />
 </Icon>
 `;
+
+exports[`DotsIcon [common] example testing should match snapshot(s) for 1.default 8`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-DotsIcon"
+  color="primary"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  style={
+    Object {
+      "display": "block",
+      "margin": "10px",
+    }
+  }
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-DotsIcon-color-primary"
+    cx="8"
+    cy="8"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-primary"
+    cx="8"
+    cy="14.5"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-primary"
+    cx="8"
+    cy="1.5"
+    r="1"
+  />
+</Icon>
+`;
+
+exports[`DotsIcon [common] example testing should match snapshot(s) for 1.default 9`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-DotsIcon"
+  color="secondary-one"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  style={
+    Object {
+      "display": "block",
+      "margin": "10px",
+    }
+  }
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-DotsIcon-color-secondary-one"
+    cx="8"
+    cy="8"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-secondary-one"
+    cx="8"
+    cy="14.5"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-secondary-one"
+    cx="8"
+    cy="1.5"
+    r="1"
+  />
+</Icon>
+`;
+
+exports[`DotsIcon [common] example testing should match snapshot(s) for 1.default 10`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-DotsIcon"
+  color="secondary-two"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  style={
+    Object {
+      "display": "block",
+      "margin": "10px",
+    }
+  }
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-DotsIcon-color-secondary-two"
+    cx="8"
+    cy="8"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-secondary-two"
+    cx="8"
+    cy="14.5"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-secondary-two"
+    cx="8"
+    cy="1.5"
+    r="1"
+  />
+</Icon>
+`;
+
+exports[`DotsIcon [common] example testing should match snapshot(s) for 1.default 11`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-DotsIcon"
+  color="secondary-three"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  style={
+    Object {
+      "display": "block",
+      "margin": "10px",
+    }
+  }
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-DotsIcon-color-secondary-three"
+    cx="8"
+    cy="8"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-secondary-three"
+    cx="8"
+    cy="14.5"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-secondary-three"
+    cx="8"
+    cy="1.5"
+    r="1"
+  />
+</Icon>
+`;
+
+exports[`DotsIcon [common] example testing should match snapshot(s) for 1.default 12`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-DotsIcon"
+  color="success"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  style={
+    Object {
+      "display": "block",
+      "margin": "10px",
+    }
+  }
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-DotsIcon-color-success"
+    cx="8"
+    cy="8"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-success"
+    cx="8"
+    cy="14.5"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-success"
+    cx="8"
+    cy="1.5"
+    r="1"
+  />
+</Icon>
+`;
+
+exports[`DotsIcon [common] example testing should match snapshot(s) for 1.default 13`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-DotsIcon"
+  color="neutral-dark"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  style={
+    Object {
+      "display": "block",
+      "margin": "10px",
+    }
+  }
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-DotsIcon-color-neutral-dark"
+    cx="8"
+    cy="8"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-neutral-dark"
+    cx="8"
+    cy="14.5"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-neutral-dark"
+    cx="8"
+    cy="1.5"
+    r="1"
+  />
+</Icon>
+`;
+
+exports[`DotsIcon [common] example testing should match snapshot(s) for 1.default 14`] = `
+<Icon
+  aspectRatio="xMidYMid meet"
+  className="lucid-DotsIcon"
+  color="neutral-light"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  style={
+    Object {
+      "display": "block",
+      "margin": "10px",
+    }
+  }
+  viewBox="0 0 16 16"
+>
+  <circle
+    className="lucid-DotsIcon-color-neutral-light"
+    cx="8"
+    cy="8"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-neutral-light"
+    cx="8"
+    cy="14.5"
+    r="1"
+  />
+  <circle
+    className="lucid-DotsIcon-color-neutral-light"
+    cx="8"
+    cy="1.5"
+    r="1"
+  />
+</Icon>
+`;

--- a/src/components/Icon/DotsIcon/examples/1.default.jsx
+++ b/src/components/Icon/DotsIcon/examples/1.default.jsx
@@ -15,5 +15,12 @@ export default () => (
 		<DotsIcon style={blockStyle} color='success' />
 		<DotsIcon style={blockStyle} color='neutral-dark' />
 		<DotsIcon style={blockStyle} color='neutral-light' />
+		<DotsIcon style={blockStyle} direction='vertical' />
+		<DotsIcon style={blockStyle} direction='vertical' color='secondary-one' />
+		<DotsIcon style={blockStyle} direction='vertical' color='secondary-two' />
+		<DotsIcon style={blockStyle} direction='vertical' color='secondary-three' />
+		<DotsIcon style={blockStyle} direction='vertical' color='success' />
+		<DotsIcon style={blockStyle} direction='vertical' color='neutral-dark' />
+		<DotsIcon style={blockStyle} direction='vertical' color='neutral-light' />
 	</div>
 );


### PR DESCRIPTION
## PR Checklist

Add vertical option to the three dots icon.

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/txp-127-add-vertical-orientation-to-dots-icon/?path=/story/icons-icons-dotsicon--default)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
