### PR TITLE
Feature/TXP-105 min-width added for table

### DIFF
--- a/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
@@ -16907,7 +16907,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 onResize={null}
                 rowSpan={null}
                 sortDirection="up"
-                width={900}
+                width={100}
               >
                 E-Mail
               </Table.Th>
@@ -17471,7 +17471,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -17578,7 +17578,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -17685,7 +17685,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -17792,7 +17792,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -17899,7 +17899,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -18006,7 +18006,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -18113,7 +18113,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -18220,7 +18220,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -18327,7 +18327,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -18434,7 +18434,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -18587,6 +18587,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 isResizable={true}
                 isSorted={false}
                 key="first_name"
+                minWidth={50}
                 onClick={null}
                 onResize={[Function]}
                 rowSpan={null}
@@ -18619,7 +18620,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 onResize={[Function]}
                 rowSpan={null}
                 sortDirection="up"
-                width={900}
+                width={100}
               >
                 E-Mail
               </Table.Th>
@@ -19152,6 +19153,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row0first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19183,7 +19185,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -19259,6 +19261,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row1first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19290,7 +19293,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -19366,6 +19369,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row2first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19397,7 +19401,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -19473,6 +19477,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row3first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19504,7 +19509,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -19580,6 +19585,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row4first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19611,7 +19617,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -19687,6 +19693,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row5first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19718,7 +19725,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -19794,6 +19801,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row6first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19825,7 +19833,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -19901,6 +19909,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row7first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -19932,7 +19941,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -20008,6 +20017,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row8first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -20039,7 +20049,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >
@@ -20115,6 +20125,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 hasBorderLeft={false}
                 hasBorderRight={false}
                 key="row9first_name"
+                minWidth={50}
                 rowSpan={1}
                 style={
                   Object {
@@ -20146,7 +20157,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 900,
+                    "width": 100,
                   }
                 }
               >

--- a/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.spec.jsx.snap
@@ -16907,7 +16907,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 onResize={null}
                 rowSpan={null}
                 sortDirection="up"
-                width={100}
+                width={900}
               >
                 E-Mail
               </Table.Th>
@@ -17471,7 +17471,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -17578,7 +17578,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -17685,7 +17685,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -17792,7 +17792,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -17899,7 +17899,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -18006,7 +18006,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -18113,7 +18113,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -18220,7 +18220,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -18327,7 +18327,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -18434,7 +18434,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 13.fixe
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -18620,7 +18620,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 onResize={[Function]}
                 rowSpan={null}
                 sortDirection="up"
-                width={100}
+                width={900}
               >
                 E-Mail
               </Table.Th>
@@ -19185,7 +19185,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -19293,7 +19293,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -19401,7 +19401,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -19509,7 +19509,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -19617,7 +19617,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -19725,7 +19725,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -19833,7 +19833,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -19941,7 +19941,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -20049,7 +20049,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >
@@ -20157,7 +20157,7 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
                 rowSpan={1}
                 style={
                   Object {
-                    "width": 100,
+                    "width": 900,
                   }
                 }
               >

--- a/src/components/DataTable/examples/13.fixed-headers.jsx
+++ b/src/components/DataTable/examples/13.fixed-headers.jsx
@@ -133,7 +133,7 @@ export default createClass({
 					Last
 				</DataTable.Column>
 
-				<DataTable.Column field='email' align='left' width={900}>
+				<DataTable.Column field='email' align='left' width={100}>
 					E-Mail
 				</DataTable.Column>
 

--- a/src/components/DataTable/examples/13.fixed-headers.jsx
+++ b/src/components/DataTable/examples/13.fixed-headers.jsx
@@ -133,7 +133,7 @@ export default createClass({
 					Last
 				</DataTable.Column>
 
-				<DataTable.Column field='email' align='left' width={100}>
+				<DataTable.Column field='email' align='left' width={900}>
 					E-Mail
 				</DataTable.Column>
 

--- a/src/components/DataTable/examples/14.resizable-fixed-headers-table.jsx
+++ b/src/components/DataTable/examples/14.resizable-fixed-headers-table.jsx
@@ -127,7 +127,7 @@ export default createClass({
 	renderDataTable(props) {
 		return (
 			<DataTable data={data} {...props}>
-				<DataTable.Column field='id' align='left' width={35} minWidth={35} isResizable>
+				<DataTable.Column field='id' align='left' width={35} isResizable>
 					ID
 				</DataTable.Column>
 
@@ -146,13 +146,11 @@ export default createClass({
 					align='left'
 					width={100}
 					isResizable
-					minWidth={50}
 				>
 					Last
 				</DataTable.Column>
 
-				<DataTable.Column field='email' align='left' width={100} 
-					minWidth={50} isResizable>
+				<DataTable.Column field='email' align='left' width={100} isResizable>
 					E-Mail
 				</DataTable.Column>
 
@@ -161,7 +159,6 @@ export default createClass({
 					align='left'
 					width={100}
 					isResizable
-					minWidth={55}
 				>
 					Occupation
 				</DataTable.Column>

--- a/src/components/DataTable/examples/14.resizable-fixed-headers-table.jsx
+++ b/src/components/DataTable/examples/14.resizable-fixed-headers-table.jsx
@@ -127,7 +127,7 @@ export default createClass({
 	renderDataTable(props) {
 		return (
 			<DataTable data={data} {...props}>
-				<DataTable.Column field='id' align='left' width={35} isResizable>
+				<DataTable.Column field='id' align='left' width={35} minWidth={35} isResizable>
 					ID
 				</DataTable.Column>
 
@@ -135,6 +135,7 @@ export default createClass({
 					field='first_name'
 					align='left'
 					width={100}
+					minWidth={50}
 					isResizable
 				>
 					First
@@ -145,11 +146,13 @@ export default createClass({
 					align='left'
 					width={100}
 					isResizable
+					minWidth={50}
 				>
 					Last
 				</DataTable.Column>
 
-				<DataTable.Column field='email' align='left' width={900} isResizable>
+				<DataTable.Column field='email' align='left' width={100} 
+					minWidth={50} isResizable>
 					E-Mail
 				</DataTable.Column>
 
@@ -158,6 +161,7 @@ export default createClass({
 					align='left'
 					width={100}
 					isResizable
+					minWidth={55}
 				>
 					Occupation
 				</DataTable.Column>

--- a/src/components/DataTable/examples/14.resizable-fixed-headers-table.jsx
+++ b/src/components/DataTable/examples/14.resizable-fixed-headers-table.jsx
@@ -150,7 +150,7 @@ export default createClass({
 					Last
 				</DataTable.Column>
 
-				<DataTable.Column field='email' align='left' width={100} isResizable>
+				<DataTable.Column field='email' align='left' width={900} isResizable>
 					E-Mail
 				</DataTable.Column>
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -498,7 +498,7 @@ export class Th extends React.Component<IThProps, IThState> {
 			passiveWidth = parseInt(passiveWidth);
 		}
 		
-		const activeWidth = this.props.minWidth && passiveWidth + coordinates.dX > this.props.minWidth ? passiveWidth + coordinates.dX : !this.props.minWidth ? passiveWidth + coordinates.dX : this.props.minWidth;
+		const activeWidth = ((this.props.minWidth && passiveWidth + coordinates.dX > this.props.minWidth) || !this.props.minWidth) ? passiveWidth + coordinates.dX : this.props.minWidth;
 
 		this.setState({ activeWidth });
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -252,6 +252,9 @@ interface IThProps
 	/** Sets the width of the cell. */
 	width?: number | string;
 
+	/** Sets the min width of the cell. */
+	minWidth?: number | string;
+	
 	/** Indicates for how many columns the cell extends */
 	colSpan?: number;
 
@@ -367,6 +370,10 @@ export class Th extends React.Component<IThProps, IThState> {
 
 		width: oneOfType([number, string])`
 			Sets the width of the cell.
+		`,
+
+		minWidth: oneOfType([number, string])`
+			Sets the min width of the cell.
 		`,
 
 		isFirstRow: bool`
@@ -490,8 +497,8 @@ export class Th extends React.Component<IThProps, IThState> {
 		} else if (_.isString(passiveWidth)) {
 			passiveWidth = parseInt(passiveWidth);
 		}
-
-		const activeWidth = passiveWidth + coordinates.dX;
+		
+		const activeWidth = this.props.minWidth && passiveWidth + coordinates.dX > this.props.minWidth ? passiveWidth + coordinates.dX : !this.props.minWidth ? passiveWidth + coordinates.dX : this.props.minWidth;
 
 		this.setState({ activeWidth });
 


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
