### PR TITLE
Feature/cxp 1080 update table cursor icon

### DIFF
--- a/src/components/Table/Table.less
+++ b/src/components/Table/Table.less
@@ -21,11 +21,19 @@
 	&-no-hover.@{prefix}-Table {
 		.@{prefix}-Table-Tbody {
 			.@{prefix}-Table-Tr:hover {
+				cursor: default;
+
 				& > .@{prefix}-Table-Td.@{prefix}-Table-is-first-single::after {
 					display: none;
 				}
 				& > .@{prefix}-Table-Td[rowspan] {
 					background-color: white;
+				}
+			}
+			.@{prefix}-Table-Tr.@{prefix}-Table-is-selected:hover {
+				cursor: default;
+				& > .@{prefix}-Table-Td[rowspan] {
+					background-color: #e6ecf5;
 				}
 			}
 		}
@@ -263,6 +271,8 @@
 
 			// style row cells on hover
 			&:hover {
+				cursor: pointer;
+
 				.selectCellsOnRow(
 					{background-color: @color-table-row-hover-background;}
 				);

--- a/src/components/Tag/examples/01.basic.jsx
+++ b/src/components/Tag/examples/01.basic.jsx
@@ -7,8 +7,8 @@ export default createClass({
 		return (
 			<div>
 				<div>
-					<Tag id='1'>Amet</Tag>
-					<Tag id='2'>nam</Tag>
+					<Tag>Amet</Tag>
+					<Tag>nam</Tag>
 					<Tag>quibusdam</Tag>
 					<Tag isRemovable>nobis</Tag>
 					<Tag isRemovable>autem</Tag>

--- a/src/components/Tag/examples/01.basic.jsx
+++ b/src/components/Tag/examples/01.basic.jsx
@@ -7,8 +7,8 @@ export default createClass({
 		return (
 			<div>
 				<div>
-					<Tag>Amet</Tag>
-					<Tag>nam</Tag>
+					<Tag id='1'>Amet</Tag>
+					<Tag id='2'>nam</Tag>
 					<Tag>quibusdam</Tag>
 					<Tag isRemovable>nobis</Tag>
 					<Tag isRemovable>autem</Tag>


### PR DESCRIPTION
## PR Checklist

Update the `Table` cursor icon so that it shows the pointer when hovering over rows and the arrow when the row is  set to `no hover`.

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/feature_cxp-1080-update-table-cursor-icon/?path=/docs/table-table--no-hover)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
