### PR TITLE
Use donutWidth prop to control width of a donut chart

### DIFF
--- a/src/components/PieChart/PieChart.tsx
+++ b/src/components/PieChart/PieChart.tsx
@@ -185,6 +185,7 @@ const PieChart = (props: IPieChartProps) => {
 		palette,
 		colorMap,
 		isDonut,
+		donutWidth,
 		ToolTip: toolTipProps,
 
 		isHovering,
@@ -238,7 +239,7 @@ const PieChart = (props: IPieChartProps) => {
 
 	const arc = d3Shape
 		.arc()
-		.innerRadius(isDonut ? outerRadius - PieChart.DONUT_WIDTH : INNER_RADIUS)
+		.innerRadius(isDonut ? outerRadius - donutWidth : INNER_RADIUS)
 		.outerRadius(outerRadius);
 
 	// Useful for capturing hovers when we're in donut mode


### PR DESCRIPTION
`PieChart` component has a `donutWidth` prop in it, but it is not used to control the width of the donut chart. It uses the default prop 15px value of `DONUT_WIDTH` all the time. Make it so if `donutWidth` prop passed then use its value, otherwise use `DONUT_WIDTH`


## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
