### PR TITLE
Expose component interfaces

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -31,7 +31,7 @@ interface IAccordionPropsRaw extends StandardProps {
 	) => void;
 }
 
-type IAccordionProps = Overwrite<
+export type IAccordionProps = Overwrite<
 	React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
 	IAccordionPropsRaw
 >;

--- a/src/components/ExpanderPanel/ExpanderPanel.tsx
+++ b/src/components/ExpanderPanel/ExpanderPanel.tsx
@@ -36,7 +36,7 @@ Header.propTypes = {
 	`,
 };
 
-interface IExpanderPanelProps extends StandardProps {
+export interface IExpanderPanelProps extends StandardProps {
 	/** Indicates that the component is in the "expanded" state when true and in
 			the "unexpanded" state when false. */
 	isExpanded: boolean;

--- a/src/components/PieChart/PieChart.tsx
+++ b/src/components/PieChart/PieChart.tsx
@@ -141,7 +141,7 @@ export interface IPieChartPropsRaw extends StandardProps {
 	yAxisFormatter: (y: number) => string | number;
 }
 
-type IPieChartProps = Overwrite<React.SVGProps<SVGGElement>, IPieChartPropsRaw>;
+export type IPieChartProps = Overwrite<React.SVGProps<SVGGElement>, IPieChartPropsRaw>;
 
 const defaultProps = {
 	height: 200,

--- a/src/components/VerticalListMenu/VerticalListMenu.tsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.tsx
@@ -53,7 +53,8 @@ export interface IVerticalListMenuPropsRaw extends StandardProps {
 		}
 	) => void;
 }
-type IVerticalListMenuProps = Overwrite<
+
+export type IVerticalListMenuProps = Overwrite<
 	React.DetailedHTMLProps<
 		React.HTMLAttributes<HTMLUListElement>,
 		HTMLUListElement

--- a/src/components/VerticalTabs/VerticalTabs.tsx
+++ b/src/components/VerticalTabs/VerticalTabs.tsx
@@ -81,7 +81,7 @@ interface IVerticalTabsPropsRaw extends StandardProps {
 	) => void;
 }
 
-type IVerticalTabsProps = Overwrite<
+export type IVerticalTabsProps = Overwrite<
 	React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
 	IVerticalTabsPropsRaw
 >;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,49 +1,49 @@
 // components with reducers
-import Accordion, { AccordionDumb } from './components/Accordion/Accordion';
+import Accordion, { AccordionDumb, IAccordionState, IAccordionProps } from './components/Accordion/Accordion';
 import Autocomplete, {
 	AutocompleteDumb,
 	// @ts-ignore: not converted yet
 } from './components/Autocomplete/Autocomplete';
 import ButtonGroup, {
-	ButtonGroupDumb,
+	ButtonGroupDumb, IButtonGroupProps, IButtonGroupState
 } from './components/ButtonGroup/ButtonGroup';
 import SearchableSelect, {
-	SearchableSelectDumb,
+	SearchableSelectDumb, ISearchableSelectProps, ISearchableSelectState, ISearchableSelectOptionProps
 } from './components/SearchableSelect/SearchableSelect';
-import DateSelect, { DateSelectDumb } from './components/DateSelect/DateSelect';
+import DateSelect, { DateSelectDumb, IDateSelectProps, IDateSelectState } from './components/DateSelect/DateSelect';
 import SearchableMultiSelect, {
-	SearchableMultiSelectDumb,
+	SearchableMultiSelectDumb, ISearchableMultiSelectProps, ISearchableMultiSelectState, ISearchableMultiSelectOptionProps, ISearchableMultiSelectPropsRaw
 } from './components/SearchableMultiSelect/SearchableMultiSelect';
 import SearchableSingleSelect, {
-	SearchableSingleSelectDumb,
+	SearchableSingleSelectDumb, ISearchableSingleSelectProps, ISearchableSingleSelectState, ISearchableSingleSelectOptionProps, ISearchableSingleSelectPropsRaw
 } from './components/SearchableSingleSelect/SearchableSingleSelect';
-import DropMenu, { DropMenuDumb } from './components/DropMenu/DropMenu';
-import Expander, { ExpanderDumb } from './components/Expander/Expander';
+import DropMenu, { DropMenuDumb, IDropMenuProps, IDropMenuState, IDropMenuOptionProps, IDropMenuOptionGroupProps, IDropMenuFixedOptionProps, IDropMenuNullOptionProps } from './components/DropMenu/DropMenu';
+import Expander, { ExpanderDumb, IExpanderProps, IExpanderState } from './components/Expander/Expander';
 import ExpanderPanel, {
-	ExpanderPanelDumb,
+	ExpanderPanelDumb, IExpanderPanelProps, IExpanderPanelHeaderProps
 } from './components/ExpanderPanel/ExpanderPanel';
-import Paginator, { PaginatorDumb } from './components/Paginator/Paginator';
-import PieChart, { PieChartDumb } from './components/PieChart/PieChart';
+import Paginator, { PaginatorDumb, IPaginatorProps, IPaginatorState } from './components/Paginator/Paginator';
+import PieChart, { PieChartDumb, IPieChartProps, IPieChartPropsRaw } from './components/PieChart/PieChart';
 // @ts-ignore: not converted yet
 import RadioGroup, { RadioGroupDumb } from './components/RadioGroup/RadioGroup';
 import SearchField, {
-	SearchFieldDumb,
+	SearchFieldDumb, ISearchFieldProps, ISearchFieldState
 } from './components/SearchField/SearchField';
-import Sidebar, { SidebarDumb } from './components/Sidebar/Sidebar';
+import Sidebar, { SidebarDumb, ISidebarProps, ISidebarState } from './components/Sidebar/Sidebar';
 import SingleSelect, {
-	SingleSelectDumb,
+	SingleSelectDumb, ISingleSelectProps, ISingleSelectState, ISingleSelectOptionProps
 } from './components/SingleSelect/SingleSelect';
 import SplitButton, {
-	SplitButtonDumb,
+	SplitButtonDumb, ISplitButtonProps
 } from './components/SplitButton/SplitButton';
-import Submarine, { SubmarineDumb } from './components/Submarine/Submarine';
-import Tabs, { TabsDumb } from './components/Tabs/Tabs';
-import ToolTip, { ToolTipDumb } from './components/ToolTip/ToolTip';
+import Submarine, { SubmarineDumb, ISubmarineState } from './components/Submarine/Submarine';
+import Tabs, { TabsDumb, ITabsState } from './components/Tabs/Tabs';
+import ToolTip, { ToolTipDumb, IToolTipProps, IToolTipState } from './components/ToolTip/ToolTip';
 import VerticalListMenu, {
-	VerticalListMenuDumb,
+	VerticalListMenuDumb, IVerticalListMenuProps, IVerticalListMenuState, IVerticalListMenuItemProps, IVerticalListMenuPropsRaw
 } from './components/VerticalListMenu/VerticalListMenu';
 import VerticalTabs, {
-	VerticalTabsDumb,
+	VerticalTabsDumb, IVerticalTabsProps, IVerticalTabsState
 } from './components/VerticalTabs/VerticalTabs';
 
 // dumb components
@@ -221,6 +221,8 @@ export {
 export {
 	Accordion,
 	AccordionDumb,
+	IAccordionProps,
+	IAccordionState,
 	AddURLIcon,
 	AnalyzeDataIcon,
 	ArrowIcon,
@@ -243,6 +245,8 @@ export {
 	Button,
 	ButtonGroup,
 	ButtonGroupDumb,
+	IButtonGroupProps,
+	IButtonGroupState,
 	CalendarIcon,
 	ChatIcon,
 	Checkbox,
@@ -260,6 +264,8 @@ export {
 	DataTable,
 	DateSelect,
 	DateSelectDumb,
+	IDateSelectProps,
+	IDateSelectState,
 	DeleteIcon,
 	Dialog,
 	DotsIcon,
@@ -268,6 +274,12 @@ export {
 	DraggableList,
 	DropMenu,
 	DropMenuDumb,
+	IDropMenuProps,
+	IDropMenuState,
+	IDropMenuOptionProps, 
+	IDropMenuOptionGroupProps, 
+	IDropMenuFixedOptionProps, 
+	IDropMenuNullOptionProps,
 	DuplicateIcon,
 	EditIcon,
 	EligibilityIcon,
@@ -277,8 +289,12 @@ export {
 	EqualsIcon,
 	Expander,
 	ExpanderDumb,
+	IExpanderProps, 
+	IExpanderState,
 	ExpanderPanel,
 	ExpanderPanelDumb,
+	IExpanderPanelProps, 
+	IExpanderPanelHeaderProps,
 	FileIcon,
 	FilterIcon,
 	FlagIcon,
@@ -316,9 +332,13 @@ export {
 	OverlayWrapper,
 	Paginator,
 	PaginatorDumb,
+	IPaginatorProps, 
+	IPaginatorState,
 	Panel,
 	PieChart,
 	PieChartDumb,
+	IPieChartProps,
+	IPieChartPropsRaw,
 	PlusIcon,
 	Point,
 	Points,
@@ -338,12 +358,25 @@ export {
 	ScrollTable,
 	SearchableMultiSelect,
 	SearchableMultiSelectDumb,
+	ISearchableMultiSelectProps,
+	ISearchableMultiSelectState,
+	ISearchableMultiSelectOptionProps,
+	ISearchableMultiSelectPropsRaw,
 	SearchableSingleSelect,
 	SearchableSingleSelectDumb,
+	ISearchableSingleSelectProps,
+	ISearchableSingleSelectState,
+	ISearchableSingleSelectOptionProps,
+	ISearchableSingleSelectPropsRaw,
 	SearchableSelect,
 	SearchableSelectDumb,
+	ISearchableSelectProps,
+	ISearchableSelectState,
+	ISearchableSelectOptionProps,
 	SearchField,
 	SearchFieldDumb,
+	ISearchFieldProps, 
+	ISearchFieldState,
 	SearchIcon,
 	Selection,
 	SeparatorIcon,
@@ -352,10 +385,16 @@ export {
 	SidePanel,
 	Sidebar,
 	SidebarDumb,
+	ISidebarProps,
+	ISidebarState,
 	SingleSelect,
 	SingleSelectDumb,
+	ISingleSelectProps, 
+	ISingleSelectState, 
+	ISingleSelectOptionProps,
 	SplitButton,
 	SplitButtonDumb,
+	ISplitButtonProps,
 	SplitHorizontal,
 	SplitVertical,
 	StarIcon,
@@ -364,6 +403,7 @@ export {
 	StopwatchIcon,
 	Submarine,
 	SubmarineDumb,
+	ISubmarineState,
 	SuccessIcon,
 	SuccessLightIcon,
 	Switch,
@@ -372,12 +412,15 @@ export {
 	Table,
 	Tabs,
 	TabsDumb,
+	ITabsState,
 	Tag,
 	TextIcon,
 	TextField,
 	TextFieldValidated,
 	ToolTip,
 	ToolTipDumb,
+	IToolTipProps,
+	IToolTipState,
 	Typography,
 	Underline,
 	UnlinkedIcon,
@@ -387,8 +430,14 @@ export {
 	Validation,
 	VerticalListMenu,
 	VerticalListMenuDumb,
+	IVerticalListMenuProps,
+	IVerticalListMenuState, 
+	IVerticalListMenuItemProps,
+	IVerticalListMenuPropsRaw,
 	VerticalTabs,
 	VerticalTabsDumb,
+	IVerticalTabsProps,
+	IVerticalTabsState,
 	VideoIcon,
 	VideoLiveIcon,
 	VideoLongIcon,


### PR DESCRIPTION
This PR exposes each of the component interfaces for state and props, some of the subcomponent interfaces, and raw props interfaces at the package level so they can be used. There is an argument for exporting everything based on the situation so that's what I did. Let me know if you don't want anything exposed here.

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
