### PR TITLE
BUDE-420: Update Bars props

### DIFF
--- a/src/components/Bars/Bars.tsx
+++ b/src/components/Bars/Bars.tsx
@@ -144,7 +144,12 @@ interface IBarsProps extends StandardProps {
 	 * This formatter will over-ride yTooltipFormatter and yAxisTooltipDataFormatter.
 	 * Signature: \`dataPoint => {}\`
 	 */
-	renderTooltipBody: (dataPoint: number) => {};
+	renderTooltipBody: (dataPoint: number | string | object) => {};
+
+	/** Optional built in SVG transform attribute, used to transform the bars position
+	 * in the same way CSS transform is used, `translate(10, 20)`
+	 */
+	transform?: string;
 }
 
 interface IBarsState {
@@ -280,6 +285,11 @@ export class Bars extends PureComponent<IBarsProps, IBarsState> {
 			the associated data point. This formatter will over-ride yTooltipFormatter
 			and yAxisTooltipDataFormatter. Signature:
 			\`dataPoint => {}\`
+		`,
+
+		transform: string`
+			Optional built in SVG transform attribute, used to transform the bars position
+			in the same way CSS transform is used, \`translate(10, 20)\`
 		`,
 	};
 

--- a/src/components/Bars/Bars.tsx
+++ b/src/components/Bars/Bars.tsx
@@ -20,7 +20,7 @@ const cx = lucidClassNames.bind('&-Bars');
 
 const { arrayOf, func, number, object, bool, string } = PropTypes;
 
-interface IBarsProps extends StandardProps {
+interface IBarsProps extends StandardProps, React.SVGProps<SVGGElement> {
 	/**
 	 * De-normalized data
 	 *
@@ -145,11 +145,6 @@ interface IBarsProps extends StandardProps {
 	 * Signature: \`dataPoint => {}\`
 	 */
 	renderTooltipBody: (dataPoint: number | string | object) => {};
-
-	/** Optional built in SVG transform attribute, used to transform the bars position
-	 * in the same way CSS transform is used, `translate(10, 20)`
-	 */
-	transform?: string;
 }
 
 interface IBarsState {
@@ -285,11 +280,6 @@ export class Bars extends PureComponent<IBarsProps, IBarsState> {
 			the associated data point. This formatter will over-ride yTooltipFormatter
 			and yAxisTooltipDataFormatter. Signature:
 			\`dataPoint => {}\`
-		`,
-
-		transform: string`
-			Optional built in SVG transform attribute, used to transform the bars position
-			in the same way CSS transform is used, \`translate(10, 20)\`
 		`,
 	};
 


### PR DESCRIPTION
Small PR updating Bars props

First I updated renderTooltipBody to have a type of `number | string | object` instead of just number. Because I've seen instances of it being any of those, object in my specific case that this PR is addressing.

Second, ~I'm adding `transform` as a prop. Transform is an included attribute for svg's that is helpful to be used for tweaking the positioning of the Bars within axes.~ I've updated Bars to extend SVGProps props, to include `transform` and others

## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
