### PR TITLE
Bude 121

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1179,6 +1179,7 @@
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
 			"integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -5192,9 +5193,9 @@
 			}
 		},
 		"@types/react-transition-group": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-1.1.6.tgz",
-			"integrity": "sha512-zzoJIWFAqvI3EwDizpeJoShUEe6dVIw3EDRmnqLlpmQgfbaw6XUmJYFVOiAyZVnO/9L7zPSe3kN8aZ2q3JP2DA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+			"integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
@@ -7639,11 +7640,6 @@
 			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
 			"dev": true
 		},
-		"chain-function": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
-			"integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -9763,6 +9759,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
 			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2"
 			}
@@ -20110,15 +20107,38 @@
 			}
 		},
 		"react-transition-group": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-			"integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
 			"requires": {
-				"chain-function": "^1.0.0",
-				"dom-helpers": "^3.2.0",
-				"loose-envify": "^1.3.1",
-				"prop-types": "^15.5.6",
-				"warning": "^3.0.0"
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.10.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+					"integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"dom-helpers": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+					"integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+					"requires": {
+						"@babel/runtime": "^7.8.7",
+						"csstype": "^2.6.7"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.5",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+				}
 			}
 		},
 		"reactcss": {
@@ -20350,7 +20370,8 @@
 		"regenerator-runtime": {
 			"version": "0.13.2",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.13.4",
@@ -23996,6 +24017,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"react-day-picker": "^6.2.1",
 		"react-motion": "^0.5.2",
 		"react-peek": "^1.0.5",
-		"react-transition-group": "^1.2.1",
+		"react-transition-group": "^4.4.1",
 		"reselect": "^4.0.0"
 	},
 	"devDependencies": {
@@ -100,7 +100,7 @@
 		"@types/react": "^16.8.23",
 		"@types/react-dom": "^16.8.4",
 		"@types/react-motion": "0.0.29",
-		"@types/react-transition-group": "^1.1.6",
+		"@types/react-transition-group": "^4.4.0",
 		"@types/sinon": "^7.0.13",
 		"@typescript-eslint/eslint-plugin": "^1.13.0",
 		"@typescript-eslint/parser": "^1.13.0",

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { CSSTransition } from 'react-transition-group';
 import { lucidClassNames } from '../../util/style-helpers';
 import { omitProps, StandardProps } from '../../util/component-types';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
@@ -88,48 +88,46 @@ export const Banner = (props: IBannerProps): React.ReactElement => {
 	}
 
 	return (
-		<TransitionGroup>
-			<CSSTransition
-				classNames={cx('&')}
-				timeout={300}
+		<CSSTransition
+			in={!isClosed}
+			classNames={cx('&')}
+			timeout={300}
+			unmountOnExit
+		>
+			<section
+				{...omitProps(passThroughs, undefined, _.keys(Banner.propTypes))}
+				className={cx(
+					'&',
+					{
+						'&-has-icon': displayedIcon,
+						'&-has-close': isCloseable,
+						'&-primary': kind === 'primary',
+						'&-success': kind === 'success',
+						'&-warning': kind === 'warning',
+						'&-danger': kind === 'danger',
+						'&-info': kind === 'info',
+						'&-small': isSmall,
+						'&-filled': isFilled,
+					},
+					className
+				)}
 			>
-				{!isClosed ? (
-					<section
-						{...omitProps(passThroughs, undefined, _.keys(Banner.propTypes))}
-						className={cx(
-							'&',
-							{
-								'&-has-icon': displayedIcon,
-								'&-has-close': isCloseable,
-								'&-primary': kind === 'primary',
-								'&-success': kind === 'success',
-								'&-warning': kind === 'warning',
-								'&-danger': kind === 'danger',
-								'&-info': kind === 'info',
-								'&-small': isSmall,
-								'&-filled': isFilled,
-							},
-							className
-						)}
-					>
-						{displayedIcon ? (
-							<span className={cx('&-icon')}>{displayedIcon}</span>
-						) : null}
+				{displayedIcon ? (
+					<span className={cx('&-icon')}>{displayedIcon}</span>
+				) : null}
 
-						<span className={cx('&-content')}>{children}</span>
+				<span className={cx('&-content')}>{children}</span>
 
-						{isCloseable ? (
-							<CloseIcon
-								isClickable
-								size={8}
-								className={cx('&-close')}
-								onClick={handleClose}
-							/>
-						) : null}
-					</section>
-				) : <React.Fragment></React.Fragment>}
-			</CSSTransition>
-		</TransitionGroup>
+				{isCloseable ? (
+					<CloseIcon
+						isClickable
+						size={8}
+						className={cx('&-close')}
+						onClick={handleClose}
+					/>
+				) : null}
+			</section>
+		</CSSTransition>
 	);
 };
 

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
-import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { lucidClassNames } from '../../util/style-helpers';
 import { omitProps, StandardProps } from '../../util/component-types';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
@@ -88,47 +88,48 @@ export const Banner = (props: IBannerProps): React.ReactElement => {
 	}
 
 	return (
-		<ReactTransitionGroup
-			transitionName={cx('&')}
-			transitionEnterTimeout={300}
-			transitionLeaveTimeout={300}
-		>
-			{!isClosed ? (
-				<section
-					{...omitProps(passThroughs, undefined, _.keys(Banner.propTypes))}
-					className={cx(
-						'&',
-						{
-							'&-has-icon': displayedIcon,
-							'&-has-close': isCloseable,
-							'&-primary': kind === 'primary',
-							'&-success': kind === 'success',
-							'&-warning': kind === 'warning',
-							'&-danger': kind === 'danger',
-							'&-info': kind === 'info',
-							'&-small': isSmall,
-							'&-filled': isFilled,
-						},
-						className
-					)}
-				>
-					{displayedIcon ? (
-						<span className={cx('&-icon')}>{displayedIcon}</span>
-					) : null}
+		<TransitionGroup>
+			<CSSTransition
+				classNames={cx('&')}
+				timeout={300}
+			>
+				{!isClosed ? (
+					<section
+						{...omitProps(passThroughs, undefined, _.keys(Banner.propTypes))}
+						className={cx(
+							'&',
+							{
+								'&-has-icon': displayedIcon,
+								'&-has-close': isCloseable,
+								'&-primary': kind === 'primary',
+								'&-success': kind === 'success',
+								'&-warning': kind === 'warning',
+								'&-danger': kind === 'danger',
+								'&-info': kind === 'info',
+								'&-small': isSmall,
+								'&-filled': isFilled,
+							},
+							className
+						)}
+					>
+						{displayedIcon ? (
+							<span className={cx('&-icon')}>{displayedIcon}</span>
+						) : null}
 
-					<span className={cx('&-content')}>{children}</span>
+						<span className={cx('&-content')}>{children}</span>
 
-					{isCloseable ? (
-						<CloseIcon
-							isClickable
-							size={8}
-							className={cx('&-close')}
-							onClick={handleClose}
-						/>
-					) : null}
-				</section>
-			) : null}
-		</ReactTransitionGroup>
+						{isCloseable ? (
+							<CloseIcon
+								isClickable
+								size={8}
+								className={cx('&-close')}
+								onClick={handleClose}
+							/>
+						) : null}
+					</section>
+				) : <React.Fragment></React.Fragment>}
+			</CSSTransition>
+		</TransitionGroup>
 	);
 };
 

--- a/src/components/Banner/__snapshots__/Banner.spec.jsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.spec.jsx.snap
@@ -1,1223 +1,1124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Banner [common] example testing should match snapshot(s) for 0.stateful 1`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
   >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Default
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Default
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 1`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Default
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Default
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 2`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Default -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Default -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 3`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Success
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Success
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 4`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-success lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-success lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Success -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Success -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 5`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
+      Warning 
+      <a
+        href="#"
       >
-        Warning 
-        <a
-          href="#"
-        >
-          Don't Click Here
-        </a>
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+        Don't Click Here
+      </a>
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 6`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-warning lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-warning lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Warning -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Warning -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 7`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Danger
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Danger
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 8`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-danger lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-danger lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Danger -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Danger -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 9`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Info
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Info
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 10`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-info lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-info lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Info -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Info -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 11`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-icon"
     >
-      <span
-        className="lucid-Banner-icon"
-      >
-        <ChatIcon
-          aspectRatio="xMidYMid meet"
-          color="primary"
-          isClickable={false}
-          isDisabled={false}
-          onClick={[Function]}
-          onSelect={[Function]}
-          size={16}
-          viewBox="0 0 16 16"
-        />
-      </span>
-      <span
-        className="lucid-Banner-content"
-      >
-        Has Icon
-      </span>
-      <CloseIcon
+      <ChatIcon
         aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
         color="primary"
-        isClickable={true}
+        isClickable={false}
         isDisabled={false}
         onClick={[Function]}
         onSelect={[Function]}
-        size={8}
+        size={16}
         viewBox="0 0 16 16"
       />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+    </span>
+    <span
+      className="lucid-Banner-content"
+    >
+      Has Icon
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 12`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        <div>
-          Sit totam voluptas error dolorum ullam Quo ipsam esse amet mollitia consequuntur Cumque cum nisi porro cumque sit nisi Facilis placeat suscipit earum blanditiis eveniet Earum dolor voluptates perferendis quis
-        </div>
-        <div>
-          Adipisicing culpa atque totam quidem dicta consequatur fugiat quaerat Facilis cupiditate amet nam in perferendis Veritatis iusto molestiae illum doloribus deserunt Odit autem obcaecati dolores ad incidunt? Ipsa eveniet modi.
-        </div>
-        <div>
-          Lorem sit explicabo vitae illum labore Nostrum inventore dolor nisi deserunt voluptatem Voluptas itaque nesciunt omnis necessitatibus asperiores! Eius error ab consequatur necessitatibus repudiandae quibusdam Odio consequuntur at necessitatibus at
-        </div>
-        <div>
-          <a
-            href="#"
-          >
-            Click Me
-          </a>
-        </div>
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      <div>
+        Sit totam voluptas error dolorum ullam Quo ipsam esse amet mollitia consequuntur Cumque cum nisi porro cumque sit nisi Facilis placeat suscipit earum blanditiis eveniet Earum dolor voluptates perferendis quis
+      </div>
+      <div>
+        Adipisicing culpa atque totam quidem dicta consequatur fugiat quaerat Facilis cupiditate amet nam in perferendis Veritatis iusto molestiae illum doloribus deserunt Odit autem obcaecati dolores ad incidunt? Ipsa eveniet modi.
+      </div>
+      <div>
+        Lorem sit explicabo vitae illum labore Nostrum inventore dolor nisi deserunt voluptatem Voluptas itaque nesciunt omnis necessitatibus asperiores! Eius error ab consequatur necessitatibus repudiandae quibusdam Odio consequuntur at necessitatibus at
+      </div>
+      <div>
+        <a
+          href="#"
+        >
+          Click Me
+        </a>
+      </div>
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 13`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        <div>
-          Success -- Outline
-        </div>
-        <div>
-          Outline banners are for messages with multi-line content.
-        </div>
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      <div>
+        Success -- Outline
+      </div>
+      <div>
+        Outline banners are for messages with multi-line content.
+      </div>
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 14`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        <div>
-          Warning -- Outline
-        </div>
-        <div>
-          Outline banners are for messages with multi-line content.
-        </div>
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      <div>
+        Warning -- Outline
+      </div>
+      <div>
+        Outline banners are for messages with multi-line content.
+      </div>
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 15`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        <div>
-          Danger -- Outline
-        </div>
-        <div>
-          Outline banners are for messages with multi-line content.
-        </div>
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      <div>
+        Danger -- Outline
+      </div>
+      <div>
+        Outline banners are for messages with multi-line content.
+      </div>
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 16`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        <div>
-          Info -- Outline
-        </div>
-        <div>
-          Outline banners are for messages with multi-line content.
-        </div>
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      <div>
+        Info -- Outline
+      </div>
+      <div>
+        Outline banners are for messages with multi-line content.
+      </div>
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 17`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-icon"
     >
-      <span
-        className="lucid-Banner-icon"
-      >
-        <ChatIcon
-          aspectRatio="xMidYMid meet"
-          color="primary"
-          isClickable={false}
-          isDisabled={false}
-          onClick={[Function]}
-          onSelect={[Function]}
-          size={16}
-          viewBox="0 0 16 16"
-        />
-      </span>
-      <span
-        className="lucid-Banner-content"
-      >
-        <div>
-          Has Icon -- Outline
-        </div>
-        <div>
-          Outline banners are for messages with multi-line content.
-        </div>
-      </span>
-      <CloseIcon
+      <ChatIcon
         aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
         color="primary"
-        isClickable={true}
+        isClickable={false}
         isDisabled={false}
         onClick={[Function]}
         onSelect={[Function]}
-        size={8}
+        size={16}
         viewBox="0 0 16 16"
       />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+    </span>
+    <span
+      className="lucid-Banner-content"
+    >
+      <div>
+        Has Icon -- Outline
+      </div>
+      <div>
+        Outline banners are for messages with multi-line content.
+      </div>
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 1`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Default
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Default
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 2`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Default -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Default -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 3`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Success
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Success
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 4`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Success -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Success -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 5`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Warning
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Warning
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 6`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Warning -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Warning -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 7`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Danger
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Danger
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 8`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Danger -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Danger -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 9`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Info
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Info
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 10`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Info -- No Close 
-        ×
-      </span>
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Info -- No Close 
+      ×
+    </span>
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 11`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-small"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Default -- Outline Only
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Default -- Outline Only
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 12`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Success -- Outline Only
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Success -- Outline Only
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 13`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Warning -- Outline Only
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Warning -- Outline Only
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 14`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Danger -- Outline Only
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Danger -- Outline Only
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 15`] = `
-<TransitionGroup
-  childFactory={[Function]}
-  component="div"
+<CSSTransition
+  classNames="lucid-Banner"
+  in={true}
+  timeout={300}
+  unmountOnExit={true}
 >
-  <CSSTransition
-    classNames="lucid-Banner"
-    timeout={300}
-  >
-    <section
-      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small"
-      style={
-        Object {
-          "marginBottom": 8,
-        }
+  <section
+    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small"
+    style={
+      Object {
+        "marginBottom": 8,
       }
+    }
+  >
+    <span
+      className="lucid-Banner-content"
     >
-      <span
-        className="lucid-Banner-content"
-      >
-        Info -- Outline Only
-      </span>
-      <CloseIcon
-        aspectRatio="xMidYMid meet"
-        className="lucid-Banner-close"
-        color="primary"
-        isClickable={true}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={8}
-        viewBox="0 0 16 16"
-      />
-    </section>
-  </CSSTransition>
-</TransitionGroup>
+      Info -- Outline Only
+    </span>
+    <CloseIcon
+      aspectRatio="xMidYMid meet"
+      className="lucid-Banner-close"
+      color="primary"
+      isClickable={true}
+      isDisabled={false}
+      onClick={[Function]}
+      onSelect={[Function]}
+      size={8}
+      viewBox="0 0 16 16"
+    />
+  </section>
+</CSSTransition>
 `;

--- a/src/components/Banner/__snapshots__/Banner.spec.jsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.spec.jsx.snap
@@ -1,1190 +1,1223 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Banner [common] example testing should match snapshot(s) for 0.stateful 1`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
     >
-      Default
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Default
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 1`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Default
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Default
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 2`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Default -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Default -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 3`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Success
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Success
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 4`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-success lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-success lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Success -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Success -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 5`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Warning 
-      <a
-        href="#"
+      <span
+        className="lucid-Banner-content"
       >
-        Don't Click Here
-      </a>
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 6`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-warning lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      Warning -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 7`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      Danger
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 8`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-danger lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      Danger -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 9`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      Info
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 10`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-info lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      Info -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 11`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-icon"
-    >
-      <ChatIcon
-        aspectRatio="xMidYMid meet"
-        color="primary"
-        isClickable={false}
-        isDisabled={false}
-        onClick={[Function]}
-        onSelect={[Function]}
-        size={16}
-        viewBox="0 0 16 16"
-      />
-    </span>
-    <span
-      className="lucid-Banner-content"
-    >
-      Has Icon
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 12`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-close"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      <div>
-        Sit totam voluptas error dolorum ullam Quo ipsam esse amet mollitia consequuntur Cumque cum nisi porro cumque sit nisi Facilis placeat suscipit earum blanditiis eveniet Earum dolor voluptates perferendis quis
-      </div>
-      <div>
-        Adipisicing culpa atque totam quidem dicta consequatur fugiat quaerat Facilis cupiditate amet nam in perferendis Veritatis iusto molestiae illum doloribus deserunt Odit autem obcaecati dolores ad incidunt? Ipsa eveniet modi.
-      </div>
-      <div>
-        Lorem sit explicabo vitae illum labore Nostrum inventore dolor nisi deserunt voluptatem Voluptas itaque nesciunt omnis necessitatibus asperiores! Eius error ab consequatur necessitatibus repudiandae quibusdam Odio consequuntur at necessitatibus at
-      </div>
-      <div>
+        Warning 
         <a
           href="#"
         >
-          Click Me
+          Don't Click Here
         </a>
-      </div>
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 13`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      <div>
-        Success -- Outline
-      </div>
-      <div>
-        Outline banners are for messages with multi-line content.
-      </div>
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 14`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      <div>
-        Warning -- Outline
-      </div>
-      <div>
-        Outline banners are for messages with multi-line content.
-      </div>
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 15`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      <div>
-        Danger -- Outline
-      </div>
-      <div>
-        Outline banners are for messages with multi-line content.
-      </div>
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 16`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-content"
-    >
-      <div>
-        Info -- Outline
-      </div>
-      <div>
-        Outline banners are for messages with multi-line content.
-      </div>
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
-`;
-
-exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 17`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
->
-  <section
-    className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
-  >
-    <span
-      className="lucid-Banner-icon"
-    >
-      <ChatIcon
+      </span>
+      <CloseIcon
         aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
         color="primary"
-        isClickable={false}
+        isClickable={true}
         isDisabled={false}
         onClick={[Function]}
         onSelect={[Function]}
-        size={16}
+        size={8}
         viewBox="0 0 16 16"
       />
-    </span>
-    <span
-      className="lucid-Banner-content"
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 6`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-warning lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      <div>
-        Has Icon -- Outline
-      </div>
-      <div>
-        Outline banners are for messages with multi-line content.
-      </div>
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Warning -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 7`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        Danger
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 8`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-danger lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        Danger -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 9`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        Info
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 10`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-info lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        Info -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 11`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-icon"
+      >
+        <ChatIcon
+          aspectRatio="xMidYMid meet"
+          color="primary"
+          isClickable={false}
+          isDisabled={false}
+          onClick={[Function]}
+          onSelect={[Function]}
+          size={16}
+          viewBox="0 0 16 16"
+        />
+      </span>
+      <span
+        className="lucid-Banner-content"
+      >
+        Has Icon
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 12`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-close"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        <div>
+          Sit totam voluptas error dolorum ullam Quo ipsam esse amet mollitia consequuntur Cumque cum nisi porro cumque sit nisi Facilis placeat suscipit earum blanditiis eveniet Earum dolor voluptates perferendis quis
+        </div>
+        <div>
+          Adipisicing culpa atque totam quidem dicta consequatur fugiat quaerat Facilis cupiditate amet nam in perferendis Veritatis iusto molestiae illum doloribus deserunt Odit autem obcaecati dolores ad incidunt? Ipsa eveniet modi.
+        </div>
+        <div>
+          Lorem sit explicabo vitae illum labore Nostrum inventore dolor nisi deserunt voluptatem Voluptas itaque nesciunt omnis necessitatibus asperiores! Eius error ab consequatur necessitatibus repudiandae quibusdam Odio consequuntur at necessitatibus at
+        </div>
+        <div>
+          <a
+            href="#"
+          >
+            Click Me
+          </a>
+        </div>
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 13`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        <div>
+          Success -- Outline
+        </div>
+        <div>
+          Outline banners are for messages with multi-line content.
+        </div>
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 14`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        <div>
+          Warning -- Outline
+        </div>
+        <div>
+          Outline banners are for messages with multi-line content.
+        </div>
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 15`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        <div>
+          Danger -- Outline
+        </div>
+        <div>
+          Outline banners are for messages with multi-line content.
+        </div>
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 16`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-content"
+      >
+        <div>
+          Info -- Outline
+        </div>
+        <div>
+          Outline banners are for messages with multi-line content.
+        </div>
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
+`;
+
+exports[`Banner [common] example testing should match snapshot(s) for 1.stateless 17`] = `
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
+>
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
+  >
+    <section
+      className="lucid-Banner lucid-Banner-has-icon lucid-Banner-has-close lucid-Banner-danger"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
+    >
+      <span
+        className="lucid-Banner-icon"
+      >
+        <ChatIcon
+          aspectRatio="xMidYMid meet"
+          color="primary"
+          isClickable={false}
+          isDisabled={false}
+          onClick={[Function]}
+          onSelect={[Function]}
+          size={16}
+          viewBox="0 0 16 16"
+        />
+      </span>
+      <span
+        className="lucid-Banner-content"
+      >
+        <div>
+          Has Icon -- Outline
+        </div>
+        <div>
+          Outline banners are for messages with multi-line content.
+        </div>
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 1`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Default
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Default
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 2`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Default -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Default -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 3`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Success
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Success
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 4`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-success lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Success -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Success -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 5`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Warning
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Warning
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 6`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-warning lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Warning -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Warning -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 7`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Danger
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Danger
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 8`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-danger lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Danger -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Danger -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 9`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Info
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Info
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 10`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-info lucid-Banner-small lucid-Banner-filled"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Info -- No Close 
-      ×
-    </span>
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Info -- No Close 
+        ×
+      </span>
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 11`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-small"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-small"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Default -- Outline Only
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Default -- Outline Only
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 12`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-success lucid-Banner-small"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Success -- Outline Only
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Success -- Outline Only
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 13`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-warning lucid-Banner-small"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Warning -- Outline Only
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Warning -- Outline Only
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 14`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-danger lucid-Banner-small"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Danger -- Outline Only
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Danger -- Outline Only
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;
 
 exports[`Banner [common] example testing should match snapshot(s) for 2.small 15`] = `
-<CSSTransitionGroup
-  transitionAppear={false}
-  transitionEnter={true}
-  transitionEnterTimeout={300}
-  transitionLeave={true}
-  transitionLeaveTimeout={300}
-  transitionName="lucid-Banner"
+<TransitionGroup
+  childFactory={[Function]}
+  component="div"
 >
-  <section
-    className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small"
-    style={
-      Object {
-        "marginBottom": 8,
-      }
-    }
+  <CSSTransition
+    classNames="lucid-Banner"
+    timeout={300}
   >
-    <span
-      className="lucid-Banner-content"
+    <section
+      className="lucid-Banner lucid-Banner-has-close lucid-Banner-info lucid-Banner-small"
+      style={
+        Object {
+          "marginBottom": 8,
+        }
+      }
     >
-      Info -- Outline Only
-    </span>
-    <CloseIcon
-      aspectRatio="xMidYMid meet"
-      className="lucid-Banner-close"
-      color="primary"
-      isClickable={true}
-      isDisabled={false}
-      onClick={[Function]}
-      onSelect={[Function]}
-      size={8}
-      viewBox="0 0 16 16"
-    />
-  </section>
-</CSSTransitionGroup>
+      <span
+        className="lucid-Banner-content"
+      >
+        Info -- Outline Only
+      </span>
+      <CloseIcon
+        aspectRatio="xMidYMid meet"
+        className="lucid-Banner-close"
+        color="primary"
+        isClickable={true}
+        isDisabled={false}
+        onClick={[Function]}
+        onSelect={[Function]}
+        size={8}
+        viewBox="0 0 16 16"
+      />
+    </section>
+  </CSSTransition>
+</TransitionGroup>
 `;

--- a/src/components/Dialog/Dialog.less
+++ b/src/components/Dialog/Dialog.less
@@ -9,8 +9,6 @@
 @Dialog-size-largeWidth: 90%;
 
 .@{prefix}-Dialog {
-	.transition-group-animation-fade();
-
 	&-window {
 		display: flex;
 		flex-direction: column;

--- a/src/components/Overlay/Overlay.spec.jsx
+++ b/src/components/Overlay/Overlay.spec.jsx
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme';
 import { common } from '../../util/generic-tests';
 import sinon from 'sinon';
 import assert from 'assert';
+import { CSSTransition } from 'react-transition-group';
 
 import Overlay from './Overlay';
 
@@ -20,11 +21,29 @@ describe('Overlay', () => {
 		assert(wrapper.contains('Flux Capacitor'));
 	});
 
-	it('should not render when isShown is false', () => {
-		const wrapper = shallow(<Overlay isShown={false}>Flux Capacitor</Overlay>);
-
-		assert(!wrapper.contains('Flux Capacitor'));
+	describe('when isAnimated is false', () => {
+		describe('and when isShown is true', () => {
+			it('should render CSSTransition with in prop as false', () => {
+				const wrapper = shallow(<Overlay isShown={false} isAnimated={true}>Flux Capacitor</Overlay>);
+				assert.equal(wrapper.find(CSSTransition).props().in, false);
+			});
+		});
+		describe('and when isShown is false', () => {
+			it('should render CSSTransition with in prop as false', () => {
+				const wrapper = shallow(<Overlay isShown={true} isAnimated={true}>Flux Capacitor</Overlay>);
+				assert.equal(wrapper.find(CSSTransition).props().in, true);
+			});
+		});
 	});
+
+	describe('when isAnimated is true', () => {
+		it('should not render when isShown is false', () => {
+			const wrapper = shallow(<Overlay isShown={false} isAnimated={false}>Flux Capacitor</Overlay>);
+			assert(!wrapper.contains('Flux Capacitor'));
+		});
+	});
+
+
 
 	it('should have the correct class when isModal is false', () => {
 		const wrapper = shallow(

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
 import Portal from '../Portal/Portal';
-import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { lucidClassNames, uniqueName } from '../../util/style-helpers';
 import { omitProps, StandardProps } from '../../util/component-types';
 
@@ -185,13 +185,14 @@ class Overlay extends React.Component<IOverlayProps, IOverlayState, {}> {
 		return (
 			<Portal portalId={portalId}>
 				{isAnimated ? (
-					<ReactTransitionGroup
-						transitionName={cx('&')}
-						transitionEnterTimeout={300}
-						transitionLeaveTimeout={300}
-					>
-						{overlayElement}
-					</ReactTransitionGroup>
+					<TransitionGroup>
+						<CSSTransition
+							classNames={cx('&')}
+							timeout={300}
+						>
+							{overlayElement || <React.Fragment></React.Fragment>}
+						</CSSTransition>
+					</TransitionGroup>
 				) : (
 					overlayElement
 				)}

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
 import Portal from '../Portal/Portal';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { CSSTransition } from 'react-transition-group';
 import { lucidClassNames, uniqueName } from '../../util/style-helpers';
 import { omitProps, StandardProps } from '../../util/component-types';
 
@@ -168,7 +168,7 @@ class Overlay extends React.Component<IOverlayProps, IOverlayState, {}> {
 
 		const { portalId } = this.state;
 
-		const overlayElement = isShown ? (
+		const overlayElement = (
 			<div
 				{...omitProps(passThroughs, undefined, Object.keys(Overlay.propTypes))}
 				className={cx(className, '&', {
@@ -180,22 +180,22 @@ class Overlay extends React.Component<IOverlayProps, IOverlayState, {}> {
 			>
 				{children}
 			</div>
-		) : null;
+		);
 
 		return (
 			<Portal portalId={portalId}>
 				{isAnimated ? (
-					<TransitionGroup>
-						<CSSTransition
-							classNames={cx('&')}
-							timeout={300}
-						>
-							{overlayElement || <React.Fragment></React.Fragment>}
-						</CSSTransition>
-					</TransitionGroup>
-				) : (
+					<CSSTransition
+						in={isShown}
+						classNames={cx('&')}
+						timeout={300}
+						unmountOnExit
+					>
+						{overlayElement}
+					</CSSTransition>
+				) : isShown ? (
 					overlayElement
-				)}
+				) : null}
 			</Portal>
 		);
 	}

--- a/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
+++ b/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
@@ -4,15 +4,27 @@ exports[`Overlay [common] example testing should match snapshot(s) for basic 1`]
 <Portal
   portalId="1-Overlay-Portal-6"
 >
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
+  <CSSTransition
+    classNames="lucid-Overlay"
+    in={false}
+    timeout={300}
+    unmountOnExit={true}
   >
-    <CSSTransition
-      classNames="lucid-Overlay"
-      timeout={300}
-    />
-  </TransitionGroup>
+    <div
+      className="lucid-Overlay lucid-Overlay-is-animated"
+      onClick={[Function]}
+    >
+      <div
+        style={
+          Object {
+            "color": "#fff",
+          }
+        }
+      >
+        User cannot interact with the background (except scrolling).
+      </div>
+    </div>
+  </CSSTransition>
 </Portal>
 `;
 
@@ -20,20 +32,42 @@ exports[`Overlay [common] example testing should match snapshot(s) for no-modal 
 <Portal
   portalId="1-Overlay-Portal-7"
 >
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
+  <CSSTransition
+    classNames="lucid-Overlay"
+    in={false}
+    timeout={300}
+    unmountOnExit={true}
   >
-    <CSSTransition
-      classNames="lucid-Overlay"
-      timeout={300}
-    />
-  </TransitionGroup>
+    <div
+      className="lucid-Overlay lucid-Overlay-is-not-modal lucid-Overlay-is-animated"
+      onClick={[Function]}
+    >
+      <div
+        style={
+          Object {
+            "backgroundColor": "#eee",
+            "padding": "100px",
+          }
+        }
+      >
+        User can still interact with the background.
+        <Button
+          hasOnlyIcon={false}
+          isActive={false}
+          isDisabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Close
+        </Button>
+      </div>
+    </div>
+  </CSSTransition>
 </Portal>
 `;
 
 exports[`Overlay should render with isAnimated=false 1`] = `
 <Portal
-  portalId="1-Overlay-Portal-11"
+  portalId="1-Overlay-Portal-13"
 />
 `;

--- a/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
+++ b/src/components/Overlay/__snapshots__/Overlay.spec.jsx.snap
@@ -4,14 +4,15 @@ exports[`Overlay [common] example testing should match snapshot(s) for basic 1`]
 <Portal
   portalId="1-Overlay-Portal-6"
 >
-  <CSSTransitionGroup
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={300}
-    transitionLeave={true}
-    transitionLeaveTimeout={300}
-    transitionName="lucid-Overlay"
-  />
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
+  >
+    <CSSTransition
+      classNames="lucid-Overlay"
+      timeout={300}
+    />
+  </TransitionGroup>
 </Portal>
 `;
 
@@ -19,14 +20,15 @@ exports[`Overlay [common] example testing should match snapshot(s) for no-modal 
 <Portal
   portalId="1-Overlay-Portal-7"
 >
-  <CSSTransitionGroup
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={300}
-    transitionLeave={true}
-    transitionLeaveTimeout={300}
-    transitionName="lucid-Overlay"
-  />
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
+  >
+    <CSSTransition
+      classNames="lucid-Overlay"
+      timeout={300}
+    />
+  </TransitionGroup>
 </Portal>
 `;
 

--- a/src/components/OverlayWrapper/OverlayWrapper.spec.jsx
+++ b/src/components/OverlayWrapper/OverlayWrapper.spec.jsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import assert from 'assert';
 import { common } from '../../util/generic-tests';
 import OverlayWrapper from './OverlayWrapper';
+import { CSSTransition } from 'react-transition-group';
 
 const { Message } = OverlayWrapper;
 
@@ -21,12 +22,8 @@ describe('OverlayWrapper', () => {
 				);
 			});
 
-			it('should not show the overlay message', () => {
-				assert.equal(
-					wrapper.find('.lucid-OverlayWrapper-message-container').length,
-					0
-				);
-				assert.equal(wrapper.find(Message).length, 0);
+			it('should render CSSTransition with correct in prop', () => {
+				assert.equal(wrapper.find(CSSTransition).props().in, false);
 			});
 
 			it('should render other content', () => {
@@ -45,12 +42,8 @@ describe('OverlayWrapper', () => {
 				);
 			});
 
-			it('should not show the overlay message', () => {
-				assert.equal(
-					wrapper.find('.lucid-OverlayWrapper-message-container').length,
-					0
-				);
-				assert.equal(wrapper.find(Message).length, 0);
+			it('should render CSSTransition with correct in prop', () => {
+				assert.equal(wrapper.find(CSSTransition).props().in, false);
 			});
 
 			it('should render other content', () => {
@@ -68,6 +61,10 @@ describe('OverlayWrapper', () => {
 						<div>Some content</div>
 					</OverlayWrapper>
 				);
+			});
+
+			it('should render CSSTransition with correct in prop', () => {
+				assert.equal(wrapper.find(CSSTransition).props().in, true);
 			});
 
 			it('should show the overlay message', () => {

--- a/src/components/OverlayWrapper/OverlayWrapper.tsx
+++ b/src/components/OverlayWrapper/OverlayWrapper.tsx
@@ -9,7 +9,7 @@ import {
 	omitProps,
 	StandardProps,
 } from '../../util/component-types';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { CSSTransition } from 'react-transition-group';
 
 const cx = lucidClassNames.bind('&-OverlayWrapper');
 
@@ -67,6 +67,7 @@ const defaultProps = {
 	hasOverlay: true,
 	overlayKind: 'light' as const,
 	anchorMessage: false,
+	isVisible: false,
 };
 
 export const OverlayWrapper = (
@@ -96,24 +97,22 @@ export const OverlayWrapper = (
 			className={cx('&', className)}
 		>
 			{otherChildren}
-			<TransitionGroup>
-				<CSSTransition
-					classNames={cx('&-message-container')}
-					timeout={300}
+			<CSSTransition
+				in={isVisible}
+				classNames={cx('&-message-container')}
+				timeout={300}
+				unmountOnExit
+			>
+				<div
+					className={cx('&-message-container', {
+						'&-has-overlay': hasOverlay,
+						'&-kind-light': hasOverlay && overlayKind === 'light',
+						'&-anchored-message': anchorMessage,
+					})}
 				>
-					{isVisible ? (
-						<div
-							className={cx('&-message-container', {
-								'&-has-overlay': hasOverlay,
-								'&-kind-light': hasOverlay && overlayKind === 'light',
-								'&-anchored-message': anchorMessage,
-							})}
-						>
-							<div {...messageElementProp} />
-						</div>
-					) : <React.Fragment></React.Fragment>}
-				</CSSTransition>
-			</TransitionGroup>
+					<div {...messageElementProp} />
+				</div>
+			</CSSTransition>
 		</div>
 	);
 };

--- a/src/components/OverlayWrapper/OverlayWrapper.tsx
+++ b/src/components/OverlayWrapper/OverlayWrapper.tsx
@@ -9,7 +9,7 @@ import {
 	omitProps,
 	StandardProps,
 } from '../../util/component-types';
-import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 const cx = lucidClassNames.bind('&-OverlayWrapper');
 
@@ -96,23 +96,24 @@ export const OverlayWrapper = (
 			className={cx('&', className)}
 		>
 			{otherChildren}
-			<ReactTransitionGroup
-				transitionName={cx('&-message-container')}
-				transitionEnterTimeout={300}
-				transitionLeaveTimeout={300}
-			>
-				{isVisible && (
-					<div
-						className={cx('&-message-container', {
-							'&-has-overlay': hasOverlay,
-							'&-kind-light': hasOverlay && overlayKind === 'light',
-							'&-anchored-message': anchorMessage,
-						})}
-					>
-						<div {...messageElementProp} />
-					</div>
-				)}
-			</ReactTransitionGroup>
+			<TransitionGroup>
+				<CSSTransition
+					classNames={cx('&-message-container')}
+					timeout={300}
+				>
+					{isVisible ? (
+						<div
+							className={cx('&-message-container', {
+								'&-has-overlay': hasOverlay,
+								'&-kind-light': hasOverlay && overlayKind === 'light',
+								'&-anchored-message': anchorMessage,
+							})}
+						>
+							<div {...messageElementProp} />
+						</div>
+					) : <React.Fragment></React.Fragment>}
+				</CSSTransition>
+			</TransitionGroup>
 		</div>
 	);
 };

--- a/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
+++ b/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
@@ -69,21 +69,22 @@ exports[`OverlayWrapper [common] example testing should match snapshot(s) for 1.
     yAxisTitleColor="#000"
     yAxisTooltipFormatter={[Function]}
   />
-  <CSSTransitionGroup
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={300}
-    transitionLeave={true}
-    transitionLeaveTimeout={300}
-    transitionName="lucid-OverlayWrapper-message-container"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <div
-      className="lucid-OverlayWrapper-message-container lucid-OverlayWrapper-has-overlay lucid-OverlayWrapper-kind-light"
+    <CSSTransition
+      classNames="lucid-OverlayWrapper-message-container"
+      timeout={300}
     >
-      <div>
-        Message Goes Here
+      <div
+        className="lucid-OverlayWrapper-message-container lucid-OverlayWrapper-has-overlay lucid-OverlayWrapper-kind-light"
+      >
+        <div>
+          Message Goes Here
+        </div>
       </div>
-    </div>
-  </CSSTransitionGroup>
+    </CSSTransition>
+  </TransitionGroup>
 </div>
 `;

--- a/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
+++ b/src/components/OverlayWrapper/__snapshots__/OverlayWrapper.spec.jsx.snap
@@ -69,22 +69,19 @@ exports[`OverlayWrapper [common] example testing should match snapshot(s) for 1.
     yAxisTitleColor="#000"
     yAxisTooltipFormatter={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
+  <CSSTransition
+    classNames="lucid-OverlayWrapper-message-container"
+    in={true}
+    timeout={300}
+    unmountOnExit={true}
   >
-    <CSSTransition
-      classNames="lucid-OverlayWrapper-message-container"
-      timeout={300}
+    <div
+      className="lucid-OverlayWrapper-message-container lucid-OverlayWrapper-has-overlay lucid-OverlayWrapper-kind-light"
     >
-      <div
-        className="lucid-OverlayWrapper-message-container lucid-OverlayWrapper-has-overlay lucid-OverlayWrapper-kind-light"
-      >
-        <div>
-          Message Goes Here
-        </div>
+      <div>
+        Message Goes Here
       </div>
-    </CSSTransition>
-  </TransitionGroup>
+    </div>
+  </CSSTransition>
 </div>
 `;

--- a/src/components/SwitchLabeled/SwitchLabeled.jsx
+++ b/src/components/SwitchLabeled/SwitchLabeled.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
-import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { lucidClassNames } from '../../util/style-helpers';
 import { createClass, getFirst, omitProps } from '../../util/component-types';
 import Switch from '../Switch/Switch';
@@ -123,19 +123,20 @@ const SwitchLabeled = createClass({
 					onSelect={onSelect}
 					{...omitProps(passThroughs, SwitchLabeled, [], false)}
 				/>
-				<ReactTransitionGroup
-					transitionName={cx('&-text')}
-					transitionEnterTimeout={100}
-					transitionLeaveTimeout={100}
-					style={{ position: 'relative' }}
-					className={cx('&-text')}
-				>
-					{labelChildProps ? (
-						<span key={this._labelKey}>
-							{labelChildProps.children || labelChildProps}
-						</span>
-					) : null}
-				</ReactTransitionGroup>
+				<TransitionGroup>
+					<CSSTransition
+						classNames={cx('&-text')}
+						timeout={100}
+						style={{ position: 'relative' }}
+						className={cx('&-text')}
+					>
+						{labelChildProps ? (
+							<span key={this._labelKey}>
+								{labelChildProps.children || labelChildProps}
+							</span>
+						) : <React.Fragment></React.Fragment>}
+					</CSSTransition>
+				</TransitionGroup>
 			</label>
 		);
 	},

--- a/src/components/SwitchLabeled/SwitchLabeled.jsx
+++ b/src/components/SwitchLabeled/SwitchLabeled.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'react-peek/prop-types';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { CSSTransition } from 'react-transition-group';
 import { lucidClassNames } from '../../util/style-helpers';
 import { createClass, getFirst, omitProps } from '../../util/component-types';
 import Switch from '../Switch/Switch';
@@ -103,6 +103,7 @@ const SwitchLabeled = createClass({
 			getFirst(this.props, SwitchLabeled.Label),
 			'props'
 		);
+		const isShown = !!labelChildProps;
 
 		return (
 			<label
@@ -123,20 +124,20 @@ const SwitchLabeled = createClass({
 					onSelect={onSelect}
 					{...omitProps(passThroughs, SwitchLabeled, [], false)}
 				/>
-				<TransitionGroup>
+				{labelChildProps && (
 					<CSSTransition
+						in={isShown}
 						classNames={cx('&-text')}
 						timeout={100}
 						style={{ position: 'relative' }}
 						className={cx('&-text')}
+						unmountOnExit
 					>
-						{labelChildProps ? (
-							<span key={this._labelKey}>
-								{labelChildProps.children || labelChildProps}
-							</span>
-						) : <React.Fragment></React.Fragment>}
+						<span key={this._labelKey}>
+							{labelChildProps.children || labelChildProps}
+						</span>
 					</CSSTransition>
-				</TransitionGroup>
+				)}
 			</label>
 		);
 	},

--- a/src/components/SwitchLabeled/SwitchLabeled.spec.jsx
+++ b/src/components/SwitchLabeled/SwitchLabeled.spec.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import assert from 'assert';
 import React from 'react';
-import ReactTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { CSSTransition } from 'react-transition-group';
 import { mount, shallow } from 'enzyme';
 
 import { common } from '../../util/generic-tests';
@@ -62,7 +62,7 @@ describe('SwitchLabeled', () => {
 
 				assert.equal(
 					wrapper
-						.find(ReactTransitionGroup)
+						.find(CSSTransition)
 						.find('span')
 						.prop('children'),
 					'foo'
@@ -80,7 +80,7 @@ describe('SwitchLabeled', () => {
 
 				assert.equal(
 					wrapper
-						.find(ReactTransitionGroup)
+						.find(CSSTransition)
 						.find('span')
 						.prop('children'),
 					'foo'

--- a/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.jsx.snap
+++ b/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.jsx.snap
@@ -19,27 +19,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Airplane Mode
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Airplane Mode
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Airplane Mode
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -62,27 +59,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Bluetooth
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Bluetooth
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Bluetooth
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -105,27 +99,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Cellular Data
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Cellular Data
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Cellular Data
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -144,27 +135,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
     isSelected={true}
     onSelect={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Airplane Mode Activated
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Airplane Mode Activated
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -183,27 +171,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
     isSelected={true}
     onSelect={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Bluetooth Enabled
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Bluetooth Enabled
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -222,27 +207,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
     isSelected={true}
     onSelect={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Use Cellular Data
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Use Cellular Data
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -265,27 +247,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -304,27 +283,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Just text
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Just text
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -343,29 +319,26 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        <span>
-          HTML element
-        </span>
+      <span>
+        HTML element
       </span>
-    </CSSTransition>
-  </TransitionGroup>
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -384,27 +357,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Text in an array
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Text in an array
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -423,31 +393,28 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
       <span
-        key="0"
+        key="1"
       >
-        <span
-          key="1"
-        >
-          HTML element in an array
-        </span>
+        HTML element in an array
       </span>
-    </CSSTransition>
-  </TransitionGroup>
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -471,27 +438,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       (default props)
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        (default props)
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      (default props)
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -515,27 +479,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       Selected
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Selected
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Selected
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -559,27 +520,24 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       Disabled
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Disabled
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Disabled
+    </span>
+  </CSSTransition>
 </label>
 `;
 
@@ -603,26 +561,23 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       Disabled & selected
     </SwitchLabeled.Label>
   </Switch>
-  <TransitionGroup
-    childFactory={[Function]}
-    component="div"
-  >
-    <CSSTransition
-      className="lucid-SwitchLabeled-text"
-      classNames="lucid-SwitchLabeled-text"
-      style={
-        Object {
-          "position": "relative",
-        }
+  <CSSTransition
+    className="lucid-SwitchLabeled-text"
+    classNames="lucid-SwitchLabeled-text"
+    in={true}
+    style={
+      Object {
+        "position": "relative",
       }
-      timeout={100}
+    }
+    timeout={2000}
+    unmountOnExit={true}
+  >
+    <span
+      key="0"
     >
-      <span
-        key="0"
-      >
-        Disabled & selected
-      </span>
-    </CSSTransition>
-  </TransitionGroup>
+      Disabled & selected
+    </span>
+  </CSSTransition>
 </label>
 `;

--- a/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.jsx.snap
+++ b/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.jsx.snap
@@ -19,26 +19,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Airplane Mode
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Airplane Mode
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Airplane Mode
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -61,26 +62,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Bluetooth
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Bluetooth
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Bluetooth
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -103,26 +105,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Cellular Data
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Cellular Data
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Cellular Data
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -141,26 +144,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
     isSelected={true}
     onSelect={[Function]}
   />
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Airplane Mode Activated
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Airplane Mode Activated
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -179,26 +183,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
     isSelected={true}
     onSelect={[Function]}
   />
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Bluetooth Enabled
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Bluetooth Enabled
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -217,26 +222,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
     isSelected={true}
     onSelect={[Function]}
   />
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Use Cellular Data
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Use Cellular Data
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -259,26 +265,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
       Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -297,26 +304,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Just text
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Just text
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -335,28 +343,29 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      <span>
-        HTML element
+      <span
+        key="0"
+      >
+        <span>
+          HTML element
+        </span>
       </span>
-    </span>
-  </CSSTransitionGroup>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -375,26 +384,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Text in an array
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Text in an array
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -413,30 +423,31 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
     isSelected={false}
     onSelect={[Function]}
   />
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
       <span
-        key="1"
+        key="0"
       >
-        HTML element in an array
+        <span
+          key="1"
+        >
+          HTML element in an array
+        </span>
       </span>
-    </span>
-  </CSSTransitionGroup>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -460,26 +471,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       (default props)
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      (default props)
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        (default props)
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -503,26 +515,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       Selected
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Selected
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Selected
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -546,26 +559,27 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       Disabled
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Disabled
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Disabled
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;
 
@@ -589,25 +603,26 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
       Disabled & selected
     </SwitchLabeled.Label>
   </Switch>
-  <CSSTransitionGroup
-    className="lucid-SwitchLabeled-text"
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-    transitionAppear={false}
-    transitionEnter={true}
-    transitionEnterTimeout={100}
-    transitionLeave={true}
-    transitionLeaveTimeout={100}
-    transitionName="lucid-SwitchLabeled-text"
+  <TransitionGroup
+    childFactory={[Function]}
+    component="div"
   >
-    <span
-      key="0"
+    <CSSTransition
+      className="lucid-SwitchLabeled-text"
+      classNames="lucid-SwitchLabeled-text"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+      timeout={100}
     >
-      Disabled & selected
-    </span>
-  </CSSTransitionGroup>
+      <span
+        key="0"
+      >
+        Disabled & selected
+      </span>
+    </CSSTransition>
+  </TransitionGroup>
 </label>
 `;

--- a/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.jsx.snap
+++ b/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.jsx.snap
@@ -28,7 +28,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -68,7 +68,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -108,7 +108,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -144,7 +144,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -180,7 +180,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -216,7 +216,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -256,7 +256,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for int
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -292,7 +292,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -328,7 +328,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -366,7 +366,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -402,7 +402,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for lab
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -447,7 +447,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -488,7 +488,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -529,7 +529,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span
@@ -570,7 +570,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for sta
         "position": "relative",
       }
     }
-    timeout={2000}
+    timeout={100}
     unmountOnExit={true}
   >
     <span

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -254,7 +254,7 @@ interface IThProps
 
 	/** Sets the min width of the cell. */
 	minWidth?: number | string;
-	
+
 	/** Indicates for how many columns the cell extends */
 	colSpan?: number;
 
@@ -420,7 +420,7 @@ export class Th extends React.Component<IThProps, IThState> {
 		passiveWidth: this.props.width || null,
 	};
 
-	componentWillReceiveProps({ width }: { width?: number | string | null }) {
+	UNSAFE_componentWillReceiveProps({ width }: { width?: number | string | null }) {
 		if (!_.isNil(width) && width !== this.props.width) {
 			this.setState({
 				hasSetWidth: true,
@@ -498,7 +498,7 @@ export class Th extends React.Component<IThProps, IThState> {
 		} else if (_.isString(passiveWidth)) {
 			passiveWidth = parseInt(passiveWidth);
 		}
-		
+
 		const activeWidth = ((minWidth && passiveWidth + coordinates.dX > minWidth) || !minWidth) ? passiveWidth + coordinates.dX : minWidth;
 
 		this.setState({ activeWidth });

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -142,7 +142,7 @@
 // Animations
 // -----------------------------------------------------------------------------
 
-// This set of mixins in intended to be used with ReactCSSTransitionGroup. It's
+// This set of mixins in intended to be used with CSSTransition. It's
 // important that you place this mixin directly underneath the parent that
 // should be animating.
 
@@ -151,20 +151,18 @@
 		.opacity(0.01);
 	}
 
-	&-enter&-enter-active {
-		.opacity(1);
-
+	&-enter-active {
 		transition: opacity @timing ease-in;
-	}
-
-	&-leave {
 		.opacity(1);
 	}
 
-	&-leave&-leave-active {
+	&-exit {
+		.opacity(1);
+	}
+
+	&-exit-active {
+		transition: opacity @timing ease-in;
 		.opacity(0.01);
-
-		transition: opacity @timing ease-in;
 	}
 }
 


### PR DESCRIPTION
I have upgraded "react-transition-group' library as there were many errors and warning being through in our consumers. This library will not work after the next react upgrade as noted in the warnings (deprecated lifecycles). This included the migration as documented here: https://github.com/reactjs/react-transition-group/blob/master/Migration.md

## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BUDE-121)

- Manually tested across supported browsers

  - [x ] Chrome
  - [ x] Firefox
  - [ x] Safari

- [x ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
