### PR TITLE
Fix SearchableSingleSelect warnings

### DIFF
--- a/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
+++ b/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
@@ -516,7 +516,11 @@ class SearchableSingleSelect extends React.Component<
 
 			return (
 				<div
-					{...omitProps(passThroughs, undefined)}
+					{...omitProps(
+						passThroughs,
+						undefined,
+						_.keys(SearchableSingleSelect.propTypes)
+					)}
 					className={cx('&', className)}
 				>
 					<Selection


### PR DESCRIPTION
Fix SearchableSingleSelect warnings that appears when you select an item

<img width="572" alt="sss-warning-1" src="https://user-images.githubusercontent.com/8205449/88721151-fc7e7e00-d0f3-11ea-9339-f7e2fb1dc91a.png">
<img width="533" alt="sss-warning-2" src="https://user-images.githubusercontent.com/8205449/88721152-fc7e7e00-d0f3-11ea-97c1-69bbb6a6e22b.png">

## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [ ] One core team UX approval
