### PR TITLE
Issue 1164: Omit Selection prop from DropMenuOption prop types

### DIFF
--- a/src/components/DropMenu/DropMenu.spec.jsx
+++ b/src/components/DropMenu/DropMenu.spec.jsx
@@ -770,6 +770,29 @@ describe('DropMenu', () => {
 				assert.equal(optionDOMNodes[0].innerHTML, 'option b');
 				assert.equal(optionDOMNodes[1].innerHTML, 'option c');
 			});
+
+			it('should render children options with `Selection` properties without generating React warnings', () => {
+				wrapper = mount(
+					<DropMenu isExpanded>
+						<Control>control</Control>
+						<Option Selection={{ kind: 'warning' }}>option a</Option>
+						<Option>option b</Option>
+						<Option>option c</Option>
+					</DropMenu>
+				);
+
+				const flyOutDOMNode = document.querySelector(
+					'.lucid-DropMenu.lucid-ContextMenu-FlyOut'
+				);
+				const optionDOMNodes = flyOutDOMNode.querySelectorAll(
+					'.lucid-DropMenu-Option'
+				);
+
+				assert.equal(optionDOMNodes.length, 3);
+				assert.equal(optionDOMNodes[0].innerHTML, 'option a');
+				assert.equal(optionDOMNodes[1].innerHTML, 'option b');
+				assert.equal(optionDOMNodes[2].innerHTML, 'option c');
+			});
 		});
 
 		describe('OptionGroup', () => {

--- a/src/components/DropMenu/DropMenu.tsx
+++ b/src/components/DropMenu/DropMenu.tsx
@@ -844,7 +844,7 @@ class DropMenu extends React.Component<IDropMenuPropsWithPassThroughs, IDropMenu
 				{...omitProps(
 					optionProps,
 					undefined,
-					_.keys(DropMenu.Option.propTypes)
+					[..._.keys(DropMenu.Option.propTypes), 'Selection']
 				)}
 				onClick={event =>
 					this.handleSelectOption(optionIndex, optionProps, event)


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval

Closes #1164 