### PR TITLE
BUDE-646

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.8.7
+- #1169 [patch] We have updated our test cases for DraggableLineChart. We have also added span as a type to Typography so users can have a div under them
+
 ## 5.8.6
 - #1166 [patch] We have updated the new DraggableLineChart to be able to take foreign react component
 - #1163 [none] Improve the GH upload script to work with https

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## 5.8.7
 - #1169 [patch] We have updated our test cases for DraggableLineChart. We have also added span as a type to Typography so users can have a div under them
+https://github.com/appnexus/lucid/compare/v5.8.6...v5.8.7
+
 
 ## 5.8.6
 - #1166 [patch] We have updated the new DraggableLineChart to be able to take foreign react component
 - #1163 [none] Improve the GH upload script to work with https
 - #1160 [patch] Fix SearchableSingleSelect warnings 
-https://github.com/appnexus/lucid/compare/v5.8.5...v5.8.4
+https://github.com/appnexus/lucid/compare/v5.8.5...v5.8.6
 
 ## 5.8.5
 - #1159 [patch] We have added a new DraggableLineChart component

--- a/src/components/DraggableLineChart/DraggableLineChart.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.tsx
@@ -18,7 +18,7 @@ export type IDraggableLineChartProps = Overwrite<
 >;
 
 const getCleanData = (data: IData): IData => {
-	return data.map(({ x, y }) => ({ x, y: Number.isInteger(y) ? y : 0 }));
+	return data.map(({ x, y }) => ({ x, y: Number.isFinite(y) ? y : 0 }));
 };
 
 const draggableLineChartDefaultProps = {

--- a/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
+++ b/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
@@ -7,11 +7,11 @@ import { IChartData, IData } from '../DraggableLineChartD3';
 
 const initialCustomSpendDataPoints = [
 	{ x: '12 AM', y: 0, ref: React.createRef() },
-	{ x: '1 AM', y: 0, ref: React.createRef() },
-	{ x: '2 AM', y: 0, ref: React.createRef() },
-	{ x: '3 AM', y: 0, ref: React.createRef() },
-	{ x: '4 AM', y: 0, ref: React.createRef() },
-	{ x: '5 AM', y: 5, ref: React.createRef() },
+	{ x: '1 AM', y: 1, ref: React.createRef() },
+	{ x: '2 AM', y: 1.5, ref: React.createRef() },
+	{ x: '3 AM', y: 2, ref: React.createRef() },
+	{ x: '4 AM', y: 3.8, ref: React.createRef() },
+	{ x: '5 AM', y: 3.66, ref: React.createRef() },
 	{ x: '6 AM', y: 5, ref: React.createRef() },
 	{ x: '7 AM', y: 10, ref: React.createRef() },
 	{ x: '8 AM', y: 5, ref: React.createRef() },
@@ -72,13 +72,18 @@ export default createClass({
 			customSpendDataPoints: initialCustomSpendDataPoints,
 		};
 	},
-	onDragHandler(newYValue: string, xValue: string): IData {
+	onDragHandler(
+		newYValue: string,
+		xValue: string,
+		fromOnChangeHandler?: boolean
+	): IData {
+		const cleanedYValue = fromOnChangeHandler
+			? newYValue
+			: +Number(newYValue).toFixed(0);
 		const newCustomSpendDataPoints = _.map(
 			this.state.customSpendDataPoints,
 			dataPoint =>
-				dataPoint.x === xValue
-					? { ...dataPoint, y: +Number(newYValue).toFixed(0) }
-					: dataPoint
+				dataPoint.x === xValue ? { ...dataPoint, y: cleanedYValue } : dataPoint
 		);
 		this.setState({ customSpendDataPoints: newCustomSpendDataPoints });
 		return newCustomSpendDataPoints;
@@ -92,7 +97,11 @@ export default createClass({
 		const nextValue = +Number(newYValue).toFixed(0);
 
 		if (currentYValue !== nextValue) {
-			const newCustomSpendDataPoints = this.onDragHandler(newYValue, xValue);
+			const newCustomSpendDataPoints = this.onDragHandler(
+				newYValue,
+				xValue,
+				true
+			);
 			const nextIndex =
 				currentIndex >= newCustomSpendDataPoints.length - 1
 					? 0
@@ -126,7 +135,7 @@ export default createClass({
 		return (
 			<div style={style}>
 				<DraggableLineChart
-					data={customSpendDataPoints}
+					data={_.map(customSpendDataPoints, x => x)}
 					width={900}
 					dataIsCentered
 					onDragEnd={this.onDragHandler}

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -19,6 +19,7 @@ export enum ElementTypes {
 	code = 'code',
 	kbd = 'kbd',
 	samp = 'samp',
+	span = 'span'
 }
 
 export interface ITypographyProps

--- a/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
+++ b/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
@@ -80,6 +80,14 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 </samp>
 `;
 
+exports[`Typography [common] example testing should match snapshot(s) for 01.variants 11`] = `
+<span
+  className="lucid-Typography lucid-Typography-span"
+>
+  span. sample code outputs
+</span>
+`;
+
 exports[`Typography [common] example testing should match snapshot(s) for 02.nested 1`] = `
 <h1
   className="lucid-Typography lucid-Typography-h1"

--- a/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
+++ b/src/components/Typography/__snapshots__/Typography.spec.jsx.snap
@@ -84,7 +84,34 @@ exports[`Typography [common] example testing should match snapshot(s) for 01.var
 <span
   className="lucid-Typography lucid-Typography-span"
 >
-  span. sample code outputs
+  span. sample code outputs with help bubble
+  <div
+    className="HelpBubble"
+  >
+    <ToolTip
+      alignment="start"
+      direction="right"
+      name="I am a div under typography"
+    >
+      <ToolTip.Title
+        className="HelpBubble-title"
+      >
+        look at me
+      </ToolTip.Title>
+      <ToolTip.Target>
+        <HelpIcon
+          aspectRatio="xMidYMid meet"
+          color="primary"
+          isClickable={false}
+          isDisabled={false}
+          onClick={[Function]}
+          onSelect={[Function]}
+          size={12}
+          viewBox="0 0 16 16"
+        />
+      </ToolTip.Target>
+    </ToolTip>
+  </div>
 </span>
 `;
 

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import createClass from 'create-react-class';
 import { Typography } from '../../../index';
+import HelpIcon from '../../Icon/HelpIcon/HelpIcon';
+import ToolTip from '../../ToolTip/ToolTip';
+
+const { Title, Body, Target } = ToolTip;
 
 export default createClass({
 	render() {
@@ -16,7 +20,17 @@ export default createClass({
 				<Typography variant='code'>code. snazzy code</Typography> <br />
 				<Typography variant='kbd'>kbd. keyboard inputs</Typography> <br />
 				<Typography variant='samp'>samp. sample code outputs</Typography> <br />
-				<Typography variant='span'>span. sample code outputs</Typography> <br />
+				<Typography variant='span'>
+					span. sample code outputs with help bubble
+					<div className='HelpBubble'>
+						<ToolTip alignment={'start'} direction={'right'} name='I am a div under typography'>
+							<Title className='HelpBubble-title'>look at me</Title>
+							<Target>
+								<HelpIcon size={12} />
+							</Target>
+						</ToolTip>
+					</div>
+				</Typography> <br />
 			</div>
 		);
 	},

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -16,6 +16,7 @@ export default createClass({
 				<Typography variant='code'>code. snazzy code</Typography> <br />
 				<Typography variant='kbd'>kbd. keyboard inputs</Typography> <br />
 				<Typography variant='samp'>samp. sample code outputs</Typography> <br />
+				<Typography variant='span'>span. sample code outputs</Typography> <br />
 			</div>
 		);
 	},

--- a/src/components/Typography/examples/01.variants.jsx
+++ b/src/components/Typography/examples/01.variants.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
 import createClass from 'create-react-class';
+import React from 'react';
 import { Typography } from '../../../index';
 import HelpIcon from '../../Icon/HelpIcon/HelpIcon';
 import ToolTip from '../../ToolTip/ToolTip';
 
-const { Title, Body, Target } = ToolTip;
+const { Title, Target } = ToolTip;
 
 export default createClass({
 	render() {


### PR DESCRIPTION
Adding span as an option in Typography.tsx. Without a span we are unable to add help bubbles without warnings as you can't add that component under a p tag

## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BUDE-646)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
