### PR TITLE
BUDE-646: Fix missing line

### DIFF
--- a/src/components/DraggableLineChart/DraggableLineChart.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.tsx
@@ -131,7 +131,7 @@ class DraggableLineChart extends React.Component<IDraggableLineChartProps, {}> {
 		  Optional react component to render within X-Axis.
 			Note: If you are using input boxes or similar and you want to navigate 
 			to the next component on tab, you will might need to provide refs 
-			in the data. This react component will always be passed the following props: ({ x: string, y: number, ref: any })
+			in the data. This react component will always be passed the following props: ({x, y, ref }: { x: string; y: number; ref?: any })
 		`,
 	};
 	static defaultProps = draggableLineChartDefaultProps ;

--- a/src/components/DraggableLineChart/DraggableLineChart.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.tsx
@@ -131,7 +131,7 @@ class DraggableLineChart extends React.Component<IDraggableLineChartProps, {}> {
 		  Optional react component to render within X-Axis.
 			Note: If you are using input boxes or similar and you want to navigate 
 			to the next component on tab, you will might need to provide refs 
-			in the data.
+			in the data. This react component will always be passed the following props: ({ x: string, y: number, ref: any })
 		`,
 	};
 	static defaultProps = draggableLineChartDefaultProps ;

--- a/src/components/DraggableLineChart/DraggableLineChartD3.ts
+++ b/src/components/DraggableLineChart/DraggableLineChartD3.ts
@@ -134,6 +134,7 @@ class DraggableLineChartD3 {
 			dataIsCentered,
 			cx,
 			xAxisRenderProp,
+			data,
 		} = this.params;
 		const xGroup = getGroup(this.selection, `${cx('&-Axis')}`);
 		xGroup
@@ -145,6 +146,7 @@ class DraggableLineChartD3 {
 						tickSize: margin.top + margin.bottom - height,
 						xAxisRenderProp,
 						dataIsCentered,
+						data
 					});
 				if (xAxisTicksVertical) {
 					xAxis.classed('Vert', true);

--- a/src/components/DraggableLineChart/d3-helpers.ts
+++ b/src/components/DraggableLineChart/d3-helpers.ts
@@ -116,6 +116,13 @@ const lucidXAxis = (
 		.attr('x2', rMax)
 		.attr('y1', 0)
 		.attr('y2', 0);
+	axisGroup
+		.append('line')
+		.attr('stroke', 'black')
+		.attr('x1', rMin)
+		.attr('x2', rMax)
+		.attr('y1', -tickSize)
+		.attr('y2', -tickSize);
 
 	const xLines = getGroups(axisGroup, 'xLines', domain);
 	const xLine = xLines.attr(

--- a/src/components/DraggableLineChart/d3-helpers.ts
+++ b/src/components/DraggableLineChart/d3-helpers.ts
@@ -4,7 +4,7 @@ import * as d3Array from 'd3-array';
 import ReactDOM from 'react-dom';
 import { IData } from './DraggableLineChartD3';
 
-export type IXAxisRenderProp = (xValue: string, yValue: number, ref: any) => JSX.Element;
+export type IXAxisRenderProp = ({x, y, ref }: { x: string; y: number; ref?: any }) => JSX.Element;
 export type ISelection = Selection<SVGElement | any, {} | any, null, undefined>;
 
 const getGroup = (selection: ISelection, className: string): ISelection => {
@@ -143,7 +143,7 @@ const lucidXAxis = (
 			if (xValue !== '' && !_.isNil(xValue)) {
 				const subData = _.find(data, { x: xValue }) || { y: 0, ref: undefined};
 				ReactDOM.render(
-					xAxisRenderProp(xValue, subData.y, subData.ref),
+					xAxisRenderProp({ x: xValue, y: subData.y, ref: subData.ref}),
 					node[0]
 				);
 			} else return xValue;

--- a/src/components/DraggableLineChart/d3-helpers.ts
+++ b/src/components/DraggableLineChart/d3-helpers.ts
@@ -2,8 +2,9 @@ import { Selection } from 'd3-selection';
 import _ from 'lodash';
 import * as d3Array from 'd3-array';
 import ReactDOM from 'react-dom';
+import { IData } from './DraggableLineChartD3';
 
-export type IXAxisRenderProp = (xValue: string) => JSX.Element;
+export type IXAxisRenderProp = (xValue: string, yValue: number, ref: any) => JSX.Element;
 export type ISelection = Selection<SVGElement | any, {} | any, null, undefined>;
 
 const getGroup = (selection: ISelection, className: string): ISelection => {
@@ -35,8 +36,8 @@ const getTickObj = (selection: ISelection): ISelection => {
 		data = selection
 			.selectAll('foreignObject')
 			.append('xhtml:div')
-			.attr('tabindex',0)
-			.style('position','fixed')
+			.attr('tabindex', 0)
+			.style('position', 'fixed')
 			.style('transform', 'translate(0px, -50px)')
 			.classed('innerDiv', true);
 	}
@@ -96,11 +97,13 @@ const lucidXAxis = (
 		tickSize,
 		xAxisRenderProp,
 		dataIsCentered,
+		data,
 	}: {
 		xScale: any;
 		tickSize: number;
 		xAxisRenderProp?: IXAxisRenderProp;
 		dataIsCentered?: boolean;
+		data: IData;
 	}
 ): void => {
 	const range = xScale.range();
@@ -138,7 +141,11 @@ const lucidXAxis = (
 		const tickRender = getTickRender(tickObj, (rMax - rMin) / domainLength);
 		tickRender.html((xValue: any, num: any, node: any) => {
 			if (xValue !== '' && !_.isNil(xValue)) {
-				ReactDOM.render(xAxisRenderProp(xValue), node[0]);
+				const subData = _.find(data, { x: xValue }) || { y: 0, ref: undefined};
+				ReactDOM.render(
+					xAxisRenderProp(xValue, subData.y, subData.ref),
+					node[0]
+				);
 			} else return xValue;
 		});
 	}

--- a/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
+++ b/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useMemo } from 'react';
 import createClass from 'create-react-class';
 import _ from 'lodash';
-import { DraggableLineChart, TextField } from '../../../index';
+import React, { useCallback } from 'react';
+import { DraggableLineChart, TextFieldValidated } from '../../../index';
 import { IXAxisRenderProp } from '../d3-helpers';
-import { IChartData, IData } from '../DraggableLineChartD3';
+import { IData } from '../DraggableLineChartD3';
 
 const initialCustomSpendDataPoints = [
 	{ x: '12 AM', y: 0, ref: React.createRef() },
@@ -23,42 +23,32 @@ const initialCustomSpendDataPoints = [
 const style = {
 	paddingTop: '4rem',
 };
-type IChangeHandler = (
-	newYValue: string,
-	xValue: string,
-	customSpendDataPoints: IData
-) => void;
+type IChangeHandler = (newYValue: string, xValue: string) => void;
 
 const DataInput = ({
 	xValue,
-	customSpendDataPoints,
+	yValue,
+	myRef,
 	changeHandler,
 }: {
 	xValue: string;
-	customSpendDataPoints: IData;
+	yValue: number;
+	myRef: any;
 	changeHandler: IChangeHandler;
 }): JSX.Element => {
-	const customSpendDataPoint = useMemo(() => {
-		return (
-			_.find(customSpendDataPoints, ({ x }: IChartData) => x === xValue) || {
-				x: '',
-				y: 0,
-			}
-		);
-	}, [customSpendDataPoints, xValue]);
 	const onChange = useCallback(
 		newYValue => {
-			changeHandler(newYValue, xValue, customSpendDataPoints);
+			changeHandler(newYValue, xValue);
 		},
-		[customSpendDataPoints, changeHandler, xValue]
+		[changeHandler, xValue]
 	);
 	return (
 		<div style={{ width: '70%', margin: 'auto' }}>
-			<TextField
-				value={customSpendDataPoint.y || 0}
+			<TextFieldValidated
+				value={yValue || 0}
 				onBlur={onChange}
 				tabIndex={0}
-				ref={customSpendDataPoint.ref}
+				ref={myRef}
 			/>
 			<div style={{ margin: 'auto', textAlign: 'center', width: '95%' }}>
 				{xValue}
@@ -85,6 +75,7 @@ export default createClass({
 			dataPoint =>
 				dataPoint.x === xValue ? { ...dataPoint, y: cleanedYValue } : dataPoint
 		);
+		console.log({ newCustomSpendDataPoints });
 		this.setState({ customSpendDataPoints: newCustomSpendDataPoints });
 		return newCustomSpendDataPoints;
 	},
@@ -117,12 +108,15 @@ export default createClass({
 		}: {
 			onChangeHandler: (newYValue: string, xValue: string) => void;
 		},
-		xValue: string
+		xValue: string,
+		yValue: number,
+		myRef: any
 	): JSX.Element {
 		return (
 			<DataInput
 				xValue={xValue}
-				customSpendDataPoints={this.state.customSpendDataPoints}
+				yValue={yValue}
+				myRef={myRef}
 				changeHandler={onChangeHandler}
 			/>
 		);

--- a/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
+++ b/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
@@ -75,7 +75,6 @@ export default createClass({
 			dataPoint =>
 				dataPoint.x === xValue ? { ...dataPoint, y: cleanedYValue } : dataPoint
 		);
-		console.log({ newCustomSpendDataPoints });
 		this.setState({ customSpendDataPoints: newCustomSpendDataPoints });
 		return newCustomSpendDataPoints;
 	},

--- a/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
+++ b/src/components/DraggableLineChart/examples/02.ExampleWithExternalXAxisRenderProp.tsx
@@ -108,15 +108,13 @@ export default createClass({
 		}: {
 			onChangeHandler: (newYValue: string, xValue: string) => void;
 		},
-		xValue: string,
-		yValue: number,
-		myRef: any
+		{x, y, ref }: { x: string; y: number; ref?: any }
 	): JSX.Element {
 		return (
 			<DataInput
-				xValue={xValue}
-				yValue={yValue}
-				myRef={myRef}
+				xValue={x}
+				yValue={y}
+				myRef={ref}
 				changeHandler={onChangeHandler}
 			/>
 		);
@@ -129,7 +127,7 @@ export default createClass({
 		return (
 			<div style={style}>
 				<DraggableLineChart
-					data={_.map(customSpendDataPoints, x => x)}
+					data={customSpendDataPoints}
 					width={900}
 					dataIsCentered
 					onDragEnd={this.onDragHandler}


### PR DESCRIPTION
Fixed missing style line. We have also updated the component to always pass back x, y, and ref to each render prop. This will eliminate the need to the consumers to need to tie any data back to that component.

## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BUDE-646-part2/?path=/docs/visualizations-draggablelinechart--example-with-external-x-axis-render-prop)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
