### PR TITLE
BUDE-479: Add option to LoadingIndicator and OverlayWrapper to center loading message and prevent scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - #1174 [patch] BUDE-811: Tweak spacing with inputs and graph padding
 - #1173 [patch] BUDE-811: Update color of point in DraggableLineChart
 - #1172 [patch] Added Wrench, Share, Lightbulb and Hosted icons.
+  https://github.com/appnexus/lucid/compare/v5.8.8...v5.8.9
 
 ## 5.8.8
 

--- a/src/components/LoadingIndicator/LoadingIndicator.less
+++ b/src/components/LoadingIndicator/LoadingIndicator.less
@@ -10,4 +10,9 @@
 		font-weight: @font-weight-regular;
 		color: @color-neutral-9;
 	}
+
+	&.preventScroll {
+		height: 100vh;
+		overflow-y: hidden;
+	}
 }

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -65,7 +65,7 @@ export const LoadingIndicator = (
 				// _.keys(LoadingIndicator.propTypes)
 				['children', 'className', 'isLoading', 'Message']
 			)}
-			className={cx('&', className)}
+			className={cx('&', centerMessage && 'preventScroll', className)}
 			isVisible={isLoading}
 			anchorMessage={anchorMessage}
 			centerMessage={centerMessage}

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -26,6 +26,13 @@ export interface ILoadingIndicatorProps extends IOverlayWrapperProps {
 	 */
 	anchorMessage: boolean;
 
+	/** Positions the loading message near the center of the container and
+	 * prevents scrolling behind the message. By default, the loading message is
+	 * vertically aligned to the middle of the container, and the content behind
+	 * is scrollable.
+	 */
+	centerMessage: boolean;
+
 	/** Style variations for the overlay behind the loading indicator. */
 	overlayKind: 'light' | 'dark';
 }
@@ -35,12 +42,13 @@ const defaultProps = {
 	isLoading: false,
 	overlayKind: 'light' as const,
 	anchorMessage: false,
+	centerMessage: false,
 };
 
 export const LoadingIndicator = (
 	props: ILoadingIndicatorProps
 ): React.ReactElement => {
-	const { children, className, isLoading, anchorMessage } = props;
+	const { children, className, isLoading, anchorMessage, centerMessage } = props;
 
 	const messageElement = getFirst(
 		props,
@@ -60,6 +68,7 @@ export const LoadingIndicator = (
 			className={cx('&', className)}
 			isVisible={isLoading}
 			anchorMessage={anchorMessage}
+			centerMessage={centerMessage}
 		>
 			{otherChildren}
 			<OverlayWrapperMessage>{messageElement}</OverlayWrapperMessage>
@@ -110,6 +119,13 @@ LoadingIndicator.propTypes = {
 	anchorMessage: bool`
 		Positions the loading message near the top of the container. By default,
 		the loading message is vertically aligned to the middle of the container.
+	`,
+
+	centerMessage: bool`
+		Positions the loading message near the center of the container and
+		prevents scrolling behind the message. By default, the loading message is
+		vertically aligned to the middle of the container, and the content behind
+		is scrollable.
 	`,
 
 	overlayKind: oneOf(['light', 'dark'])`

--- a/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
+++ b/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.spec.jsx.snap
@@ -3,6 +3,7 @@
 exports[`LoadingIndicator [common] example testing should match snapshot(s) for 1.interactive 1`] = `
 <OverlayWrapper
   anchorMessage={false}
+  centerMessage={false}
   className="lucid-LoadingIndicator"
   hasOverlay={true}
   isVisible={true}
@@ -107,6 +108,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
 exports[`LoadingIndicator [common] example testing should match snapshot(s) for 2.default 1`] = `
 <OverlayWrapper
   anchorMessage={false}
+  centerMessage={false}
   className="lucid-LoadingIndicator"
   hasOverlay={true}
   isVisible={true}
@@ -186,6 +188,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
 exports[`LoadingIndicator [common] example testing should match snapshot(s) for 3.custom-message 1`] = `
 <OverlayWrapper
   anchorMessage={false}
+  centerMessage={false}
   className="lucid-LoadingIndicator"
   hasOverlay={true}
   isVisible={true}
@@ -287,6 +290,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
 exports[`LoadingIndicator [common] example testing should match snapshot(s) for 3.custom-message 2`] = `
 <OverlayWrapper
   anchorMessage={false}
+  centerMessage={false}
   className="lucid-LoadingIndicator"
   hasOverlay={true}
   isVisible={true}
@@ -383,6 +387,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
 exports[`LoadingIndicator [common] example testing should match snapshot(s) for 4.no-title 1`] = `
 <OverlayWrapper
   anchorMessage={false}
+  centerMessage={false}
   className="lucid-LoadingIndicator"
   hasOverlay={true}
   isVisible={true}
@@ -465,6 +470,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
 exports[`LoadingIndicator [common] example testing should match snapshot(s) for 5.no-overlay 1`] = `
 <OverlayWrapper
   anchorMessage={false}
+  centerMessage={false}
   className="lucid-LoadingIndicator"
   hasOverlay={false}
   isVisible={true}
@@ -544,6 +550,7 @@ exports[`LoadingIndicator [common] example testing should match snapshot(s) for 
 exports[`LoadingIndicator [common] example testing should match snapshot(s) for 6.light-overlay 1`] = `
 <OverlayWrapper
   anchorMessage={false}
+  centerMessage={false}
   className="lucid-LoadingIndicator"
   hasOverlay={true}
   isVisible={true}

--- a/src/components/OverlayWrapper/OverlayWrapper.less
+++ b/src/components/OverlayWrapper/OverlayWrapper.less
@@ -35,11 +35,10 @@
 	}
 
 	&-centered-message {
-		height: 100vh;
-		overflow-y: hidden;
-
 		.lucid-LoadingMessage {
-			margin: 100% auto;
+			position: fixed;
+			top: 45%;
+			left: 45%;
 		}
 	}
 }

--- a/src/components/OverlayWrapper/OverlayWrapper.less
+++ b/src/components/OverlayWrapper/OverlayWrapper.less
@@ -33,4 +33,13 @@
 		align-items: flex-start;
 		padding-top: 100px;
 	}
+
+	&-centered-message {
+		height: 100vh;
+		overflow-y: hidden;
+
+		.lucid-LoadingMessage {
+			margin: 100% auto;
+		}
+	}
 }

--- a/src/components/OverlayWrapper/OverlayWrapper.tsx
+++ b/src/components/OverlayWrapper/OverlayWrapper.tsx
@@ -59,6 +59,14 @@ export interface IOverlayWrapperProps
 	 */
 	anchorMessage: boolean;
 
+	/** By default, the OverlayMessage is vertically aligned to the middle of the
+	 *	OverlayWrapper. Set this to true to position the `OverlayMessage` near the center of
+	 *	the `OverlayWrapper`, and prevent scrolling behind the message.
+	 *
+	 * @default false
+	 */
+	centerMessage: boolean;
+
 	/** *Child Element* The Message to display in the overlay. */
 	Message?: React.ReactNode & { props: IMessageProps };
 }
@@ -67,6 +75,7 @@ const defaultProps = {
 	hasOverlay: true,
 	overlayKind: 'light' as const,
 	anchorMessage: false,
+	centerMessage: false,
 	isVisible: false,
 };
 
@@ -80,6 +89,7 @@ export const OverlayWrapper = (
 		children,
 		overlayKind,
 		anchorMessage,
+		centerMessage,
 		...passThroughs
 	} = props;
 
@@ -108,6 +118,7 @@ export const OverlayWrapper = (
 						'&-has-overlay': hasOverlay,
 						'&-kind-light': hasOverlay && overlayKind === 'light',
 						'&-anchored-message': anchorMessage,
+						'&-centered-message': centerMessage,
 					})}
 				>
 					<div {...messageElementProp} />
@@ -154,6 +165,13 @@ OverlayWrapper.propTypes = {
 		By default, the \`OverlayMessage\` is vertically aligned to the middle of the
 		OverlayWrapper. Set this to true to position the \`OverlayMessage\` near the top of 
 		the \`OverlayWrapper\`.
+	`,
+
+	centerMessage: bool`
+		Positions the loading message near the center of the container and
+		prevents scrolling behind the message. By default, the loading message is
+		vertically aligned to the middle of the container, and the content behind
+		is scrollable.
 	`,
 
 	Message: node`


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
