### PR TITLE
Bude 967: Add in helper text for draggable line chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.18
+- [patch] Adding helper text box for DraggableLineChart
+  https://github.com/appnexus/lucid/compare/v5.8.17...v5.8.18
+
 ## 5.8.17
 - [patch] Fixing less on TimeSelect
   https://github.com/appnexus/lucid/compare/v5.8.16...v5.8.17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucid-ui",
-	"version": "5.8.16",
+	"version": "5.8.17",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucid-ui",
-	"version": "5.8.16",
+	"version": "5.8.17",
 	"description": "A UI component library from AppNexus.",
 	"main": "dist/index.js",
 	"module": "lib/index.js",

--- a/src/components/DraggableLineChart/DraggableLineChart.less
+++ b/src/components/DraggableLineChart/DraggableLineChart.less
@@ -7,8 +7,8 @@
 	}
 
 	&-empty-info {
-		border: solid 1px @featured-color-default-borderColor;
-		padding: 15px;
+		border: @border-standardBorder;
+		padding: @size-L;
 		font-weight: @font-weight-medium;
 		background-color: @color-white;
 	}

--- a/src/components/DraggableLineChart/DraggableLineChart.less
+++ b/src/components/DraggableLineChart/DraggableLineChart.less
@@ -6,6 +6,13 @@
 		fill-opacity: 0;
 	}
 
+	&-empty-info {
+		border: solid 1px @featured-color-default-borderColor;
+		padding: 15px;
+		font-weight: @font-weight-medium;
+		background-color: @color-white;
+	}
+
 	&-tooltip-line {
 		shape-rendering: crispEdges;
 		stroke-width: 2;

--- a/src/components/DraggableLineChart/DraggableLineChart.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.tsx
@@ -9,6 +9,12 @@ import DraggableLineChartD3, {
 
 const cx = lucidClassNames.bind('&-DraggableLineChart');
 
+const getEmptyRenderProp = (preSelectText: string) => (
+	<div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+		<div className={cx('&-empty-info')}>{preSelectText}</div>
+	</div>
+);
+
 export type IDraggableLineChartProps = Overwrite<
 	React.SVGProps<SVGGElement>,
 	IDraggableLineChart
@@ -50,7 +56,13 @@ class DraggableLineChart extends React.Component<IDraggableLineChartProps, {}> {
 			xAxisRenderProp,
 			showPreselect,
 			onPreselect,
+			preSelectText,
 		} = this.props;
+		const emptyRenderProp =
+			onPreselect && preSelectText
+				? () => getEmptyRenderProp(preSelectText)
+				: undefined;
+
 		this.d3LineChart = new DraggableLineChartD3(svg, {
 			height: height || draggableLineChartDefaultProps.height,
 			width: width || draggableLineChartDefaultProps.width,
@@ -61,6 +73,7 @@ class DraggableLineChart extends React.Component<IDraggableLineChartProps, {}> {
 			dataIsCentered,
 			yAxisMin,
 			xAxisRenderProp,
+			emptyRenderProp,
 			cx,
 			showPreselect,
 			onPreselect,
@@ -97,6 +110,7 @@ class DraggableLineChart extends React.Component<IDraggableLineChartProps, {}> {
 					'xAxisRenderProp',
 					'showPreselect',
 					'onPreselect',
+					'preSelectText',
 				])}
 				ref={(ref: SVGSVGElement) => (this.ref = ref)}
 				className={cx('&')}

--- a/src/components/DraggableLineChart/DraggableLineChartD3.ts
+++ b/src/components/DraggableLineChart/DraggableLineChartD3.ts
@@ -96,7 +96,7 @@ export interface IDraggableLineChart extends StandardProps {
 			in the data. This react component will always be passed the following props: ({x, y, ref }: { x: string; y: number; ref?: any }) */
 	xAxisRenderProp?: IXAxisRenderProp;
 	/**
-	 * Text to show to users when there is no date
+	 * Text to show to users when there is no data selection
 	 */
 	preSelectText?: string;
 }
@@ -175,10 +175,6 @@ class DraggableLineChartD3 {
 	getHasRenderedPoint = () => {
 		return !!this.params.hasRenderedPoint;
 	};
-
-	// getHasRenderedEmptyBox = () => {
-	// 	return !!this.params.hasRenderedEmptyBox;
-	// };
 
 	getHasRenderedLine = () => {
 		return !!this.params.hasRenderedLine;

--- a/src/components/DraggableLineChart/DraggableLineChartD3.ts
+++ b/src/components/DraggableLineChart/DraggableLineChartD3.ts
@@ -321,7 +321,7 @@ class DraggableLineChartD3 {
 				.append('foreignObject')
 				.attr('height', height)
 				.attr('width', width)
-				.attr('x', 80)
+				.attr('x', this.params.margin.left)
 				.classed('emptyRender', true);
 			emptyRender.html(
 				(value: any, num: any, node: any): any => {

--- a/src/components/DraggableLineChart/DraggableLineChartD3.ts
+++ b/src/components/DraggableLineChart/DraggableLineChartD3.ts
@@ -4,6 +4,7 @@ import * as d3Shape from 'd3-shape';
 import * as d3Drag from 'd3-drag';
 import * as d3Selection from 'd3-selection';
 import * as d3Transition from 'd3-transition';
+import ReactDOM from 'react-dom';
 import { d3Scale } from '../../index';
 import _ from 'lodash';
 import * as d3Array from 'd3-array';
@@ -94,6 +95,10 @@ export interface IDraggableLineChart extends StandardProps {
 			to the next component on tab, you will might need to provide refs
 			in the data. This react component will always be passed the following props: ({x, y, ref }: { x: string; y: number; ref?: any }) */
 	xAxisRenderProp?: IXAxisRenderProp;
+	/**
+	 * Text to show to users when there is no date
+	 */
+	preSelectText?: string;
 }
 
 interface IDraggableLineChartParams extends IDraggableLineChart {
@@ -107,6 +112,7 @@ interface IDraggableLineChartParams extends IDraggableLineChart {
 	mouseDownStep?: number;
 	hasRenderedPoint?: boolean;
 	hasRenderedLine?: boolean;
+	emptyRenderProp?: () => JSX.Element;
 }
 
 class DraggableLineChartD3 {
@@ -169,6 +175,10 @@ class DraggableLineChartD3 {
 	getHasRenderedPoint = () => {
 		return !!this.params.hasRenderedPoint;
 	};
+
+	// getHasRenderedEmptyBox = () => {
+	// 	return !!this.params.hasRenderedEmptyBox;
+	// };
 
 	getHasRenderedLine = () => {
 		return !!this.params.hasRenderedLine;
@@ -301,6 +311,29 @@ class DraggableLineChartD3 {
 					.y((d: any) => this.yScale(d.y))
 			);
 	};
+	renderEmptyRenderProp = (height: number, width: number) => {
+		const { emptyRenderProp } = this.params;
+		if (!emptyRenderProp || !this.shouldShowPreselect()) {
+			return;
+		}
+
+		const emptyDataObject = this.selection.selectAll('.emptyRender');
+		console.log({ emptyDataObject });
+		if (emptyDataObject.empty()) {
+			const emptyRender: ISelection = this.selection
+				.selectAll('.overlayContainer')
+				.append('foreignObject')
+				.attr('height', height)
+				.attr('width', width)
+				.attr('x', 80)
+				.classed('emptyRender', true);
+			emptyRender.html(
+				(value: any, num: any, node: any): any => {
+					ReactDOM.render(emptyRenderProp(), node[0]);
+				}
+			);
+		}
+	};
 	renderPoints = () => {
 		if (this.shouldShowPreselect()) {
 			return;
@@ -413,6 +446,8 @@ class DraggableLineChartD3 {
 			.append('g')
 			.classed('overlayContainer', true)
 			.attr('transform', `translate(${0},${top})`);
+
+		this.renderEmptyRenderProp(innerHeight, stepCount * stepWidth);
 
 		const overlayTrack = overlayContainer
 			.selectAll('rect')

--- a/src/components/DraggableLineChart/DraggableLineChartD3.ts
+++ b/src/components/DraggableLineChart/DraggableLineChartD3.ts
@@ -314,7 +314,6 @@ class DraggableLineChartD3 {
 		}
 
 		const emptyDataObject = this.selection.selectAll('.emptyRender');
-		console.log({ emptyDataObject });
 		if (emptyDataObject.empty()) {
 			const emptyRender: ISelection = this.selection
 				.selectAll('.overlayContainer')

--- a/src/components/DraggableLineChart/examples/03.ExampleWithNoDataWithPreselect.tsx
+++ b/src/components/DraggableLineChart/examples/03.ExampleWithNoDataWithPreselect.tsx
@@ -88,7 +88,11 @@ export default createClass({
 	onPreselectHandler(data: ISelectedChartData[]): void {
 		const totalSelected = _.filter(data, ['isSelected', true]).length;
 		const avg = Math.round((100 / totalSelected) * 10) / 10;
-		const updatedData = _.map(data, (step) => ({ ref: step.ref, x: step.x, y: step.isSelected ? avg : step.y }));
+		const updatedData = _.map(data, step => ({
+			ref: step.ref,
+			x: step.x,
+			y: step.isSelected ? avg : step.y,
+		}));
 
 		this.setState({ customSpendDataPoints: updatedData });
 	},
@@ -147,6 +151,7 @@ export default createClass({
 					xAxisRenderProp={renderProp}
 					showPreselect={true}
 					onPreselect={this.onPreselectHandler}
+					preSelectText='Click and drag to select hours'
 				/>
 			</div>
 		);


### PR DESCRIPTION




## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BUDE-967/?path=/docs/visualizations-draggablelinechart--example-with-no-data-with-preselect)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
