### PR TITLE
TXP-484: removing style that causes labels to be not horizontally ali…

### DIFF
--- a/src/components/SwitchLabeled/SwitchLabeled.less
+++ b/src/components/SwitchLabeled/SwitchLabeled.less
@@ -77,7 +77,6 @@
 		.transition-group-animation-fade(@timing-animation-hover);
 
 		position: relative;
-		height: @Switch-height;
 
 		// Since we have two elements in the dom during the transition from one
 		// label to another, we want the element that's leaving to appear "over


### PR DESCRIPTION
This PR removes a css `height` property that was causing the label in the `SwitchLabelled` component to not be aligned (see attached screenshot). This problem can be seen on the storybook pages for lucid and anx-react.
 
Before:
![image](https://user-images.githubusercontent.com/12438018/100279670-db039680-2f1b-11eb-88fb-25ef4ff9615d.png)
After:
![image](https://user-images.githubusercontent.com/12438018/100279711-ee166680-2f1b-11eb-94d2-ce3bda84b93e.png)

## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
