### PR TITLE
Bude 966: Add optional flag to truncate Table cell content with ellipsis when fixedHeader

### DIFF
--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -216,7 +216,6 @@ const DataTable = createClass({
 			minRows: 10,
 			hasFixedHeader: false,
 			fixedColumnCount: 0,
-			truncateContent: false,
 		};
 	},
 

--- a/src/components/DataTable/DataTable.jsx
+++ b/src/components/DataTable/DataTable.jsx
@@ -178,6 +178,10 @@ const DataTable = createClass({
 			using the \`fixedColumnCount\` prop.
 		`,
 
+		truncateContent: bool`
+			Truncates \`Table.Td\` content with ellipses, must be used with \`hasFixedHeader\`
+		`,
+
 		Column: any`
 			*Child Element*
 
@@ -212,6 +216,7 @@ const DataTable = createClass({
 			minRows: 10,
 			hasFixedHeader: false,
 			fixedColumnCount: 0,
+			truncateContent: false,
 		};
 	},
 
@@ -423,6 +428,7 @@ const DataTable = createClass({
 			minRows,
 			emptyCellText,
 			fixedRowHeight,
+			truncateContent
 		} = this.props;
 
 		const fillerRowCount = _.clamp(minRows - _.size(data), 0, Infinity);
@@ -497,6 +503,7 @@ const DataTable = createClass({
 													index +
 													_.get(columnProps, 'field', columnIndex)
 												}
+												truncateContent={truncateContent}
 											>
 												{isEmpty ? emptyCellText : cellValue}
 											</Td>

--- a/src/components/Table/Table.less
+++ b/src/components/Table/Table.less
@@ -239,6 +239,12 @@
 				background-clip: padding-box; // fixes Firefox background paints over collapsed border
 				border-bottom: @border-table-row;
 
+				&.@{prefix}-Table-truncate-content {
+					text-overflow: ellipsis;
+					overflow: hidden;
+					white-space: nowrap;
+				}
+
 				// remove all borders from the perimeter of the body
 				&.@{prefix}-Table-is-first-row {
 					border-top: 1px solid @color-table-header-border;

--- a/src/components/Table/Table.spec.jsx
+++ b/src/components/Table/Table.spec.jsx
@@ -312,6 +312,17 @@ describe('Table', () => {
 						);
 					});
 				});
+
+				describe('truncateContent', () => {
+					it('should apply the class name `lucid-Table-truncate-content`', () => {
+						const wrapper = shallow(<Td truncateContent />);
+
+						assert.equal(
+							wrapper.find('td.lucid-Table-truncate-content').length,
+							1
+						);
+					});
+				});
 			});
 		});
 	});

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -663,7 +663,7 @@ export interface ITdProps
 	rowSpan: number | null;
 
 	/** Truncates `Table.Td` content with ellipses, must be used with `hasFixedHeader` */
-	truncateContent: boolean;
+	truncateContent?: boolean;
 }
 
 const Td = (props: ITdProps): React.ReactElement => {
@@ -715,7 +715,6 @@ Td.defaultProps = {
 	align: 'left',
 	hasBorderRight: false,
 	hasBorderLeft: false,
-	truncateContent: false,
 	rowSpan: 1,
 };
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -661,6 +661,9 @@ export interface ITdProps
 	isEmpty?: boolean;
 
 	rowSpan: number | null;
+
+	/** Truncates `Table.Td` content with ellipses, must be used with `hasFixedHeader` */
+	truncateContent: boolean;
 }
 
 const Td = (props: ITdProps): React.ReactElement => {
@@ -674,6 +677,7 @@ const Td = (props: ITdProps): React.ReactElement => {
 		align,
 		hasBorderRight,
 		hasBorderLeft,
+		truncateContent,
 		...passThroughs
 	} = props;
 
@@ -697,6 +701,7 @@ const Td = (props: ITdProps): React.ReactElement => {
 					'&-align-right': align === 'right',
 					'&-has-border-right': hasBorderRight,
 					'&-has-border-left': hasBorderLeft,
+					'&-truncate-content': truncateContent,
 				},
 				className
 			)}
@@ -710,6 +715,7 @@ Td.defaultProps = {
 	align: 'left',
 	hasBorderRight: false,
 	hasBorderLeft: false,
+	truncateContent: false,
 	rowSpan: 1,
 };
 
@@ -761,6 +767,10 @@ Td.propTypes = {
 
 	isEmpty: bool`
 		Indicates if the cell has any data or not.
+	`,
+
+	truncateContent: bool`
+		Truncates \`Table.Td\` content with ellipses, must be used with \`hasFixedHeader\`
 	`,
 };
 


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
