### PR TITLE
BUDE-969: Add formatted-options example to SearchableSingleSelect

### DIFF
--- a/src/components/SearchableSingleSelect/__snapshots__/SearchableSingleSelect.spec.jsx.snap
+++ b/src/components/SearchableSingleSelect/__snapshots__/SearchableSingleSelect.spec.jsx.snap
@@ -1590,6 +1590,141 @@ exports[`SearchableSingleSelect [common] example testing should match snapshot(s
 </div>
 `;
 
+exports[`SearchableSingleSelect [common] example testing should match snapshot(s) for 07.formatted-options 1`] = `
+<div
+  className="lucid-SearchableSingleSelect"
+>
+  <DropMenu
+    ContextMenu={
+      Object {
+        "alignmentOffset": -13,
+        "directonOffset": -1,
+        "minWidthOffset": -28,
+      }
+    }
+    alignment="start"
+    className="lucid-SearchableSingleSelect-DropMenu lucid-SearchableSingleSelect-DropMenu-is-small"
+    direction="down"
+    flyOutStyle={
+      Object {
+        "maxHeight": "18em",
+      }
+    }
+    focusedIndex={null}
+    isDisabled={false}
+    isExpanded={false}
+    onCollapse={[Function]}
+    onExpand={[Function]}
+    onFocusNext={[Function]}
+    onFocusOption={[Function]}
+    onFocusPrev={[Function]}
+    onSelect={[Function]}
+    optionContainerStyle={Object {}}
+    portalId=""
+    selectedIndices={null}
+  >
+    <DropMenu.Control>
+      <SearchField
+        autoComplete="off"
+        className="lucid-SearchableSingleSelect-search"
+        debounceLevel={500}
+        isDisabled={false}
+        onChange={[Function]}
+        onChangeDebounced={[Function]}
+        onSubmit={[Function]}
+        value=""
+      />
+    </DropMenu.Control>
+    <DropMenu.OptionGroup
+      isHidden={false}
+      key="SearchableSingleSelectOptionGroup0"
+    >
+      <OptionCols
+        col1="ID"
+        col2="NAME"
+        col3="DESCRIPTION"
+      />
+      <SearchableSingleSelect.Option
+        Selected="Drone (13)"
+        filterText="13 Drone lorem ipsum dolor sit"
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+      >
+        <Component />
+      </SearchableSingleSelect.Option>
+      <SearchableSingleSelect.Option
+        Selected="Appa (14)"
+        filterText="14 Appa dolor sit amet consectetur"
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+      >
+        <Component />
+      </SearchableSingleSelect.Option>
+      <SearchableSingleSelect.Option
+        Selected="Breakfast (14)"
+        filterText="15 Breakfast amet consectetur adipiscing elit"
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+      >
+        <Component />
+      </SearchableSingleSelect.Option>
+      <SearchableSingleSelect.Option
+        Selected="Scout (15)"
+        filterText="16 Scout adipiscing elit sed do"
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+      >
+        <Component />
+      </SearchableSingleSelect.Option>
+      <DropMenu.Option
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+        key="SearchableSingleSelectOption0"
+      >
+        <Component
+          searchText=""
+        />
+      </DropMenu.Option>
+      <DropMenu.Option
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+        key="SearchableSingleSelectOption1"
+      >
+        <Component
+          searchText=""
+        />
+      </DropMenu.Option>
+      <DropMenu.Option
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+        key="SearchableSingleSelectOption2"
+      >
+        <Component
+          searchText=""
+        />
+      </DropMenu.Option>
+      <DropMenu.Option
+        isDisabled={false}
+        isHidden={false}
+        isWrapped={true}
+        key="SearchableSingleSelectOption3"
+      >
+        <Component
+          searchText=""
+        />
+      </DropMenu.Option>
+    </DropMenu.OptionGroup>
+  </DropMenu>
+</div>
+`;
+
 exports[`SearchableSingleSelect custom formatting should render Option child function by passing in {searchText}, setting filterText on each option and using a custom optionFilter 1`] = `
 <div
   className="lucid-SearchableSingleSelect"

--- a/src/components/SearchableSingleSelect/examples/07.formatted-options.tsx
+++ b/src/components/SearchableSingleSelect/examples/07.formatted-options.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SearchableSingleSelect } from '../../../index';
+
+const { Option, OptionGroup } = SearchableSingleSelect;
+
+const OptionCols = ({ col1, col2 }: { col1: string; col2: string }) => (
+	<div style={{ display: 'flex' }}>
+		<div style={{ width: 100 }}>{col1}</div>
+		<div>{col2}</div>
+	</div>
+);
+
+export default createClass({
+	render() {
+		return (
+			<SearchableSingleSelect
+				SearchField={{
+					placeholder: 'Character',
+				}}
+			>
+				<OptionGroup>
+					<OptionCols col1='NAME' col2='NUMBER'  />
+
+					<Option Selected='Drone (13)'>
+						<OptionCols col1='Drone' col2='13' />
+					</Option>
+
+					<Option Selected='Appa (14)'>
+						<OptionCols col1='Appa' col2='14' />
+					</Option>
+
+					<Option Selected='Breakfast (15)'>
+						<OptionCols col1='Breakfast' col2='15' />
+					</Option>
+
+					<Option Selected='Scout (16)'>
+						<OptionCols col1='Scout' col2='16' />
+					</Option>
+				</OptionGroup>
+			</SearchableSingleSelect>
+		);
+	},
+});

--- a/src/components/SearchableSingleSelect/examples/07.formatted-options.tsx
+++ b/src/components/SearchableSingleSelect/examples/07.formatted-options.tsx
@@ -1,44 +1,94 @@
 import React from 'react';
-import createClass from 'create-react-class';
-import { SearchableSingleSelect } from '../../../index';
+import _ from 'lodash';
+import { SearchableSingleSelect, Underline } from '../../../index';
 
-const { Option, OptionGroup } = SearchableSingleSelect;
-
-const OptionCols = ({ col1, col2 }: { col1: string; col2: string }) => (
+// eslint-disable-next-line react/prop-types
+const OptionCols = ({
+	col1,
+	col2,
+	col3,
+	textMatch,
+}: {
+	col1: string;
+	col2: string;
+	col3: string;
+	textMatch?: string | undefined;
+}) => (
 	<div style={{ display: 'flex' }}>
-		<div style={{ width: 100 }}>{col1}</div>
-		<div>{col2}</div>
+		<div style={{ width: 100 }}>
+			<Underline match={textMatch}>{col1}</Underline>
+		</div>
+		<div style={{ width: 100 }}>
+			<Underline match={textMatch}>{col2}</Underline>
+		</div>
+		<div style={{ width: 200 }}>
+			<Underline match={textMatch}>{col3}</Underline>
+		</div>
 	</div>
 );
 
-export default createClass({
+const optionFilter = (
+	searchText: string,
+	{ filterText }: { filterText: string }
+) => {
+	if (filterText) {
+		return new RegExp(_.escapeRegExp(searchText), 'i').test(filterText);
+	}
+	return true;
+};
+
+export default class extends React.Component {
 	render() {
 		return (
-			<SearchableSingleSelect
-				SearchField={{
-					placeholder: 'Character',
-				}}
-			>
-				<OptionGroup>
-					<OptionCols col1='NAME' col2='NUMBER'  />
+			<SearchableSingleSelect optionFilter={optionFilter}>
+				<SearchableSingleSelect.OptionGroup>
+					<OptionCols col1='ID' col2='NAME' col3='DESCRIPTION' />
 
-					<Option Selected='Drone (13)'>
-						<OptionCols col1='Drone' col2='13' />
-					</Option>
+					<SearchableSingleSelect.Option filterText='13 Drone lorem ipsum dolor sit' Selected='Drone (13)'>
+						{({ searchText }: { searchText: string }) => (
+							<OptionCols
+								col1='13'
+								col2='Drone'
+								col3='lorem ipsum dolor sit'
+								textMatch={searchText}
+							/>
+						)}
+					</SearchableSingleSelect.Option>
 
-					<Option Selected='Appa (14)'>
-						<OptionCols col1='Appa' col2='14' />
-					</Option>
+					<SearchableSingleSelect.Option filterText='14 Appa dolor sit amet consectetur' Selected='Appa (14)'>
+						{({ searchText }: { searchText: string }) => (
+							<OptionCols
+								col1='14'
+								col2='Appa'
+								col3='dolor sit amet consectetur'
+								textMatch={searchText}
+							/>
+						)}
+					</SearchableSingleSelect.Option>
 
-					<Option Selected='Breakfast (15)'>
-						<OptionCols col1='Breakfast' col2='15' />
-					</Option>
+					<SearchableSingleSelect.Option filterText='15 Breakfast amet consectetur adipiscing elit' Selected='Breakfast (14)'>
+						{({ searchText }: { searchText: string }) => (
+							<OptionCols
+								col1='14'
+								col2='Breakfast'
+								col3='amet consectetur adipiscing elit'
+								textMatch={searchText}
+							/>
+						)}
+					</SearchableSingleSelect.Option>
 
-					<Option Selected='Scout (16)'>
-						<OptionCols col1='Scout' col2='16' />
-					</Option>
-				</OptionGroup>
+					<SearchableSingleSelect.Option filterText='16 Scout adipiscing elit sed do' Selected='Scout (15)'>
+						{({ searchText }: { searchText: string }) => (
+							<OptionCols
+								col1='15'
+								col2='Scout'
+								col3='adipiscing elit sed do'
+								textMatch={searchText}
+							/>
+						)}
+					</SearchableSingleSelect.Option>
+				</SearchableSingleSelect.OptionGroup>
 			</SearchableSingleSelect>
 		);
-	},
-});
+	}
+}


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval


Only adding an example, no code changes
<img width="821" alt="Screen Shot 2020-12-15 at 12 04 18 PM" src="https://user-images.githubusercontent.com/14900449/102266917-f6841080-3ecd-11eb-83e7-bac198ea83c3.png">