### PR TITLE
feat: add TextFieldPlain

### DIFF
--- a/src/components/TextField/TextField.less
+++ b/src/components/TextField/TextField.less
@@ -4,7 +4,7 @@
 @TextField-size-height: @size-standard-height;
 @TextField-color-font: @color-neutral-9;
 
-.@{prefix}-TextField {
+.@{prefix}-TextField, .@{prefix}-TextFieldPlain {
 	.box-sizing();
 
 	background-color: @color-white;

--- a/src/components/TextField/TextFieldPlain.spec.jsx
+++ b/src/components/TextField/TextFieldPlain.spec.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { common } from '../../util/generic-tests';
+import TextFieldPlain from './TextFieldPlain';
+import { shallow } from 'enzyme';
+
+describe('TextField', () => {
+	common(TextFieldPlain);
+
+	test('input should have the correct value', () => {
+		const value = 'test value';
+		const wrapper = shallow(<TextFieldPlain value={value} />);
+		expect(wrapper.find('input').props().value).toEqual(value);
+	});
+
+	test('multiline textarea should have the correct value', () => {
+		const value = 'test value';
+		const wrapper = shallow(<TextFieldPlain value={value} isMultiLine />);
+		expect(wrapper.find('textarea').props().value).toEqual(value);
+	});
+});

--- a/src/components/TextField/TextFieldPlain.tsx
+++ b/src/components/TextField/TextFieldPlain.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { lucidClassNames } from '../../util/style-helpers';
+import PropTypes from 'prop-types';
+
+const cx = lucidClassNames.bind('&-TextFieldPlain');
+
+type InputProps = JSX.IntrinsicElements['input'];
+type TextareaProps = JSX.IntrinsicElements['textarea'];
+
+interface TextFieldInputPlain extends InputProps {
+	isDisabled?: boolean;
+	isMultiLine?: boolean;
+}
+interface TextFieldTextareaPlain extends TextareaProps {
+	isDisabled?: boolean;
+	isMultiLine?: boolean;
+}
+
+const TextFieldPlain = React.forwardRef(
+	(
+		{
+			isDisabled = false,
+			isMultiLine = false,
+			...props
+		}: TextFieldInputPlain | TextFieldTextareaPlain,
+		ref: React.Ref<HTMLTextAreaElement | HTMLInputElement>
+	) => {
+		const className = cx(
+			'&',
+			{
+				'&-is-disabled': isDisabled,
+				'&-is-multi-line': isMultiLine,
+				'&-is-single-line': !isMultiLine,
+			},
+			props.className
+		);
+		if (isMultiLine) {
+			return (
+				<textarea
+					ref={ref as React.Ref<HTMLTextAreaElement>}
+					{...props as TextFieldTextareaPlain}
+					className={className}
+				/>
+			);
+		} else {
+			return (
+				<input
+					ref={ref as React.Ref<HTMLInputElement>}
+					{...props as TextFieldInputPlain}
+					className={className}
+				/>
+			);
+		}
+	}
+);
+// @ts-ignore
+TextFieldPlain.propTypes = {
+	isDisabled: PropTypes.bool,
+	isMultiLine: PropTypes.bool,
+	className: PropTypes.string,
+};
+TextFieldPlain.displayName = 'TextFieldPlain';
+export default TextFieldPlain;

--- a/src/components/TextField/examples/plain.jsx
+++ b/src/components/TextField/examples/plain.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { TextFieldPlain } from '../../../index';
+
+const style = {
+	marginBottom: '10px',
+};
+
+export default function TextFieldPlainExample() {
+	return (
+		<div>
+			<TextFieldPlain style={style} placeholder='Plain Textfield example' />
+			<TextFieldPlain
+				isMultiLine
+				rows={5}
+				style={style}
+				placeholder='Plain Textfield multiline example'
+			/>
+		</div>
+	);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,7 @@ import Table from './components/Table/Table';
 import TableIcon from './components/Icon/TableIcon/TableIcon';
 import Tag from './components/Tag/Tag';
 import TextField from './components/TextField/TextField';
+import TextFieldPlain from './components/TextField/TextFieldPlain';
 import TextFieldValidated from './components/TextFieldValidated/TextFieldValidated';
 import TextIcon from './components/Icon/TextIcon/TextIcon';
 import TicketIcon from './components/Icon/TicketIcon/TicketIcon';
@@ -397,6 +398,7 @@ export {
 	Tag,
 	TextIcon,
 	TextField,
+	TextFieldPlain,
 	TextFieldValidated,
 	TicketIcon,
 	ToolTip,


### PR DESCRIPTION
note: this is a redo of https://github.com/appnexus/lucid/pull/1193 to fix the chromatic build

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/textfield-plain/?path=/docs/controls-textfield--plain)

This adds a `TextFieldPlain` component. This is a super simple wrapper around input/textrea that has the same styling as `TextField` without the complex reducers or anything fancy.

I've found TextField's state management a bit much for most cases and just need a lucid styled textfield and especially this makes it easier for testing w/o requiring any re-renders.

<img width="934" alt="Screen Shot 2021-02-01 at 12 17 50 PM" src="https://user-images.githubusercontent.com/648/106493775-9817ef00-6487-11eb-906f-c04724ab1eec.png">


- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
