### PR TITLE
BWAP-704 Added GroupLoadingSkeleton 

### DIFF
--- a/docs/load-components.js
+++ b/docs/load-components.js
@@ -283,6 +283,23 @@ module.exports = [
 	},
 
 	{
+		name: 'GroupLoadingSkeleton',
+		component: getDefaultExport(
+			require('../src/components/LoadingSkeletons/GroupLoadingSkeleton')
+		),
+		examplesContext: require.context(
+			'../src/components/LoadingSkeletons/examples/GroupLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../src/components/LoadingSkeletons/examples/GroupLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+	},
+
+	{
 		name: 'ContextMenu',
 		component: getDefaultExport(
 			require('../src/components/ContextMenu/ContextMenu')

--- a/src/components/LoadingSkeletons/GroupLoadingSkeleton.spec.tsx
+++ b/src/components/LoadingSkeletons/GroupLoadingSkeleton.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import GroupLoadingSkeleton, { GroupSkeleton } from './GroupLoadingSkeleton';
+import { ILoadingSkeletonProps, IStandardSkeleton } from './LoadingSkeleton';
+
+describe('GroupLoadingSkeleton', () => {
+	it('should render GroupLoadingSkeleton', () => {
+		const standardSkeletonProps: IStandardSkeleton = {
+			width: 100,
+			height: 100,
+			className: 'className',
+		};
+
+		const props: ILoadingSkeletonProps = {
+			...standardSkeletonProps,
+			isLoading: false,
+			children: {},
+			style: {},
+			isPanel: false,
+			hasOverlay: false,
+			numRows: 1,
+			numColumns: 1,
+			Skeleton: undefined,
+		};
+
+		const testProps = { ...props };
+		let component = shallow(<GroupLoadingSkeleton {...testProps} />);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-GroupLoadingSkeleton"]')
+				.exists()
+		).toEqual(true);
+
+		component = shallow(<GroupSkeleton {...standardSkeletonProps} />);
+
+		expect(
+			component.find('[data-test-id="loadingSkeleton-GroupSkeleton"]').exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-GroupSkeleton-svg"]')
+				.exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-GroupSkeleton-svg"]')
+				.prop('width')
+		).toEqual(testProps.width);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-GroupSkeleton-svg"]')
+				.prop('height')
+		).toEqual(testProps.height);
+	});
+});

--- a/src/components/LoadingSkeletons/GroupLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/GroupLoadingSkeleton.tsx
@@ -8,7 +8,7 @@ import LoadingSkeleton, {
 } from './LoadingSkeleton';
 
 export const GroupSkeleton = (props: IStandardSkeleton): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = { ...props };
+	const { width = '100%', height = '100%', className } = props;
 
 	const bottomRectWidth = _.toNumber(width) - _.toNumber(width) / 3;
 	return (

--- a/src/components/LoadingSkeletons/GroupLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/GroupLoadingSkeleton.tsx
@@ -1,0 +1,95 @@
+import _ from 'lodash';
+import React from 'react';
+import LoadingMessage from '../LoadingMessage/LoadingMessage';
+import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
+import LoadingSkeleton, {
+	ILoadingSkeletonProps,
+	IStandardSkeleton,
+} from './LoadingSkeleton';
+
+export const GroupSkeleton = (props: IStandardSkeleton): React.ReactElement => {
+	const { width = '100%', height = '100%', className } = { ...props };
+
+	const bottomRectWidth = _.toNumber(width) - _.toNumber(width) / 3;
+	return (
+		<div data-test-id='loadingSkeleton-GroupSkeleton'>
+			<svg
+				data-test-id='loadingSkeleton-GroupSkeleton-svg'
+				width={width}
+				height={height}
+				version='1.1'
+				xmlns='http://www.w3.org/2000/svg'
+			>
+				<g
+					id='GroupSkeleton-Details'
+					stroke='none'
+					strokeWidth='1'
+					fill='none'
+					fillRule='evenodd'
+				>
+					<g id='GroupSkeleton-Group'>
+						<g
+							id='GGroupSkeleton-Group-1'
+							className={cxBackgroundGray('&', className)}
+						>
+							<rect id='Rectangle' x='0' y='0' />
+						</g>
+						<rect
+							className={cxBackgroundGray('&', className)}
+							id='GroupSkeleton-Rectangle-1'
+							x='10'
+							y='13'
+							width={width}
+							height='10'
+						/>
+						<rect
+							className={cxBackgroundGray('&', className)}
+							id='GroupSkeleton-Rectangle-2'
+							x='10'
+							y='32'
+							width={bottomRectWidth}
+							height='18'
+						/>
+					</g>
+				</g>
+			</svg>
+		</div>
+	);
+};
+
+const GroupLoadingSkeleton = (
+	props: ILoadingSkeletonProps
+): React.ReactElement => {
+	return (
+		<LoadingSkeleton
+			data-test-id='loadingSkeleton-GroupLoadingSkeleton'
+			Skeleton={GroupSkeleton}
+			{...props}
+		/>
+	);
+};
+
+GroupLoadingSkeleton.LoadingMessage = LoadingMessage;
+
+GroupLoadingSkeleton.displayName = 'GroupLoadingSkeleton';
+GroupLoadingSkeleton.peek = {
+	description: `
+		A loading indicator wrapper with optional overlay.
+	`,
+	notes: {
+		overview: `
+			A visual indication that a section or component of the interface is loading. Designed to indicate loading data
+		`,
+		intendedUse: `
+			- Use in places where data takes time to load. GroupLoadingSkeleton lets users know that the information they expect to see will appear shortly.		
+		`,
+		technicalRecommendations: `
+			If a page is displaying a lot of data coming from multiple sources, try as best as possible to load the 
+			individual parts of the UI, so as not to disrupt the user and block them from interacting with the entire page until all data is loaded.
+		`,
+	},
+	categories: ['Loading Indicator'],
+	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
+};
+
+export default GroupLoadingSkeleton;

--- a/src/components/LoadingSkeletons/TableLoadingSkeleton.spec.tsx
+++ b/src/components/LoadingSkeletons/TableLoadingSkeleton.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import TableLoadingSkeleton, { TableSkeleton } from './TableLoadingSkeleton';
 
-describe('', () => {
+describe('TableLoadingSkeleton', () => {
 	it('should render TableLoadingSkeleton', () => {
 		const standardSkeletonProps = {
 			width: 100,

--- a/src/components/LoadingSkeletons/TableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/TableLoadingSkeleton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { lucidClassNames } from '../../util/style-helpers';
 import LoadingMessage from '../LoadingMessage/LoadingMessage';
 
@@ -44,8 +44,8 @@ export const TableRowGroup = (props: ITableRow): React.ReactElement => {
 	);
 };
 
-export const TableSkeleton: FunctionComponent<IStandardSkeleton> = props => {
-	const { width, height, className } = { ...props };
+export const TableSkeleton = (props: IStandardSkeleton): React.ReactElement => {
+	const { width = '100%', height = '100%', className } = { ...props };
 
 	return (
 		<div
@@ -59,21 +59,24 @@ export const TableSkeleton: FunctionComponent<IStandardSkeleton> = props => {
 				xmlns='http://www.w3.org/2000/svg'
 			>
 				<g
-					id='Details'
+					id='TableSkeleton-Details'
 					stroke='none'
 					strokeWidth='1'
 					fill='none'
 					fillRule='evenodd'
 				>
 					<g
-						id='Tab_Skeleton-DM'
+						id='TableSkeleton-Tab_Skeleton'
 						transform='translate(-31.000000, -3554.000000)'
 					>
 						<g
-							id='Lifetime-Failed'
+							id='TableSkeleton-Group-1'
 							transform='translate(30.000000, 3491.000000)'
 						>
-							<g id='Group-2' transform='translate(1.000000, 63.000000)'>
+							<g
+								id='TableSkeleton-Group-2'
+								transform='translate(1.000000, 63.000000)'
+							>
 								<TableRowGroup
 									transform='translate(0.000000, 31.000000)'
 									width={width}
@@ -151,7 +154,7 @@ export const TableSkeleton: FunctionComponent<IStandardSkeleton> = props => {
                   10 L140,20 L20,20 L20,10 L140,10 Z M350,10 L350,20 L230,20 L230,10 L350,10 Z M560,10 L560,20 L440,20 L440,
                   10 L560,10 Z M770,10 L770,20 L650,20 L650,10 L770,10 Z M980,10 L980,20 L860,20 L860,10 L980,10 Z M1190,10 L1190,
                   20 L1070,20 L1070,10 L1190,10 Z'
-									id='Combined-Shape'
+									id='TableSkeleton-Combined-Shape'
 								/>
 							</g>
 						</g>

--- a/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/1.basic.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { GroupLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return <GroupLoadingSkeleton isLoading={true} width={200} height={100} />;
+	},
+});

--- a/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/2.add-header.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { GroupLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<GroupLoadingSkeleton
+				isLoading={true}
+				width={200}
+				height={50}
+				header='Added Header'
+			/>
+		);
+	},
+});

--- a/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/3.two-rows-three-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/3.two-rows-three-columns.tsx
@@ -12,7 +12,6 @@ export default createClass({
 					height={50}
 					numRows={2}
 					numColumns={3}
-					header={'Rows And Columns'}
 				/>
 			</div>
 		);

--- a/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/3.two-rows-three-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/3.two-rows-three-columns.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { GroupLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<GroupLoadingSkeleton
+					isLoading={true}
+					width={200}
+					height={50}
+					numRows={2}
+					numColumns={3}
+					header={'Rows And Columns'}
+				/>
+			</div>
+		);
+	},
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ import ClockIcon from './components/Icon/ClockIcon/ClockIcon';
 import CodeIcon from './components/Icon/CodeIcon/CodeIcon';
 import Collapsible from './components/Collapsible/Collapsible';
 import ComplexTableLoadingSkeleton from './components/LoadingSkeletons/ComplexTableLoadingSkeleton';
+
 import ContextMenu from './components/ContextMenu/ContextMenu';
 import CloseIcon from './components/Icon/CloseIcon/CloseIcon';
 import CrownIcon from './components/Icon/CrownIcon/CrownIcon';
@@ -111,6 +112,7 @@ import FourSquaresIcon from './components/Icon/FourSquaresIcon/FourSquaresIcon';
 import GetMaximumIcon from './components/Icon/GetMaximumIcon/GetMaximumIcon';
 import GlobeIcon from './components/Icon/GlobeIcon/GlobeIcon';
 import Grid from './components/Grid/Grid';
+import GroupLoadingSkeleton from './components/LoadingSkeletons/GroupLoadingSkeleton';
 import HamburgerMenuIcon from './components/Icon/HamburgerMenuIcon/HamburgerMenuIcon';
 import HelpIcon from './components/Icon/HelpIcon/HelpIcon';
 import HideIcon from './components/Icon/HideIcon/HideIcon';
@@ -308,6 +310,7 @@ export {
 	GetMaximumIcon,
 	GlobeIcon,
 	Grid,
+	GroupLoadingSkeleton,
 	HamburgerMenuIcon,
 	HelpIcon,
 	HideIcon,


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed
 https://docspot.adnxs.net/projects/lucid/BWAP-704_Add_GroupLoadingSkeleton_to_Lucid

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
