### PR TITLE
BWAP-709 Added SimpleTableSkeleton

### DIFF
--- a/docs/load-components.js
+++ b/docs/load-components.js
@@ -317,6 +317,23 @@ module.exports = [
 	},
 
 	{
+		name: 'SimpleTableLoadingSkeleton',
+		component: getDefaultExport(
+			require('../src/components/LoadingSkeletons/SimpleTableLoadingSkeleton')
+		),
+		examplesContext: require.context(
+			'../src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+	},
+
+	{
 		name: 'ContextMenu',
 		component: getDefaultExport(
 			require('../src/components/ContextMenu/ContextMenu')

--- a/src/components/LoadingSkeletons/SimpleTableLoadingSkeleton.spec.tsx
+++ b/src/components/LoadingSkeletons/SimpleTableLoadingSkeleton.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SimpleTableLoadingSkeleton, {
+	SimpleTableSkeleton,
+} from './SimpleTableLoadingSkeleton';
+import { ILoadingSkeletonProps, IStandardSkeleton } from './LoadingSkeleton';
+
+describe('SimpleTableLoadingSkeleton', () => {
+	it('should render SimpleTableLoadingSkeleton', () => {
+		const standardSkeletonProps: IStandardSkeleton = {
+			width: 100,
+			height: 100,
+			className: 'className',
+		};
+
+		const props: ILoadingSkeletonProps = {
+			...standardSkeletonProps,
+			isLoading: false,
+			children: {},
+			style: {},
+			isPanel: false,
+			hasOverlay: false,
+			numRows: 1,
+			numColumns: 1,
+			Skeleton: undefined,
+		};
+
+		const testProps = { ...props };
+		let component = shallow(<SimpleTableLoadingSkeleton {...testProps} />);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SimpleTableLoadingSkeleton"]')
+				.exists()
+		).toEqual(true);
+
+		component = shallow(<SimpleTableSkeleton {...standardSkeletonProps} />);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SimpleTableSkeleton"]')
+				.exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SimpleTableSkeleton-svg"]')
+				.exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SimpleTableSkeleton-svg"]')
+				.prop('width')
+		).toEqual(testProps.width);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SimpleTableSkeleton-svg"]')
+				.prop('height')
+		).toEqual(testProps.height);
+	});
+});

--- a/src/components/LoadingSkeletons/SimpleTableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/SimpleTableLoadingSkeleton.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import LoadingMessage from '../LoadingMessage/LoadingMessage';
+
+import {
+	cxBackgroundGray,
+	cxBackgroundNeutral,
+	SimpleTableSvgPath,
+} from './LoadingSkeletonsSvgUtil';
+import LoadingSkeleton, {
+	ILoadingSkeletonProps,
+	IStandardSkeleton,
+} from './LoadingSkeleton';
+
+export const SimpleTableSkeleton = (
+	props: IStandardSkeleton
+): React.ReactElement => {
+	const { width = '100%', height = '100%', className } = props;
+
+	return (
+		<div data-test-id='loadingSkeleton-SimpleTableSkeleton'>
+			<svg
+				data-test-id='loadingSkeleton-SimpleTableSkeleton-svg'
+				width={width}
+				height={height}
+				xmlns='http://www.w3.org/2000/svg'
+			>
+				<g fill='none' fillRule='evenodd'>
+					<path
+						className={cxBackgroundNeutral('&', className)}
+						d='M0 0h2642v50H0z'
+					/>
+					<path
+						className={cxBackgroundGray('&', className)}
+						d='M0 49h2642v1H0z'
+					/>
+					<path
+						className={cxBackgroundGray('&', className)}
+						d={SimpleTableSvgPath}
+					/>
+				</g>
+			</svg>
+		</div>
+	);
+};
+
+const SimpleTableLoadingSkeleton = (
+	props: ILoadingSkeletonProps
+): React.ReactElement => {
+	return (
+		<LoadingSkeleton
+			data-test-id='loadingSkeleton-SimpleTableLoadingSkeleton'
+			Skeleton={SimpleTableSkeleton}
+			{...props}
+		/>
+	);
+};
+
+SimpleTableLoadingSkeleton.LoadingMessage = LoadingMessage;
+
+SimpleTableLoadingSkeleton.displayName = 'SimpleTableLoadingSkeleton';
+SimpleTableLoadingSkeleton.peek = {
+	description: `
+		A loading indicator wrapper with optional overlay.
+	`,
+	notes: {
+		overview: `
+			A visual indication that a section or component of the interface is loading. Designed to indicate loading data
+		`,
+		intendedUse: `
+			- Use in places where data takes time to load. SimpleTableLoadingSkeleton lets users know that the information they expect to see will appear shortly.		
+		`,
+		technicalRecommendations: `
+			If a page is displaying a lot of data coming from multiple sources, try as best as possible to load the 
+			individual parts of the UI, so as not to disrupt the user and block them from interacting with the entire page until all data is loaded.
+		`,
+	},
+	categories: ['Loading Indicator'],
+	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
+};
+
+export default SimpleTableLoadingSkeleton;

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/1.basic.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SimpleTableLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return <SimpleTableLoadingSkeleton isLoading={true} />;
+	},
+});

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/1.basic.tsx
@@ -4,6 +4,6 @@ import { SimpleTableLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return <SimpleTableLoadingSkeleton isLoading={true} />;
+		return <SimpleTableLoadingSkeleton isLoading={true} height={50} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/2.add-header.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SimpleTableLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<SimpleTableLoadingSkeleton
+				isLoading={true}
+				height={100}
+				header='Custom Header'
+			/>
+		);
+	},
+});

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/2.add-header.tsx
@@ -7,7 +7,7 @@ export default createClass({
 		return (
 			<SimpleTableLoadingSkeleton
 				isLoading={true}
-				height={100}
+				height={50}
 				header='Custom Header'
 			/>
 		);

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/3.three-rows-one-column.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/3.three-rows-one-column.tsx
@@ -6,7 +6,7 @@ export default createClass({
 	render() {
 		return (
 			<div>
-				<SimpleTableLoadingSkeleton isLoading={true} numRows={3} />
+				<SimpleTableLoadingSkeleton isLoading={true} height={50} numRows={3} />
 			</div>
 		);
 	},

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/3.three-rows-one-column.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/3.three-rows-one-column.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SimpleTableLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<SimpleTableLoadingSkeleton isLoading={true} numRows={3} />
+			</div>
+		);
+	},
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,7 @@ import SettingsIcon from './components/Icon/SettingsIcon/SettingsIcon';
 import ShareIcon from './components/Icon/ShareIcon/ShareIcon';
 import ShoppingCartIcon from './components/Icon/ShoppingCartIcon/ShoppingCartIcon';
 import SidePanel from './components/SidePanel/SidePanel';
+import SimpleTableLoadingSkeleton from './components/LoadingSkeletons/SimpleTableLoadingSkeleton';
 import SplitHorizontal from './components/SplitHorizontal/SplitHorizontal';
 import SplitVertical from './components/SplitVertical/SplitVertical';
 import StarIcon from './components/Icon/StarIcon/StarIcon';
@@ -388,6 +389,7 @@ export {
 	SingleSelectDumb,
 	SplitButton,
 	SplitButtonDumb,
+	SimpleTableLoadingSkeleton,
 	SplitHorizontal,
 	SplitVertical,
 	StarIcon,


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BWAP-709_Add_SimpleTableLoadingSkeleton_to_Lucid
)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
