### PR TITLE
BWAP-718 Added SingleLineSkeleton

### DIFF
--- a/docs/load-components.js
+++ b/docs/load-components.js
@@ -142,6 +142,23 @@ module.exports = [
 	},
 
 	{
+		name: 'SingleLineLoadingSkeleton',
+		component: getDefaultExport(
+			require('../src/components/LoadingSkeletons/SingleLineLoadingSkeleton')
+		),
+		examplesContext: require.context(
+			'../src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+	},
+
+	{
 		name: 'Bars',
 		component: getDefaultExport(require('../src/components/Bars/Bars')),
 		examplesContext: require.context(

--- a/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.spec.tsx
+++ b/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SingleLineLoadingSkeleton, {
+	SingleLineSkeleton,
+} from './SingleLineLoadingSkeleton';
+import { ILoadingSkeletonProps, IStandardSkeleton } from './LoadingSkeleton';
+
+describe('', () => {
+	it('should render SingleLineLoadingSkeleton', () => {
+		const standardSkeletonProps: IStandardSkeleton = {
+			width: 100,
+			height: 100,
+
+			className: 'className',
+		};
+
+		const props: ILoadingSkeletonProps = {
+			...standardSkeletonProps,
+			isLoading: false,
+			children: {},
+			style: {},
+			isPanel: false,
+			hasOverlay: false,
+			numRows: 1,
+			numColumns: 1,
+			Skeleton: undefined,
+		};
+
+		const testProps = { ...props };
+		let component = shallow(<SingleLineLoadingSkeleton {...testProps} />);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SingleLineLoadingSkeleton"]')
+				.exists()
+		).toEqual(true);
+
+		component = shallow(<SingleLineSkeleton {...standardSkeletonProps} />);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SingleLineSkeleton"]')
+				.exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SingleLineSkeleton-svg"]')
+				.exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SingleLineSkeleton-svg"]')
+				.prop('width')
+		).toEqual(testProps.width);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SingleLineSkeleton-svg"]')
+				.prop('height')
+		).toEqual(testProps.height);
+	});
+});

--- a/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import LoadingMessage from '../LoadingMessage/LoadingMessage';
+import LoadingSkeleton, {
+	ILoadingSkeletonProps,
+	IStandardSkeleton,
+} from './LoadingSkeleton';
+import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
+
+export const SingleLineSkeleton = (
+	props: IStandardSkeleton
+): React.ReactElement => {
+	const { width = '100%', height = '100%', className } = props;
+
+	return (
+		<div data-test-id='loadingSkeleton-SingleLineSkeleton'>
+			<svg
+				data-test-id='loadingSkeleton-SingleLineSkeleton-svg'
+				width={width}
+				height={height}
+				xmlns='http://www.w3.org/2000/svg'
+			>
+				<g
+					id='SingleLineSkeleton-Details'
+					stroke='none'
+					strokeWidth='1'
+					fill='none'
+					fillRule='evenodd'
+				>
+					<g id='SingleLineSkeleton-Group'>
+						<g
+							className={cxBackgroundGray('&', className)}
+							id='SingleLineSkeleton-Group-1'
+						>
+							<rect
+								id='SingleLineSkeleton-Rectangle'
+								x='0'
+								y='0'
+								width={width}
+								height={height}
+							/>
+						</g>
+					</g>
+				</g>
+			</svg>
+		</div>
+	);
+};
+
+const SingleLineLoadingSkeleton = (
+	props: ILoadingSkeletonProps
+): React.ReactElement => {
+	return (
+		<LoadingSkeleton
+			data-test-id='loadingSkeleton-SingleLineLoadingSkeleton'
+			Skeleton={SingleLineSkeleton}
+			{...props}
+		/>
+	);
+};
+
+SingleLineLoadingSkeleton.LoadingMessage = LoadingMessage;
+
+SingleLineLoadingSkeleton.displayName = 'SingleLineLoadingSkeleton';
+SingleLineLoadingSkeleton.peek = {
+	description: `
+		A loading indicator wrapper with optional overlay.
+	`,
+	notes: {
+		overview: `
+			A visual indication that a section or component of the interface is loading. Designed to indicate loading data
+		`,
+		intendedUse: `
+			- Use in places where data takes time to load. SingleLineLoadingSkeleton lets users know that the information they expect to see will appear shortly.		
+		`,
+		technicalRecommendations: `
+			If a page is displaying a lot of data coming from multiple sources, try as best as possible to load the 
+			individual parts of the UI, so as not to disrupt the user and block them from interacting with the entire page until all data is loaded.
+		`,
+	},
+	categories: ['Loading Indicator'],
+	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
+};
+
+export default SingleLineLoadingSkeleton;

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/1.basic.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SingleLineLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return <SingleLineLoadingSkeleton isLoading={true} height={30} />;
+	},
+});

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SingleLineLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<SingleLineLoadingSkeleton
+				isLoading={true}
+				height={30}
+				header='Custom Header'
+			/>
+		);
+	},
+});

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/3.two-rows-three-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/3.two-rows-three-columns.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SingleLineLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<SingleLineLoadingSkeleton
+					isLoading={true}
+					width={250}
+					height={30}
+					numRows={2}
+					numColumns={3}
+					marginRight={20}
+					marginBottom={10}
+				/>
+			</div>
+		);
+	},
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import Autocomplete, {
 import ButtonGroup, {
 	ButtonGroupDumb,
 } from './components/ButtonGroup/ButtonGroup';
+import SingleLineLoadingSkeleton from './components/LoadingSkeletons/SingleLineLoadingSkeleton';
 import SearchableSelect, {
 	SearchableSelectDumb,
 } from './components/SearchableSelect/SearchableSelect';
@@ -384,6 +385,7 @@ export {
 	SidePanel,
 	Sidebar,
 	SidebarDumb,
+	SingleLineLoadingSkeleton,
 	SingleSelect,
 	SingleSelectDumb,
 	SplitButton,


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BWAP-718_Add_SingleLineLoadingSkeleton_to_Lucid)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
