### PR TITLE
BWAP-711 Added SmallDataTableLoadingSkeleton

### DIFF
--- a/docs/load-components.js
+++ b/docs/load-components.js
@@ -159,6 +159,23 @@ module.exports = [
 	},
 
 	{
+		name: 'SmallDataTableLoadingSkeleton',
+		component: getDefaultExport(
+			require('../src/components/LoadingSkeletons/SmallDataTableLoadingSkeleton')
+		),
+		examplesContext: require.context(
+			'../src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton',
+			true,
+			/\.(j|t)sx?$/
+		),
+	},
+
+	{
 		name: 'Bars',
 		component: getDefaultExport(require('../src/components/Bars/Bars')),
 		examplesContext: require.context(

--- a/src/components/LoadingSkeletons/SmallDataTableLoadingSkeleton.spec.tsx
+++ b/src/components/LoadingSkeletons/SmallDataTableLoadingSkeleton.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import SmallDataTableLoadingSkeleton, {
+	SmallDataTableSkeleton,
+} from './SmallDataTableLoadingSkeleton';
+import { ILoadingSkeletonProps, IStandardSkeleton } from './LoadingSkeleton';
+
+describe('', () => {
+	it('should render SmallDataTableLoadingSkeleton', () => {
+		const standardSkeletonProps: IStandardSkeleton = {
+			width: 100,
+			height: 100,
+			className: 'className',
+		};
+
+		const props: ILoadingSkeletonProps = {
+			...standardSkeletonProps,
+			isLoading: false,
+			children: {},
+			style: {},
+			isPanel: false,
+			hasOverlay: false,
+			numRows: 1,
+			numColumns: 1,
+			Skeleton: undefined,
+		};
+
+		const testProps = { ...props };
+		let component = shallow(<SmallDataTableLoadingSkeleton {...testProps} />);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SmallDataTableLoadingSkeleton"]')
+				.exists()
+		).toEqual(true);
+
+		component = shallow(<SmallDataTableSkeleton {...standardSkeletonProps} />);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SmallDataTableSkeleton"]')
+				.exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SmallDataTableSkeleton-svg"]')
+				.exists()
+		).toEqual(true);
+
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SmallDataTableSkeleton-svg"]')
+				.prop('width')
+		).toEqual(testProps.width);
+		expect(
+			component
+				.find('[data-test-id="loadingSkeleton-SmallDataTableSkeleton-svg"]')
+				.prop('height')
+		).toEqual(testProps.height);
+	});
+});

--- a/src/components/LoadingSkeletons/SmallDataTableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/SmallDataTableLoadingSkeleton.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import LoadingMessage from '../LoadingMessage/LoadingMessage';
+import LoadingSkeleton, {
+	ILoadingSkeletonProps,
+	IStandardSkeleton,
+} from './LoadingSkeleton';
+
+import {
+	cxBackgroundGray,
+	cxBackgroundNeutral,
+} from './LoadingSkeletonsSvgUtil';
+
+export const SmallDataTableSkeleton = (
+	props: IStandardSkeleton
+): React.ReactElement => {
+	const { width = '100%', height = '100%', className } = props;
+
+	return (
+		<div data-test-id='loadingSkeleton-SmallDataTableSkeleton'>
+			<svg
+				data-test-id='loadingSkeleton-SmallDataTableSkeleton-svg'
+				width={width}
+				height={height}
+				version='1.1'
+				xmlns='http://www.w3.org/2000/svg'
+			>
+				<g
+					id='SmallDataTableSkeleton-Details'
+					stroke='none'
+					strokeWidth='1'
+					fill='none'
+					fillRule='evenodd'
+				>
+					<g
+						id='SmallDataTableSkeleton-Group-1'
+						transform='translate(-598.000000, -2418.000000)'
+					>
+						<g
+							id='SmallDataTableSkeleton-Group-2'
+							transform='translate(30.000000, 2241.000000)'
+						>
+							<g
+								id='SmallDataTableSkeleton-Group-3'
+								transform='translate(568.000000, 177.000000)'
+							>
+								<g
+									id='Table-Row-/-Default'
+									transform='translate(0.000000, 30.000000)'
+								>
+									<rect
+										className={cxBackgroundNeutral('&', className)}
+										id='SmallDataTableSkeleton-BG'
+										x='0'
+										y='0'
+										width='565'
+										height='32'
+									/>
+									<rect
+										className={cxBackgroundGray('&', className)}
+										id='SmallDataTableSkeleton-Bottom-Line'
+										x='0'
+										y='31'
+										width='565'
+										height='1'
+									/>
+								</g>
+								<g
+									id='SmallDataTableSkeleton-Table-Row-/-Default'
+									transform='translate(0.000000, 62.000000)'
+								>
+									<rect
+										className={cxBackgroundNeutral('&', className)}
+										id='SmallDataTableSkeleton-BG'
+										x='0'
+										y='0'
+										width='565'
+										height='32'
+									/>
+									<rect
+										className={cxBackgroundGray('&', className)}
+										id='SmallDataTableSkeleton-Bottom-Line'
+										x='0'
+										y='31'
+										width='565'
+										height='1'
+									/>
+								</g>
+								<g
+									id='SmallDataTableSkeleton-Table-Row-/-Default'
+									transform='translate(0.000000, 94.000000)'
+								>
+									<rect
+										className={cxBackgroundNeutral('&', className)}
+										id='SmallDataTableSkeleton-BG'
+										x='0'
+										y='0'
+										width='565'
+										height='32'
+									/>
+									<rect
+										className={cxBackgroundGray('&', className)}
+										id='SmallDataTableSkeleton-Bottom-Line'
+										x='0'
+										y='31'
+										width='565'
+										height='1'
+									/>
+								</g>
+								<g id='Table-Row-/-Header-White'>
+									<rect
+										className={cxBackgroundNeutral('&', className)}
+										id='SmallDataTableSkeleton-BG'
+										x='0'
+										y='0'
+										width='565'
+										height='30'
+									/>
+									<rect
+										className={cxBackgroundGray('&', className)}
+										id='SmallDataTableSkeleton-Bottom-Line'
+										x='0'
+										y='29'
+										width='565'
+										height='1'
+									/>
+								</g>
+								<path
+									className={cxBackgroundGray('&', className)}
+									d='M111,104 L111,114 L11,114 L11,104 L111,104 Z M289,104 L289,114 L189,114 L189,104 L289,104 Z M477,
+                  104 L477,114 L377,114 L377,104 L477,104 Z M131,72 L131,82 L11,82 L11,72 L131,72 Z M309,72 L309,82 L189,
+                  82 L189,72 L309,72 Z M497,72 L497,82 L377,82 L377,72 L497,72 Z M111,40 L111,50 L11,50 L11,40 L111,40 Z M289,
+                  40 L289,50 L189,50 L189,40 L289,40 Z M477,40 L477,50 L377,50 L377,40 L477,40 Z M131,10 L131,20 L11,
+                  20 L11,10 L131,10 Z M309,10 L309,20 L189,20 L189,10 L309,10 Z M497,10 L497,20 L377,20 L377,10 L497,10 Z'
+									id='SmallDataTableSkeleton-Combined-Shape'
+								/>
+							</g>
+						</g>
+					</g>
+				</g>
+			</svg>
+		</div>
+	);
+};
+
+const SmallDataTableLoadingSkeleton = (
+	props: ILoadingSkeletonProps
+): React.ReactElement => {
+	return (
+		<LoadingSkeleton
+			data-test-id='loadingSkeleton-SmallDataTableLoadingSkeleton'
+			Skeleton={SmallDataTableSkeleton}
+			{...props}
+		/>
+	);
+};
+
+SmallDataTableLoadingSkeleton.LoadingMessage = LoadingMessage;
+
+SmallDataTableLoadingSkeleton.displayName = 'SmallDataTableLoadingSkeleton';
+SmallDataTableLoadingSkeleton.peek = {
+	description: `
+		A loading indicator wrapper with optional overlay.
+	`,
+	notes: {
+		overview: `
+			A visual indication that a section or component of the interface is loading. Designed to indicate loading data
+		`,
+		intendedUse: `
+			- Use in places where data takes time to load. SmallDataTableLoadingSkeleton lets users know that the information they expect to see will appear shortly.		
+		`,
+		technicalRecommendations: `
+			If a page is displaying a lot of data coming from multiple sources, try as best as possible to load the 
+			individual parts of the UI, so as not to disrupt the user and block them from interacting with the entire page until all data is loaded.
+		`,
+	},
+	categories: ['Loading Indicator'],
+	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
+};
+
+export default SmallDataTableLoadingSkeleton;

--- a/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/1.basic.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SmallDataTableLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return <SmallDataTableLoadingSkeleton isLoading={true} height={100} />;
+	},
+});

--- a/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/2.add-header.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SmallDataTableLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<SmallDataTableLoadingSkeleton
+				isLoading={true}
+				height={100}
+				header='Added Header'
+			/>
+		);
+	},
+});

--- a/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/3.two-rows-two-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/3.two-rows-two-columns.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { SmallDataTableLoadingSkeleton } from '../../../../index';
+
+export default createClass({
+	render() {
+		return (
+			<div>
+				<SmallDataTableLoadingSkeleton
+					isLoading={true}
+					width={300}
+					height={100}
+					numRows={2}
+					numColumns={2}
+					marginRight={100}
+					marginBottom={30}
+				/>
+			</div>
+		);
+	},
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ import ShareIcon from './components/Icon/ShareIcon/ShareIcon';
 import ShoppingCartIcon from './components/Icon/ShoppingCartIcon/ShoppingCartIcon';
 import SidePanel from './components/SidePanel/SidePanel';
 import SimpleTableLoadingSkeleton from './components/LoadingSkeletons/SimpleTableLoadingSkeleton';
+import SmallDataTableLoadingSkeleton from './components/LoadingSkeletons/SmallDataTableLoadingSkeleton';
 import SplitHorizontal from './components/SplitHorizontal/SplitHorizontal';
 import SplitVertical from './components/SplitVertical/SplitVertical';
 import StarIcon from './components/Icon/StarIcon/StarIcon';
@@ -396,6 +397,7 @@ export {
 	SplitButton,
 	SplitButtonDumb,
 	SimpleTableLoadingSkeleton,
+	SmallDataTableLoadingSkeleton,
 	SplitHorizontal,
 	SplitVertical,
 	StarIcon,


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BWAP-711_RebuildPR_Add_SmallDataTableLoadingSkeleton_to_Lucid)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
