### PR TITLE
Bwap 719 address common skeleton issues

### DIFF
--- a/src/components/LoadingSkeletons/BarChartLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/BarChartLoadingSkeleton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
 import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
@@ -9,7 +8,7 @@ import LoadingSkeleton, {
 export const BarChartSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 880, height = 350, className } = props;
 
 	return (
 		<div
@@ -76,8 +75,6 @@ export const BarChartLoadingSkeleton = (
 	);
 };
 
-BarChartLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 BarChartLoadingSkeleton.displayName = 'BarChartLoadingSkeleton';
 BarChartLoadingSkeleton.peek = {
 	description: `
@@ -95,7 +92,6 @@ BarChartLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default BarChartLoadingSkeleton;

--- a/src/components/LoadingSkeletons/CardLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/CardLoadingSkeleton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
 import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
@@ -9,7 +8,7 @@ import LoadingSkeleton, {
 export const CardSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement<IStandardSkeleton> => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 130, height = 30, className } = props;
 
 	return (
 		<div
@@ -57,8 +56,6 @@ const CardLoadingSkeleton = (
 	);
 };
 
-CardLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 CardLoadingSkeleton.displayName = 'CardLoadingSkeleton';
 CardLoadingSkeleton.peek = {
 	description: `
@@ -77,7 +74,6 @@ CardLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default CardLoadingSkeleton;

--- a/src/components/LoadingSkeletons/ComplexTableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/ComplexTableLoadingSkeleton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
 	IStandardSkeleton,
@@ -13,7 +12,7 @@ import {
 export const ComplexTableSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement<IStandardSkeleton> => {
-	const { width, height, className } = { ...props };
+	const { width = 860, height = 80, className } = props;
 
 	return (
 		<div data-test-id='loadingSkeleton-ComplexTableSkeleton'>
@@ -54,8 +53,6 @@ const ComplexTableLoadingSkeleton = (
 	);
 };
 
-ComplexTableLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 ComplexTableLoadingSkeleton.displayName = 'ComplexTableLoadingSkeleton';
 ComplexTableLoadingSkeleton.peek = {
 	description: `
@@ -74,7 +71,6 @@ ComplexTableLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default ComplexTableLoadingSkeleton;

--- a/src/components/LoadingSkeletons/ComplexTableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/ComplexTableLoadingSkeleton.tsx
@@ -12,7 +12,7 @@ import {
 export const ComplexTableSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement<IStandardSkeleton> => {
-	const { width = 860, height = 80, className } = props;
+	const { width = 860, height = 92, className } = props;
 
 	return (
 		<div data-test-id='loadingSkeleton-ComplexTableSkeleton'>

--- a/src/components/LoadingSkeletons/GroupLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/GroupLoadingSkeleton.tsx
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
 import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
@@ -8,7 +7,7 @@ import LoadingSkeleton, {
 } from './LoadingSkeleton';
 
 export const GroupSkeleton = (props: IStandardSkeleton): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 300, height = 55, className } = props;
 
 	const bottomRectWidth = _.toNumber(width) - _.toNumber(width) / 3;
 	return (
@@ -69,8 +68,6 @@ const GroupLoadingSkeleton = (
 	);
 };
 
-GroupLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 GroupLoadingSkeleton.displayName = 'GroupLoadingSkeleton';
 GroupLoadingSkeleton.peek = {
 	description: `
@@ -89,7 +86,6 @@ GroupLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default GroupLoadingSkeleton;

--- a/src/components/LoadingSkeletons/HeaderLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/HeaderLoadingSkeleton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
 import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
@@ -9,7 +8,7 @@ import LoadingSkeleton, {
 export const HeaderSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 580, height = 70, className } = props;
 	return (
 		<div data-test-id='loadingSkeleton-HeaderSkeleton'>
 			<svg
@@ -40,8 +39,6 @@ export const HeaderLoadingSkeleton = (
 	);
 };
 
-HeaderLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 HeaderLoadingSkeleton.displayName = 'HeaderLoadingSkeleton';
 HeaderLoadingSkeleton.peek = {
 	description: `
@@ -60,7 +57,6 @@ HeaderLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default HeaderLoadingSkeleton;

--- a/src/components/LoadingSkeletons/LineChartLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/LineChartLoadingSkeleton.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent } from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
+import React from 'react';
+
 import {
 	cxBackgroundGray,
 	cxBackgroundGrayStrokeNeutralFill,
@@ -12,7 +12,7 @@ import LoadingSkeleton, {
 export const LineChartSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement<IStandardSkeleton> => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 900, height = 310, className } = props;
 
 	return (
 		<div data-test-id='loadingSkeleton-LineChartSkeleton'>
@@ -83,8 +83,6 @@ const LineChartLoadingSkeleton = (
 	);
 };
 
-LineChartLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 LineChartLoadingSkeleton.displayName = 'LineChartLoadingSkeleton';
 LineChartLoadingSkeleton.peek = {
 	description: `
@@ -103,7 +101,6 @@ LineChartLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default LineChartLoadingSkeleton;

--- a/src/components/LoadingSkeletons/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/LoadingSkeleton.tsx
@@ -47,7 +47,9 @@ const animationStyle = lucidClassNames.bind(
 	'&-LoadingSkeleton-animatedSkeleton'
 );
 
-export const LoadingSkeleton: FunctionComponent<ILoadingSkeletonProps> = props => {
+export const LoadingSkeleton: FunctionComponent<ILoadingSkeletonProps> = (
+	props
+) => {
 	const {
 		Skeleton,
 		isLoading,
@@ -55,8 +57,8 @@ export const LoadingSkeleton: FunctionComponent<ILoadingSkeletonProps> = props =
 		className,
 		header,
 		style,
-		width = '100%',
-		height = '100%',
+		width = undefined,
+		height = undefined,
 		isPanel = false,
 		hasOverlay = false,
 		overlayKind = 'light',
@@ -93,13 +95,11 @@ export const LoadingSkeleton: FunctionComponent<ILoadingSkeletonProps> = props =
 		<Skeleton data-test-id='loadingSkeleton_Skeleton' {...skeletonProps} />
 	);
 
-	const matrix = _.times(numColumns, column => (
+	const matrix = _.times(numColumns, (column) => (
 		<div
 			key={`column${column}`}
 			style={{
 				display: 'inline-block',
-				width: width,
-				height: height,
 				marginRight: marginRight,
 				marginLeft: marginLeft,
 			}}
@@ -108,11 +108,9 @@ export const LoadingSkeleton: FunctionComponent<ILoadingSkeletonProps> = props =
 			<div
 				style={{
 					display: 'inline-block',
-					width: width,
-					height: height,
 				}}
 			>
-				{_.times(numRows, row => (
+				{_.times(numRows, (row) => (
 					<div
 						className={animationStyle('&', className)}
 						data-test-id='loadingSkeleton-ReactPlaceholder'

--- a/src/components/LoadingSkeletons/SimpleTableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/SimpleTableLoadingSkeleton.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
-
 import {
 	cxBackgroundGray,
 	cxBackgroundNeutral,
@@ -14,7 +12,7 @@ import LoadingSkeleton, {
 export const SimpleTableSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 880, height = 50, className } = props;
 
 	return (
 		<div data-test-id='loadingSkeleton-SimpleTableSkeleton'>
@@ -55,8 +53,6 @@ const SimpleTableLoadingSkeleton = (
 	);
 };
 
-SimpleTableLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 SimpleTableLoadingSkeleton.displayName = 'SimpleTableLoadingSkeleton';
 SimpleTableLoadingSkeleton.peek = {
 	description: `
@@ -75,7 +71,6 @@ SimpleTableLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default SimpleTableLoadingSkeleton;

--- a/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.tsx
@@ -8,7 +8,7 @@ import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
 export const SingleLineSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement => {
-	const { width = 800, height = 30, className } = props;
+	const { width = 800, height = 20, className } = props;
 
 	return (
 		<div data-test-id='loadingSkeleton-SingleLineSkeleton'>

--- a/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/SingleLineLoadingSkeleton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
 	IStandardSkeleton,
@@ -9,7 +8,7 @@ import { cxBackgroundGray } from './LoadingSkeletonsSvgUtil';
 export const SingleLineSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 800, height = 30, className } = props;
 
 	return (
 		<div data-test-id='loadingSkeleton-SingleLineSkeleton'>
@@ -58,8 +57,6 @@ const SingleLineLoadingSkeleton = (
 	);
 };
 
-SingleLineLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 SingleLineLoadingSkeleton.displayName = 'SingleLineLoadingSkeleton';
 SingleLineLoadingSkeleton.peek = {
 	description: `
@@ -78,7 +75,6 @@ SingleLineLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default SingleLineLoadingSkeleton;

--- a/src/components/LoadingSkeletons/SmallDataTableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/SmallDataTableLoadingSkeleton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
 	IStandardSkeleton,
@@ -13,7 +12,7 @@ import {
 export const SmallDataTableSkeleton = (
 	props: IStandardSkeleton
 ): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = props;
+	const { width = 565, height = 130, className } = props;
 
 	return (
 		<div data-test-id='loadingSkeleton-SmallDataTableSkeleton'>
@@ -154,8 +153,6 @@ const SmallDataTableLoadingSkeleton = (
 	);
 };
 
-SmallDataTableLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 SmallDataTableLoadingSkeleton.displayName = 'SmallDataTableLoadingSkeleton';
 SmallDataTableLoadingSkeleton.peek = {
 	description: `
@@ -174,7 +171,6 @@ SmallDataTableLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default SmallDataTableLoadingSkeleton;

--- a/src/components/LoadingSkeletons/TableLoadingSkeleton.tsx
+++ b/src/components/LoadingSkeletons/TableLoadingSkeleton.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { lucidClassNames } from '../../util/style-helpers';
-import LoadingMessage from '../LoadingMessage/LoadingMessage';
-
 import LoadingSkeleton, {
 	ILoadingSkeletonProps,
 	IStandardSkeleton,
@@ -20,7 +18,7 @@ const backgroundNeutral = lucidClassNames.bind(
 );
 
 export const TableRowGroup = (props: ITableRow): React.ReactElement => {
-	const { id, transform, width } = { ...props };
+	const { id, transform, width = '100%' } = props;
 
 	return (
 		<g id={id} transform={transform}>
@@ -45,7 +43,7 @@ export const TableRowGroup = (props: ITableRow): React.ReactElement => {
 };
 
 export const TableSkeleton = (props: IStandardSkeleton): React.ReactElement => {
-	const { width = '100%', height = '100%', className } = { ...props };
+	const { width = 800, height = 320, className } = props;
 
 	return (
 		<div
@@ -177,8 +175,6 @@ export const TableLoadingSkeleton = (
 	);
 };
 
-TableLoadingSkeleton.LoadingMessage = LoadingMessage;
-
 TableLoadingSkeleton.displayName = 'TableLoadingSkeleton';
 TableLoadingSkeleton.peek = {
 	description: `
@@ -196,7 +192,6 @@ TableLoadingSkeleton.peek = {
 		`,
 	},
 	categories: ['Loading Indicator'],
-	madeFrom: ['OverlayWrapper', 'LoadingMessage'],
 };
 
 export default TableLoadingSkeleton;

--- a/src/components/LoadingSkeletons/examples/BarChartLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/BarChartLoadingSkeleton/1.basic.tsx
@@ -4,8 +4,6 @@ import { BarChartLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return (
-			<BarChartLoadingSkeleton isLoading={true} width={840} height={200} />
-		);
+		return <BarChartLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/BarChartLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/BarChartLoadingSkeleton/2.add-header.tsx
@@ -8,7 +8,6 @@ export default createClass({
 			<BarChartLoadingSkeleton
 				isLoading={true}
 				width={880}
-				height={300}
 				header='BarChartLoadingSkeleton added header'
 			/>
 		);

--- a/src/components/LoadingSkeletons/examples/CardLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/CardLoadingSkeleton/1.basic.tsx
@@ -4,6 +4,6 @@ import { CardLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return <CardLoadingSkeleton isLoading={true} height={30} />;
+		return <CardLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/CardLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/CardLoadingSkeleton/2.add-header.tsx
@@ -4,13 +4,6 @@ import { CardLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return (
-			<CardLoadingSkeleton
-				isLoading={true}
-				width={200}
-				height={50}
-				header='Added Header'
-			/>
-		);
+		return <CardLoadingSkeleton isLoading={true} header='Added Header' />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/ComplexTableLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/ComplexTableLoadingSkeleton/1.basic.tsx
@@ -4,8 +4,6 @@ import { ComplexTableLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return (
-			<ComplexTableLoadingSkeleton isLoading={true} width={800} height={200} />
-		);
+		return <ComplexTableLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/ComplexTableLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/ComplexTableLoadingSkeleton/2.add-header.tsx
@@ -5,12 +5,7 @@ import { ComplexTableLoadingSkeleton } from '../../../../index';
 export default createClass({
 	render() {
 		return (
-			<ComplexTableLoadingSkeleton
-				isLoading={true}
-				width={800}
-				height={200}
-				header='Added Header'
-			/>
+			<ComplexTableLoadingSkeleton isLoading={true} header='Added Header' />
 		);
 	},
 });

--- a/src/components/LoadingSkeletons/examples/ComplexTableLoadingSkeleton/3.three-rows-one-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/ComplexTableLoadingSkeleton/3.three-rows-one-columns.tsx
@@ -6,12 +6,7 @@ export default createClass({
 	render() {
 		return (
 			<div>
-				<ComplexTableLoadingSkeleton
-					isLoading={true}
-					width={800}
-					height={100}
-					numRows={3}
-				/>
+				<ComplexTableLoadingSkeleton isLoading={true} width={860} numRows={3} />
 			</div>
 		);
 	},

--- a/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/1.basic.tsx
@@ -4,6 +4,6 @@ import { GroupLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return <GroupLoadingSkeleton isLoading={true} width={200} height={100} />;
+		return <GroupLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/2.add-header.tsx
@@ -4,13 +4,6 @@ import { GroupLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return (
-			<GroupLoadingSkeleton
-				isLoading={true}
-				width={200}
-				height={50}
-				header='Added Header'
-			/>
-		);
+		return <GroupLoadingSkeleton isLoading={true} header='Added Header' />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/3.two-rows-three-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/GroupLoadingSkeleton/3.two-rows-three-columns.tsx
@@ -8,10 +8,11 @@ export default createClass({
 			<div>
 				<GroupLoadingSkeleton
 					isLoading={true}
-					width={200}
-					height={50}
+					width={250}
 					numRows={2}
 					numColumns={3}
+					marginBottom={30}
+					marginRight={30}
 				/>
 			</div>
 		);

--- a/src/components/LoadingSkeletons/examples/LineChartLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/LineChartLoadingSkeleton/1.basic.tsx
@@ -4,8 +4,6 @@ import { LineChartLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return (
-			<LineChartLoadingSkeleton isLoading={true} width={1000} height={300} />
-		);
+		return <LineChartLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/LineChartLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/LineChartLoadingSkeleton/2.add-header.tsx
@@ -4,13 +4,6 @@ import { LineChartLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return (
-			<LineChartLoadingSkeleton
-				isLoading={true}
-				width={1000}
-				height={300}
-				header='Added Header'
-			/>
-		);
+		return <LineChartLoadingSkeleton isLoading={true} header='Added Header' />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/LineChartLoadingSkeleton/3.two-rows-two-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/LineChartLoadingSkeleton/3.two-rows-two-columns.tsx
@@ -9,7 +9,6 @@ export default createClass({
 				<LineChartLoadingSkeleton
 					isLoading={true}
 					width={400}
-					height={300}
 					numRows={2}
 					numColumns={2}
 					marginRight={50}

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/1.basic.tsx
@@ -4,6 +4,6 @@ import { SimpleTableLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return <SimpleTableLoadingSkeleton isLoading={true} height={50} />;
+		return <SimpleTableLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/2.add-header.tsx
@@ -8,7 +8,7 @@ export default createClass({
 			<SimpleTableLoadingSkeleton
 				isLoading={true}
 				height={50}
-				header='Custom Header'
+				header='Added Header'
 			/>
 		);
 	},

--- a/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/3.three-rows-one-column.tsx
+++ b/src/components/LoadingSkeletons/examples/SimpleTableLoadingSkeleton/3.three-rows-one-column.tsx
@@ -6,7 +6,7 @@ export default createClass({
 	render() {
 		return (
 			<div>
-				<SimpleTableLoadingSkeleton isLoading={true} height={50} numRows={3} />
+				<SimpleTableLoadingSkeleton isLoading={true} height={70} numRows={3} />
 			</div>
 		);
 	},

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/1.basic.tsx
@@ -4,6 +4,6 @@ import { SingleLineLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return <SingleLineLoadingSkeleton isLoading={true} height={30} />;
+		return <SingleLineLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
@@ -9,7 +9,7 @@ export default createClass({
 				isLoading={true}
 				width={700}
 				height={50}
-				header='Custom Header'
+				header='Added Header'
 			/>
 		);
 	},

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
@@ -7,7 +7,7 @@ export default createClass({
 		return (
 			<SingleLineLoadingSkeleton
 				isLoading={true}
-				height={30}
+				width={500}
 				header='Custom Header'
 			/>
 		);

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/2.add-header.tsx
@@ -7,7 +7,8 @@ export default createClass({
 		return (
 			<SingleLineLoadingSkeleton
 				isLoading={true}
-				width={500}
+				width={700}
+				height={50}
 				header='Custom Header'
 			/>
 		);

--- a/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/3.two-rows-three-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/SingleLineLoadingSkeleton/3.two-rows-three-columns.tsx
@@ -9,7 +9,7 @@ export default createClass({
 				<SingleLineLoadingSkeleton
 					isLoading={true}
 					width={250}
-					height={30}
+					height={20}
 					numRows={2}
 					numColumns={3}
 					marginRight={20}

--- a/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/1.basic.tsx
+++ b/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/1.basic.tsx
@@ -4,6 +4,6 @@ import { SmallDataTableLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return <SmallDataTableLoadingSkeleton isLoading={true} height={100} />;
+		return <SmallDataTableLoadingSkeleton isLoading={true} />;
 	},
 });

--- a/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/2.add-header.tsx
@@ -7,7 +7,7 @@ export default createClass({
 		return (
 			<SmallDataTableLoadingSkeleton
 				isLoading={true}
-				height={100}
+				width={700}
 				header='Added Header'
 			/>
 		);

--- a/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/3.two-rows-two-columns.tsx
+++ b/src/components/LoadingSkeletons/examples/SmallDataTableLoadingSkeleton/3.two-rows-two-columns.tsx
@@ -9,7 +9,6 @@ export default createClass({
 				<SmallDataTableLoadingSkeleton
 					isLoading={true}
 					width={300}
-					height={100}
 					numRows={2}
 					numColumns={2}
 					marginRight={100}

--- a/src/components/LoadingSkeletons/examples/TableLoadingSkeleton/2.add-header.tsx
+++ b/src/components/LoadingSkeletons/examples/TableLoadingSkeleton/2.add-header.tsx
@@ -4,12 +4,6 @@ import { TableLoadingSkeleton } from '../../../../index';
 
 export default createClass({
 	render() {
-		return (
-			<TableLoadingSkeleton
-				isLoading={true}
-				width={700}
-				header='Added Header'
-			/>
-		);
+		return <TableLoadingSkeleton isLoading={true} header='Added Header' />;
 	},
 });


### PR DESCRIPTION
1. Per request from UX team I have set default width and height for individual skeletons.
2. Updated storybook examples to better reflect default sizes
3. Per Celinton Rayen comment I have removed unused references to [skeleton].LoadingMessage = LoadingMessage
4. Mopped up few remaining {...props}


## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BWAP-719_Address_common_skeleton_issues
)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
