### PR TITLE
Bude 1069 1 add truncating ellipses to header columns

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -22,22 +22,14 @@ const cx = lucidClassNames.bind('&-DataTable');
 const cxe = lucidClassNames.bind('&-DataTable-EmptyStateWrapper');
 const SELECTOR_COLUMN_WIDTH = 41;
 
-const {
-	any,
-	func,
-	number,
-	object,
-	string: stringProps,
-	bool,
-	arrayOf,
-} = PropTypes;
+const { any, func, number, object, string: stringProps, bool, arrayOf } = PropTypes;
 
-interface IDataTableProps
-	extends ITableProps,
-		React.DetailedHTMLProps<
-			React.HTMLAttributes<HTMLDivElement>,
-			HTMLDivElement
-		> {
+interface IDataTableProps extends ITableProps,
+	React.DetailedHTMLProps<
+	React.HTMLAttributes<HTMLDivElement>,
+	HTMLDivElement
+> {
+
 	/*
 	 * 	Array of objects to be rendered in the table. Object keys match the
 	 * 	\`field\` of each defined \`DataTable.Column\`.
@@ -237,15 +229,18 @@ export const DataTable = (props: IDataTableProps) => {
 	};
 
 	const handleFixedBodyUnfixedColumnsScroll = (event: any) => {
-		fixedHeaderUnfixedColumnsRef &&
-			(fixedHeaderUnfixedColumnsRef.scrollLeft = event.target.scrollLeft);
-		fixedBodyFixedColumnsRef &&
-			(fixedBodyFixedColumnsRef.scrollTop = event.target.scrollTop);
+		fixedHeaderUnfixedColumnsRef && (fixedHeaderUnfixedColumnsRef.scrollLeft = event.target.scrollLeft);
+		fixedBodyFixedColumnsRef && (fixedBodyFixedColumnsRef.scrollTop = event.target.scrollTop);
 	};
 
-	const handleResize = (columnWidth: any, { props: { field } }: any) => {
+	const handleResize = (
+		columnWidth: any,
+		{
+			props: { field },
+		}: any
+	) => {
 		// setting latest column width to Tbody
-		setState((state) => ({
+		setState(state => ({
 			activeWidth: {
 				...state.activeWidth,
 				[field]: columnWidth,
@@ -263,12 +258,13 @@ export const DataTable = (props: IDataTableProps) => {
 
 		const hasGroupedColumns = _.some(
 			childComponentElements,
-			(childComponentElement) =>
+			childComponentElement =>
 				childComponentElement.type === DataTable.ColumnGroup
 		);
 
-		const columnSlicer = _.flow(_.compact, (columns) =>
-			_.slice(columns, startColumn, endColumn)
+		const columnSlicer = _.flow(
+			_.compact,
+			columns => _.slice(columns, startColumn, endColumn)
 		);
 		const allSelected = _.every(data, 'isSelected');
 
@@ -297,11 +293,11 @@ export const DataTable = (props: IDataTableProps) => {
 							_.map(childComponentElements, ({ props, type }, index) =>
 								type === DataTable.Column ? (
 									<Th
-										onResize={props.isResizable ? (handleResize as any) : null}
+										onResize={props.isResizable ? handleResize as any : null}
 										{..._.omit(props, ['children', 'title'])}
 										onClick={
 											DataTable.shouldColumnHandleSort(props)
-												? (_.partial(handleSort, props.field) as any)
+												? _.partial(handleSort, props.field) as any
 												: null
 										}
 										rowSpan={hasGroupedColumns ? 2 : null}
@@ -312,16 +308,16 @@ export const DataTable = (props: IDataTableProps) => {
 										{props.title || props.children}
 									</Th>
 								) : (
-									<Th
-										colSpan={_.size(
-											filterTypes(props.children, DataTable.Column)
-										)}
-										{..._.omit(props, ['field', 'children', 'width', 'title'])}
-										key={_.get(props, 'field', index)}
-									>
-										{props.title || props.children}
-									</Th>
-								)
+										<Th
+											colSpan={_.size(
+												filterTypes(props.children, DataTable.Column)
+											)}
+											{..._.omit(props, ['field', 'children', 'width', 'title'])}
+											key={_.get(props, 'field', index)}
+										>
+											{props.title || props.children}
+										</Th>
+									)
 							)
 						)
 					)}
@@ -335,29 +331,26 @@ export const DataTable = (props: IDataTableProps) => {
 									_.isNull(columnGroupProps)
 										? []
 										: [
-												<Th
-													{...omitProps(
-														columnProps,
-														undefined,
-														_.keys(DataTable.Column.propTypes),
-														false
-													)}
-													onClick={
-														DataTable.shouldColumnHandleSort(columnProps)
-															? (_.partial(
-																	handleSort,
-																	columnProps.field
-															  ) as any)
-															: null
-													}
-													style={{
-														width: columnProps.width,
-													}}
-													key={_.get(columnProps, 'field', index)}
-												>
-													{columnProps.title || columnProps.children}
-												</Th>,
-										  ]
+											<Th
+												{...omitProps(
+													columnProps,
+													undefined,
+													_.keys(DataTable.Column.propTypes),
+													false
+												)}
+												onClick={
+													DataTable.shouldColumnHandleSort(columnProps)
+														? _.partial(handleSort, columnProps.field) as any
+														: null
+												}
+												style={{
+													width: columnProps.width,
+												}}
+												key={_.get(columnProps, 'field', index)}
+											>
+												{columnProps.title || columnProps.children}
+											</Th>,
+										]
 								),
 							[]
 						)}
@@ -367,11 +360,7 @@ export const DataTable = (props: IDataTableProps) => {
 		);
 	};
 
-	const renderBody = (
-		startColumn: any,
-		endColumn: any,
-		flattenedColumns: any
-	) => {
+	const renderBody = (startColumn: any, endColumn: any, flattenedColumns: any) => {
 		const {
 			data,
 			isSelectable,
@@ -379,13 +368,14 @@ export const DataTable = (props: IDataTableProps) => {
 			minRows,
 			emptyCellText,
 			fixedRowHeight,
-			truncateContent,
+			truncateContent
 		} = props;
 
 		const fillerRowCount = _.clamp(minRows - _.size(data), 0, Infinity);
 		const isFixedColumn = endColumn < Infinity;
-		const columnSlicer = _.flow(_.compact, (columns) =>
-			_.slice(columns, startColumn, endColumn)
+		const columnSlicer = _.flow(
+			_.compact,
+			columns => _.slice(columns, startColumn, endColumn)
 		);
 
 		return (
@@ -439,14 +429,14 @@ export const DataTable = (props: IDataTableProps) => {
 													!_.isNil(columnProps.hasBorderRight)
 														? columnProps.hasBorderRight
 														: isFixedColumn &&
-														  columnIndex + 1 + (isSelectable ? 1 : 0) ===
-																endColumn
+														columnIndex + 1 + (isSelectable ? 1 : 0) ===
+														endColumn
 												}
 												style={{
 													width:
 														// @ts-ignore
 														state.activeWidth[
-															columnProps.field || columnIndex
+														columnProps.field || columnIndex
 														] || columnProps.width,
 												}}
 												key={
@@ -465,7 +455,7 @@ export const DataTable = (props: IDataTableProps) => {
 						)}
 					</Tr>
 				))}
-				{_.times(fillerRowCount, (index) => (
+				{_.times(fillerRowCount, index => (
 					<Tr
 						isDisabled
 						key={'row' + index}
@@ -547,11 +537,11 @@ export const DataTable = (props: IDataTableProps) => {
 		props,
 		DataTable.EmptyStateWrapper
 	) || (
-		<DataTable.EmptyStateWrapper
-			Title='No items found.'
-			Body='Try creating a new object or removing a filter.'
-		/>
-	);
+			<DataTable.EmptyStateWrapper
+				Title='No items found.'
+				Body='Try creating a new object or removing a filter.'
+			/>
+		);
 
 	const emptyStateWrapperClassName = cxe(
 		{
@@ -575,12 +565,7 @@ export const DataTable = (props: IDataTableProps) => {
 						<div className={cx('&-fixed-header-fixed-columns')}>
 							{fixedColumnCount > 0 ? (
 								<Table
-									{...omitProps(
-										passThroughs,
-										undefined,
-										_.keys(DataTable.propTypes),
-										false
-									)}
+									{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
 									style={style}
 									className={cx('&-fixed-header-fixed-columns-Table')}
 								>
@@ -595,15 +580,10 @@ export const DataTable = (props: IDataTableProps) => {
 						</div>
 						<div
 							className={cx('&-fixed-header-unfixed-columns')}
-							ref={(ref) => (fixedHeaderUnfixedColumnsRef = ref)}
+							ref={ref => (fixedHeaderUnfixedColumnsRef = ref)}
 						>
 							<Table
-								{...omitProps(
-									passThroughs,
-									undefined,
-									_.keys(DataTable.propTypes),
-									false
-								)}
+								{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
 								style={style}
 								className={cx('&-fixed-header-unfixed-columns-Table')}
 							>
@@ -619,16 +599,11 @@ export const DataTable = (props: IDataTableProps) => {
 					<div className={cx('&-fixed-body')}>
 						<div
 							className={cx('&-fixed-body-fixed-columns')}
-							ref={(ref) => (fixedBodyFixedColumnsRef = ref)}
+							ref={ref => (fixedBodyFixedColumnsRef = ref)}
 						>
 							{fixedColumnCount > 0 ? (
 								<Table
-									{...omitProps(
-										passThroughs,
-										undefined,
-										_.keys(DataTable.propTypes),
-										false
-									)}
+									{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
 									style={style}
 									className={cx('&-fixed-body-fixed-columns-Table')}
 									hasWordWrap={
@@ -645,48 +620,47 @@ export const DataTable = (props: IDataTableProps) => {
 						>
 							<span className={cx('&-fixed-body-unfixed-columns-shadow')} />
 							<Table
-								{...omitProps(
-									passThroughs,
-									undefined,
-									_.keys(DataTable.propTypes),
-									false
-								)}
+								{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
 								style={style}
 								className={cx('&-fixed-body-unfixed-columns-Table')}
 								hasWordWrap={
 									false /* try to protect against vertical overflow */
 								}
 							>
-								{renderBody(fixedColumnCount, Infinity, flattenedColumns)}
+								{renderBody(
+									fixedColumnCount,
+									Infinity,
+									flattenedColumns
+								)}
 							</Table>
 						</div>
 					</div>
 				</div>
 			) : (
-				<ScrollTable
-					style={style}
-					tableWidth={isFullWidth ? '100%' : undefined}
-					{...omitProps(
-						passThroughs,
-						undefined,
-						_.keys(DataTable.propTypes),
-						false
-					)}
-					className={cx(
-						'&',
-						{
-							'&-full-width': isFullWidth,
-						},
-						className
-					)}
-				>
-					{renderHeader(0, Infinity, childComponentElements, flattenedColumns)}
-					{renderBody(0, Infinity, flattenedColumns)}
-				</ScrollTable>
-			)}
+					<ScrollTable
+						style={style}
+						tableWidth={isFullWidth ? '100%' : undefined}
+						{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
+						className={cx(
+							'&',
+							{
+								'&-full-width': isFullWidth,
+							},
+							className
+						)}
+					>
+						{renderHeader(
+							0,
+							Infinity,
+							childComponentElements,
+							flattenedColumns
+						)}
+						{renderBody(0, Infinity, flattenedColumns)}
+					</ScrollTable>
+				)}
 		</EmptyStateWrapper>
 	);
-};
+}
 
 DataTable.displayName = 'DataTable';
 
@@ -872,9 +846,7 @@ interface IColumnProps extends IThProps {
 
 // type IColumnProps = Overwrite<typeof Th, IColumnPropsRaw>;
 
-const Column = (props: IColumnProps) => {
-	return null;
-};
+const Column = (props: IColumnProps) => { return null; }
 
 Column.displayName = 'DataTable.Column';
 
@@ -897,9 +869,7 @@ interface IColumnGroupProps {
 	title?: string;
 }
 
-const ColumnGroup = ({ children }: IColumnGroupProps) => {
-	return children;
-};
+const ColumnGroup = ({ children }: IColumnGroupProps) => { return children; }
 
 ColumnGroup.displayName = 'DataTable.ColumnGroup';
 
@@ -915,7 +885,7 @@ ColumnGroup.propTypes = {
 
 ColumnGroup.defaultProps = {
 	align: 'center',
-};
+}
 
 DataTable.ColumnGroup = ColumnGroup;
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -22,14 +22,22 @@ const cx = lucidClassNames.bind('&-DataTable');
 const cxe = lucidClassNames.bind('&-DataTable-EmptyStateWrapper');
 const SELECTOR_COLUMN_WIDTH = 41;
 
-const { any, func, number, object, string: stringProps, bool, arrayOf } = PropTypes;
+const {
+	any,
+	func,
+	number,
+	object,
+	string: stringProps,
+	bool,
+	arrayOf,
+} = PropTypes;
 
-interface IDataTableProps extends ITableProps,
-	React.DetailedHTMLProps<
-	React.HTMLAttributes<HTMLDivElement>,
-	HTMLDivElement
-> {
-
+interface IDataTableProps
+	extends ITableProps,
+		React.DetailedHTMLProps<
+			React.HTMLAttributes<HTMLDivElement>,
+			HTMLDivElement
+		> {
 	/*
 	 * 	Array of objects to be rendered in the table. Object keys match the
 	 * 	\`field\` of each defined \`DataTable.Column\`.
@@ -65,7 +73,7 @@ interface IDataTableProps extends ITableProps,
 	isSelectable: boolean;
 
 	/*
-	 * 	Position the \`EmptyMessage\` and \`LoadingMessage\` near the top of the container. 
+	 * 	Position the \`EmptyMessage\` and \`LoadingMessage\` near the top of the container.
 	 * 	By default, they are vertically aligned to the middle of the table. Useful
 	 * 	for tables with many rows that extend past the viewport.
 	 */
@@ -229,18 +237,15 @@ export const DataTable = (props: IDataTableProps) => {
 	};
 
 	const handleFixedBodyUnfixedColumnsScroll = (event: any) => {
-		fixedHeaderUnfixedColumnsRef && (fixedHeaderUnfixedColumnsRef.scrollLeft = event.target.scrollLeft);
-		fixedBodyFixedColumnsRef && (fixedBodyFixedColumnsRef.scrollTop = event.target.scrollTop);
+		fixedHeaderUnfixedColumnsRef &&
+			(fixedHeaderUnfixedColumnsRef.scrollLeft = event.target.scrollLeft);
+		fixedBodyFixedColumnsRef &&
+			(fixedBodyFixedColumnsRef.scrollTop = event.target.scrollTop);
 	};
 
-	const handleResize = (
-		columnWidth: any,
-		{
-			props: { field },
-		}: any
-	) => {
+	const handleResize = (columnWidth: any, { props: { field } }: any) => {
 		// setting latest column width to Tbody
-		setState(state => ({
+		setState((state) => ({
 			activeWidth: {
 				...state.activeWidth,
 				[field]: columnWidth,
@@ -254,17 +259,16 @@ export const DataTable = (props: IDataTableProps) => {
 		childComponentElements: any,
 		flattenedColumns: any
 	) => {
-		const { isSelectable, data } = props;
+		const { isSelectable, data, truncateContent } = props;
 
 		const hasGroupedColumns = _.some(
 			childComponentElements,
-			childComponentElement =>
+			(childComponentElement) =>
 				childComponentElement.type === DataTable.ColumnGroup
 		);
 
-		const columnSlicer = _.flow(
-			_.compact,
-			columns => _.slice(columns, startColumn, endColumn)
+		const columnSlicer = _.flow(_.compact, (columns) =>
+			_.slice(columns, startColumn, endColumn)
 		);
 		const allSelected = _.every(data, 'isSelected');
 
@@ -293,30 +297,31 @@ export const DataTable = (props: IDataTableProps) => {
 							_.map(childComponentElements, ({ props, type }, index) =>
 								type === DataTable.Column ? (
 									<Th
-										onResize={props.isResizable ? handleResize as any : null}
+										onResize={props.isResizable ? (handleResize as any) : null}
 										{..._.omit(props, ['children', 'title'])}
 										onClick={
 											DataTable.shouldColumnHandleSort(props)
-												? _.partial(handleSort, props.field) as any
+												? (_.partial(handleSort, props.field) as any)
 												: null
 										}
 										rowSpan={hasGroupedColumns ? 2 : null}
 										field={props.field || index}
 										key={_.get(props, 'field', index)}
+										truncateContent={truncateContent}
 									>
 										{props.title || props.children}
 									</Th>
 								) : (
-										<Th
-											colSpan={_.size(
-												filterTypes(props.children, DataTable.Column)
-											)}
-											{..._.omit(props, ['field', 'children', 'width', 'title'])}
-											key={_.get(props, 'field', index)}
-										>
-											{props.title || props.children}
-										</Th>
-									)
+									<Th
+										colSpan={_.size(
+											filterTypes(props.children, DataTable.Column)
+										)}
+										{..._.omit(props, ['field', 'children', 'width', 'title'])}
+										key={_.get(props, 'field', index)}
+									>
+										{props.title || props.children}
+									</Th>
+								)
 							)
 						)
 					)}
@@ -330,26 +335,29 @@ export const DataTable = (props: IDataTableProps) => {
 									_.isNull(columnGroupProps)
 										? []
 										: [
-											<Th
-												{...omitProps(
-													columnProps,
-													undefined,
-													_.keys(DataTable.Column.propTypes),
-													false
-												)}
-												onClick={
-													DataTable.shouldColumnHandleSort(columnProps)
-														? _.partial(handleSort, columnProps.field) as any
-														: null
-												}
-												style={{
-													width: columnProps.width,
-												}}
-												key={_.get(columnProps, 'field', index)}
-											>
-												{columnProps.title || columnProps.children}
-											</Th>,
-										]
+												<Th
+													{...omitProps(
+														columnProps,
+														undefined,
+														_.keys(DataTable.Column.propTypes),
+														false
+													)}
+													onClick={
+														DataTable.shouldColumnHandleSort(columnProps)
+															? (_.partial(
+																	handleSort,
+																	columnProps.field
+															  ) as any)
+															: null
+													}
+													style={{
+														width: columnProps.width,
+													}}
+													key={_.get(columnProps, 'field', index)}
+												>
+													{columnProps.title || columnProps.children}
+												</Th>,
+										  ]
 								),
 							[]
 						)}
@@ -359,7 +367,11 @@ export const DataTable = (props: IDataTableProps) => {
 		);
 	};
 
-	const renderBody = (startColumn: any, endColumn: any, flattenedColumns: any) => {
+	const renderBody = (
+		startColumn: any,
+		endColumn: any,
+		flattenedColumns: any
+	) => {
 		const {
 			data,
 			isSelectable,
@@ -367,14 +379,13 @@ export const DataTable = (props: IDataTableProps) => {
 			minRows,
 			emptyCellText,
 			fixedRowHeight,
-			truncateContent
+			truncateContent,
 		} = props;
 
 		const fillerRowCount = _.clamp(minRows - _.size(data), 0, Infinity);
 		const isFixedColumn = endColumn < Infinity;
-		const columnSlicer = _.flow(
-			_.compact,
-			columns => _.slice(columns, startColumn, endColumn)
+		const columnSlicer = _.flow(_.compact, (columns) =>
+			_.slice(columns, startColumn, endColumn)
 		);
 
 		return (
@@ -428,14 +439,14 @@ export const DataTable = (props: IDataTableProps) => {
 													!_.isNil(columnProps.hasBorderRight)
 														? columnProps.hasBorderRight
 														: isFixedColumn &&
-														columnIndex + 1 + (isSelectable ? 1 : 0) ===
-														endColumn
+														  columnIndex + 1 + (isSelectable ? 1 : 0) ===
+																endColumn
 												}
 												style={{
 													width:
 														// @ts-ignore
 														state.activeWidth[
-														columnProps.field || columnIndex
+															columnProps.field || columnIndex
 														] || columnProps.width,
 												}}
 												key={
@@ -454,7 +465,7 @@ export const DataTable = (props: IDataTableProps) => {
 						)}
 					</Tr>
 				))}
-				{_.times(fillerRowCount, index => (
+				{_.times(fillerRowCount, (index) => (
 					<Tr
 						isDisabled
 						key={'row' + index}
@@ -536,11 +547,11 @@ export const DataTable = (props: IDataTableProps) => {
 		props,
 		DataTable.EmptyStateWrapper
 	) || (
-			<DataTable.EmptyStateWrapper
-				Title='No items found.'
-				Body='Try creating a new object or removing a filter.'
-			/>
-		);
+		<DataTable.EmptyStateWrapper
+			Title='No items found.'
+			Body='Try creating a new object or removing a filter.'
+		/>
+	);
 
 	const emptyStateWrapperClassName = cxe(
 		{
@@ -564,7 +575,12 @@ export const DataTable = (props: IDataTableProps) => {
 						<div className={cx('&-fixed-header-fixed-columns')}>
 							{fixedColumnCount > 0 ? (
 								<Table
-									{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
+									{...omitProps(
+										passThroughs,
+										undefined,
+										_.keys(DataTable.propTypes),
+										false
+									)}
 									style={style}
 									className={cx('&-fixed-header-fixed-columns-Table')}
 								>
@@ -579,10 +595,15 @@ export const DataTable = (props: IDataTableProps) => {
 						</div>
 						<div
 							className={cx('&-fixed-header-unfixed-columns')}
-							ref={ref => (fixedHeaderUnfixedColumnsRef = ref)}
+							ref={(ref) => (fixedHeaderUnfixedColumnsRef = ref)}
 						>
 							<Table
-								{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
+								{...omitProps(
+									passThroughs,
+									undefined,
+									_.keys(DataTable.propTypes),
+									false
+								)}
 								style={style}
 								className={cx('&-fixed-header-unfixed-columns-Table')}
 							>
@@ -598,11 +619,16 @@ export const DataTable = (props: IDataTableProps) => {
 					<div className={cx('&-fixed-body')}>
 						<div
 							className={cx('&-fixed-body-fixed-columns')}
-							ref={ref => (fixedBodyFixedColumnsRef = ref)}
+							ref={(ref) => (fixedBodyFixedColumnsRef = ref)}
 						>
 							{fixedColumnCount > 0 ? (
 								<Table
-									{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
+									{...omitProps(
+										passThroughs,
+										undefined,
+										_.keys(DataTable.propTypes),
+										false
+									)}
 									style={style}
 									className={cx('&-fixed-body-fixed-columns-Table')}
 									hasWordWrap={
@@ -619,47 +645,48 @@ export const DataTable = (props: IDataTableProps) => {
 						>
 							<span className={cx('&-fixed-body-unfixed-columns-shadow')} />
 							<Table
-								{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
+								{...omitProps(
+									passThroughs,
+									undefined,
+									_.keys(DataTable.propTypes),
+									false
+								)}
 								style={style}
 								className={cx('&-fixed-body-unfixed-columns-Table')}
 								hasWordWrap={
 									false /* try to protect against vertical overflow */
 								}
 							>
-								{renderBody(
-									fixedColumnCount,
-									Infinity,
-									flattenedColumns
-								)}
+								{renderBody(fixedColumnCount, Infinity, flattenedColumns)}
 							</Table>
 						</div>
 					</div>
 				</div>
 			) : (
-					<ScrollTable
-						style={style}
-						tableWidth={isFullWidth ? '100%' : undefined}
-						{...omitProps(passThroughs, undefined, _.keys(DataTable.propTypes), false)}
-						className={cx(
-							'&',
-							{
-								'&-full-width': isFullWidth,
-							},
-							className
-						)}
-					>
-						{renderHeader(
-							0,
-							Infinity,
-							childComponentElements,
-							flattenedColumns
-						)}
-						{renderBody(0, Infinity, flattenedColumns)}
-					</ScrollTable>
-				)}
+				<ScrollTable
+					style={style}
+					tableWidth={isFullWidth ? '100%' : undefined}
+					{...omitProps(
+						passThroughs,
+						undefined,
+						_.keys(DataTable.propTypes),
+						false
+					)}
+					className={cx(
+						'&',
+						{
+							'&-full-width': isFullWidth,
+						},
+						className
+					)}
+				>
+					{renderHeader(0, Infinity, childComponentElements, flattenedColumns)}
+					{renderBody(0, Infinity, flattenedColumns)}
+				</ScrollTable>
+			)}
 		</EmptyStateWrapper>
 	);
-}
+};
 
 DataTable.displayName = 'DataTable';
 
@@ -845,7 +872,9 @@ interface IColumnProps extends IThProps {
 
 // type IColumnProps = Overwrite<typeof Th, IColumnPropsRaw>;
 
-const Column = (props: IColumnProps) => { return null; }
+const Column = (props: IColumnProps) => {
+	return null;
+};
 
 Column.displayName = 'DataTable.Column';
 
@@ -861,14 +890,16 @@ Column.propTypes = {
 	isResizable: bool,
 };
 
-DataTable.Column = Column; 
+DataTable.Column = Column;
 
 interface IColumnGroupProps {
 	children?: any;
 	title?: string;
 }
 
-const ColumnGroup = ({ children }: IColumnGroupProps) => { return children; }
+const ColumnGroup = ({ children }: IColumnGroupProps) => {
+	return children;
+};
 
 ColumnGroup.displayName = 'DataTable.ColumnGroup';
 
@@ -884,7 +915,7 @@ ColumnGroup.propTypes = {
 
 ColumnGroup.defaultProps = {
 	align: 'center',
-}
+};
 
 DataTable.ColumnGroup = ColumnGroup;
 

--- a/src/components/DataTable/__snapshots__/DataTable.spec.tsx.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.spec.tsx.snap
@@ -20229,3 +20229,1417 @@ exports[`DataTable [common] example testing should match snapshot(s) for 14.resi
   </div>
 </EmptyStateWrapper>
 `;
+
+exports[`DataTable [common] example testing should match snapshot(s) for 15.truncate-content 1`] = `
+<EmptyStateWrapper
+  Body="Try creating a new object or removing a filter."
+  Title="No items found."
+  anchorMessage={false}
+  className="lucid-DataTable-EmptyStateWrapper-has-fixed-header"
+  isEmpty={false}
+  isLoading={false}
+>
+  <div
+    className="lucid-DataTable-fixed"
+  >
+    <div
+      className="lucid-DataTable-fixed-header"
+    >
+      <div
+        className="lucid-DataTable-fixed-header-fixed-columns"
+      />
+      <div
+        className="lucid-DataTable-fixed-header-unfixed-columns"
+      >
+        <Table
+          className="lucid-DataTable-fixed-header-unfixed-columns-Table"
+          density="extended"
+          hasBorder={false}
+          hasHover={true}
+          hasLightHeader={true}
+          hasWordWrap={true}
+        >
+          <Table.Thead>
+            <Table.Tr
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+            >
+              <Table.Th
+                align="left"
+                field="id"
+                isResizable={false}
+                isSorted={false}
+                key="id"
+                onClick={null}
+                onResize={null}
+                rowSpan={null}
+                sortDirection="up"
+                truncateContent={true}
+                width={50}
+              >
+                ID
+              </Table.Th>
+              <Table.Th
+                align="left"
+                field="first_name"
+                isResizable={false}
+                isSorted={false}
+                key="first_name"
+                onClick={null}
+                onResize={null}
+                rowSpan={null}
+                sortDirection="up"
+                truncateContent={true}
+                width={100}
+              >
+                First
+              </Table.Th>
+              <Table.Th
+                align="left"
+                field="last_name"
+                isResizable={false}
+                isSorted={false}
+                key="last_name"
+                onClick={null}
+                onResize={null}
+                rowSpan={null}
+                sortDirection="up"
+                truncateContent={true}
+                width={100}
+              >
+                Last
+              </Table.Th>
+              <Table.Th
+                align="left"
+                field="email"
+                isResizable={false}
+                isSorted={false}
+                key="email"
+                onClick={null}
+                onResize={null}
+                rowSpan={null}
+                sortDirection="up"
+                truncateContent={true}
+              >
+                E-Mail
+              </Table.Th>
+              <Table.Th
+                align="left"
+                field="occupation"
+                isResizable={false}
+                isSorted={false}
+                key="occupation"
+                onClick={null}
+                onResize={null}
+                rowSpan={null}
+                sortDirection="up"
+                truncateContent={true}
+                width={100}
+              >
+                Long Occupation
+              </Table.Th>
+              <Table.Th
+                align="right"
+                field="salary"
+                isResizable={false}
+                isSorted={false}
+                key="salary"
+                onClick={null}
+                onResize={null}
+                rowSpan={null}
+                sortDirection="up"
+                truncateContent={true}
+                width={90}
+              >
+                Large Salary
+              </Table.Th>
+              <Table.Th
+                align="center"
+                field="status"
+                isResizable={false}
+                isSorted={false}
+                key="status"
+                onClick={null}
+                onResize={null}
+                rowSpan={null}
+                sortDirection="up"
+                truncateContent={true}
+                width={100}
+              >
+                Status
+              </Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+        </Table>
+      </div>
+    </div>
+    <div
+      className="lucid-DataTable-fixed-body"
+    >
+      <div
+        className="lucid-DataTable-fixed-body-fixed-columns"
+      />
+      <div
+        className="lucid-DataTable-fixed-body-unfixed-columns"
+        onScroll={[Function]}
+      >
+        <span
+          className="lucid-DataTable-fixed-body-unfixed-columns-shadow"
+        />
+        <Table
+          className="lucid-DataTable-fixed-body-unfixed-columns-Table"
+          density="extended"
+          hasBorder={false}
+          hasHover={true}
+          hasLightHeader={true}
+          hasWordWrap={false}
+        >
+          <Table.Tbody>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row0"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row0id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                1
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row0first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Isaac
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row0last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Newton
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row0email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                inewton@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row0occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Physicist mathematician
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row0salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.01
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row0status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row1"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row1id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                2
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row1first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Albert
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row1last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Einstein
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row1email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                aeinstein@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row1occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Physicist
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row1salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.02
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row1status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row2"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row2id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                3
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row2first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Leonardo
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row2last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                da Vinci
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row2email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                ldvinci@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row2occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Engineer
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row2salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.03
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row2status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row3"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row3id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                4
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row3first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Aristotle
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row3last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                --
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row3email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                aristotle@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row3occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Tutor
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row3salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.04
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row3status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row4"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row4id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                5
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row4first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Galileo
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row4last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                --
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row4email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                ggalilei@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row4occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Physicist
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row4salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.05
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row4status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row5"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row5id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                6
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row5first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Charles
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row5last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Darwin
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row5email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                cdarwin@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row5occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Biologist
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row5salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.06
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row5status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row6"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row6id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                7
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row6first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Alexander
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row6last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Macedon
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row6email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                amacedon@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row6occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Head of State
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row6salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.07
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row6status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row7"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row7id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                8
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row7first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Plato
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row7last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Plato
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row7email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                plato@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row7occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Philosopher
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row7salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.08
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row7status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row8"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row8id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                9
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row8first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Mahatma
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row8last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Gandhi
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row8email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                mgandhi@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row8occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Politician
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row8salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.09
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row8status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr
+              isActionable={false}
+              isActive={false}
+              isDisabled={false}
+              isSelected={false}
+              key="row9"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row9id"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+                truncateContent={true}
+              >
+                10
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row9first_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                William
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row9last_name"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Shakespeare
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row9email"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+                truncateContent={true}
+              >
+                wshakespear@example.com
+              </Table.Td>
+              <Table.Td
+                align="left"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row9occupation"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                Playwright
+              </Table.Td>
+              <Table.Td
+                align="right"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row9salary"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 90,
+                  }
+                }
+                truncateContent={true}
+              >
+                $100.10
+              </Table.Td>
+              <Table.Td
+                align="center"
+                hasBorderLeft={false}
+                hasBorderRight={false}
+                key="row9status"
+                rowSpan={1}
+                style={
+                  Object {
+                    "width": 100,
+                  }
+                }
+                truncateContent={true}
+              >
+                <SuccessIcon
+                  aspectRatio="xMidYMid meet"
+                  color="primary"
+                  isClickable={false}
+                  isDisabled={false}
+                  onClick={[Function]}
+                  onSelect={[Function]}
+                  size={16}
+                  viewBox="0 0 16 16"
+                />
+              </Table.Td>
+            </Table.Tr>
+          </Table.Tbody>
+        </Table>
+      </div>
+    </div>
+  </div>
+</EmptyStateWrapper>
+`;

--- a/src/components/DataTable/examples/15.truncate-content.tsx
+++ b/src/components/DataTable/examples/15.truncate-content.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import { DataTable, SuccessIcon } from '../../../index';
+
+const data = [
+	{
+		id: 1,
+		first_name: 'Isaac',
+		last_name: 'Newton',
+		email: 'inewton@example.com',
+		occupation: 'Physicist mathematician',
+		salary: '$100.01',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 2,
+		first_name: 'Albert',
+		last_name: 'Einstein',
+		email: 'aeinstein@example.com',
+		occupation: 'Physicist',
+		salary: '$100.02',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 3,
+		first_name: 'Leonardo',
+		last_name: 'da Vinci',
+		email: 'ldvinci@example.com',
+		occupation: 'Engineer',
+		salary: '$100.03',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 4,
+		first_name: 'Aristotle',
+		last_name: null,
+		email: 'aristotle@example.com',
+		occupation: 'Tutor',
+		salary: '$100.04',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 5,
+		first_name: 'Galileo',
+		email: 'ggalilei@example.com',
+		occupation: 'Physicist',
+		salary: '$100.05',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 6,
+		first_name: 'Charles',
+		last_name: 'Darwin',
+		email: 'cdarwin@example.com',
+		occupation: 'Biologist',
+		salary: '$100.06',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 7,
+		first_name: 'Alexander',
+		last_name: 'Macedon',
+		email: 'amacedon@example.com',
+		occupation: 'Head of State',
+		salary: '$100.07',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 8,
+		first_name: 'Plato',
+		last_name: 'Plato',
+		email: 'plato@example.com',
+		occupation: 'Philosopher',
+		salary: '$100.08',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 9,
+		first_name: 'Mahatma',
+		last_name: 'Gandhi',
+		email: 'mgandhi@example.com',
+		occupation: 'Politician',
+		salary: '$100.09',
+		status: <SuccessIcon />,
+	},
+	{
+		id: 10,
+		first_name: 'William',
+		last_name: 'Shakespeare',
+		email: 'wshakespear@example.com',
+		occupation: 'Playwright',
+		salary: '$100.10',
+		status: <SuccessIcon />,
+	},
+];
+
+export default createClass({
+	render() {
+		return (
+			<DataTable data={data} hasFixedHeader={true} truncateContent={true}>
+				<DataTable.Column field='id' align='left' width={50}>
+					ID
+				</DataTable.Column>
+
+				<DataTable.Column field='first_name' align='left' width={100}>
+					First
+				</DataTable.Column>
+
+				<DataTable.Column field='last_name' align='left' width={100}>
+					Last
+				</DataTable.Column>
+
+				<DataTable.Column field='email' align='left'>
+					E-Mail
+				</DataTable.Column>
+
+				<DataTable.Column field='occupation' align='left' width={100}>
+					Long Occupation
+				</DataTable.Column>
+
+				<DataTable.Column field='salary' align='right' width={90}>
+					Large Salary
+				</DataTable.Column>
+
+				<DataTable.Column field='status' align='center' width={100}>
+					Status
+				</DataTable.Column>
+			</DataTable>
+		);
+	},
+});

--- a/src/components/Table/Table.less
+++ b/src/components/Table/Table.less
@@ -209,6 +209,23 @@
 				}
 			}
 
+			// header cell content displays ellipses if text overflows
+			// and <DataTable hasFixedHeader={true} truncateContent={true}>
+			&.@{prefix}-Table-truncate-content {
+				& > .@{prefix}-Table-Th-inner {
+					justify-content: flex-start;
+					align-items: center;
+					.@{prefix}-Table-Th-inner-content {
+						flex: unset;
+						display: unset;
+						text-overflow: ellipsis;
+						overflow: hidden;
+						white-space: nowrap;
+						text-align: left;
+					}
+				}
+			}
+
 			// `Th`.`align` prop - use flex alignments in header
 			&.@{prefix}-Table-align-left
 				> .@{prefix}-Table-Th-inner

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -277,6 +277,9 @@ export interface IThProps
 	field?: string;
 
 	rowSpan?: number | null;
+
+	/** Truncates `Table.Th` content with ellipses, must be used with `hasFixedHeader` */
+	truncateContent?: boolean;
 }
 
 interface IThState {
@@ -399,6 +402,11 @@ export class Th extends React.Component<IThProps, IThState> {
 		field: string`
 			Sets the field value for the cell.
 		`,
+
+		/** Truncates `Table.Td` content with ellipses, must be used with `hasFixedHeader` */
+		truncateContent: bool`
+			Truncates header and adds ellipses.
+		`,
 	};
 
 	private rootRef = React.createRef<HTMLTableHeaderCellElement>();
@@ -420,7 +428,11 @@ export class Th extends React.Component<IThProps, IThState> {
 		passiveWidth: this.props.width || null,
 	};
 
-	UNSAFE_componentWillReceiveProps({ width }: { width?: number | string | null }) {
+	UNSAFE_componentWillReceiveProps({
+		width,
+	}: {
+		width?: number | string | null;
+	}) {
 		if (!_.isNil(width) && width !== this.props.width) {
 			this.setState({
 				hasSetWidth: true,
@@ -492,14 +504,20 @@ export class Th extends React.Component<IThProps, IThState> {
 	): void => {
 		let passiveWidth = this.state.passiveWidth;
 
-		const minWidth = (this.props.minWidth !== null && _.isString(this.props.minWidth)) ? parseInt(this.props.minWidth) : this.props.minWidth;
+		const minWidth =
+			this.props.minWidth !== null && _.isString(this.props.minWidth)
+				? parseInt(this.props.minWidth)
+				: this.props.minWidth;
 		if (passiveWidth === null) {
 			return;
 		} else if (_.isString(passiveWidth)) {
 			passiveWidth = parseInt(passiveWidth);
 		}
 
-		const activeWidth = ((minWidth && passiveWidth + coordinates.dX > minWidth) || !minWidth) ? passiveWidth + coordinates.dX : minWidth;
+		const activeWidth =
+			(minWidth && passiveWidth + coordinates.dX > minWidth) || !minWidth
+				? passiveWidth + coordinates.dX
+				: minWidth;
 
 		this.setState({ activeWidth });
 
@@ -560,6 +578,7 @@ export class Th extends React.Component<IThProps, IThState> {
 			isSorted,
 			sortDirection,
 			style,
+			truncateContent,
 			...passThroughs
 		} = this.props;
 
@@ -586,6 +605,7 @@ export class Th extends React.Component<IThProps, IThState> {
 						'&-is-sorted': isSorted,
 						'&-has-border-right': hasBorderRight,
 						'&-has-border-left': hasBorderLeft,
+						'&-truncate-content': truncateContent,
 					},
 					className
 				)}
@@ -664,7 +684,7 @@ export interface ITdProps
 
 	/** Truncates `Table.Td` content with ellipses, must be used with `hasFixedHeader` */
 	truncateContent?: boolean;
-	
+
 	/** Sets the width of the cell. */
 	width?: number | string;
 }
@@ -914,7 +934,7 @@ function mapToGrid(
 	cellType: Th | typeof Td = Td,
 	mapFn: (gridcell: IGridCell, ...args: any[]) => any = _.property('element')
 ) {
-	const cellRowList = _.map(trList, trElement =>
+	const cellRowList = _.map(trList, (trElement) =>
 		_.map(filterTypes(trElement.props.children, cellType))
 	);
 	const grid: IGridCell[][] = [];

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -428,11 +428,7 @@ export class Th extends React.Component<IThProps, IThState> {
 		passiveWidth: this.props.width || null,
 	};
 
-	UNSAFE_componentWillReceiveProps({
-		width,
-	}: {
-		width?: number | string | null;
-	}) {
+	UNSAFE_componentWillReceiveProps({ width }: { width?: number | string | null }) {
 		if (!_.isNil(width) && width !== this.props.width) {
 			this.setState({
 				hasSetWidth: true,
@@ -504,20 +500,14 @@ export class Th extends React.Component<IThProps, IThState> {
 	): void => {
 		let passiveWidth = this.state.passiveWidth;
 
-		const minWidth =
-			this.props.minWidth !== null && _.isString(this.props.minWidth)
-				? parseInt(this.props.minWidth)
-				: this.props.minWidth;
+		const minWidth = (this.props.minWidth !== null && _.isString(this.props.minWidth)) ? parseInt(this.props.minWidth) : this.props.minWidth;
 		if (passiveWidth === null) {
 			return;
 		} else if (_.isString(passiveWidth)) {
 			passiveWidth = parseInt(passiveWidth);
 		}
 
-		const activeWidth =
-			(minWidth && passiveWidth + coordinates.dX > minWidth) || !minWidth
-				? passiveWidth + coordinates.dX
-				: minWidth;
+		const activeWidth = ((minWidth && passiveWidth + coordinates.dX > minWidth) || !minWidth) ? passiveWidth + coordinates.dX : minWidth;
 
 		this.setState({ activeWidth });
 
@@ -934,7 +924,7 @@ function mapToGrid(
 	cellType: Th | typeof Td = Td,
 	mapFn: (gridcell: IGridCell, ...args: any[]) => any = _.property('element')
 ) {
-	const cellRowList = _.map(trList, (trElement) =>
+	const cellRowList = _.map(trList, trElement =>
 		_.map(filterTypes(trElement.props.children, cellType))
 	);
 	const grid: IGridCell[][] = [];


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BUDE-1069_1_add_truncating_ellipses_to_header_columns)

- Manually tested across supported browsers

  - [ x] Chrome
  - [] Firefox
  - [x ] Safari

- [x ] Unit tests written (`common` at minimum)
- [x ] PR has one of the `semver-` labels
- [x] Two core team engineer approvals
- [x] One core team UX approval
- [ ] 
![image](https://user-images.githubusercontent.com/44213339/114079570-584ef880-9878-11eb-984e-62dc415ab1c8.png)
