### PR TITLE
Exposing data table column width to child components

### DIFF
--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -1045,5 +1045,35 @@ describe('DataTable', () => {
 				);
 			});
 		});
+
+		describe('cellValue is a function', () => {
+			it('should pass column width as a prop to cellValue', () => {
+				const testDataWithFunctionInCellValue: any = [
+					{
+						id: 1,
+						first_name: 'Isaac',
+						email: 'inewton@example.com',
+						occupation: 'Physicist',
+						isDisabled: true,
+						isSelected: true,
+						isActive: true,
+						status: (width) => <Checkbox width={width} />,
+					},
+				];
+
+				const wrapper = mount(
+					<DataTable hasFixedHeader data={testDataWithFunctionInCellValue}>
+						<Column field='id' isResizable title='ID' />
+						<Column field='first_name' isResizable title='First' />
+						<Column field='last_name' isResizable title='Last' />
+						<Column field='email' isResizable title='Email' />
+						<Column field='occupation' isResizable title='Occupation' />
+						<Column field='status' isResizable title='Status' />
+					</DataTable>
+				);
+
+				expect(wrapper.find(Checkbox).props()).toHaveProperty('width');
+			});
+		});
 	});
 });

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -456,7 +456,11 @@ export const DataTable = (props: IDataTableProps) => {
 												}
 												truncateContent={truncateContent}
 											>
-												{isEmpty ? emptyCellText : cellValue}
+												{isEmpty
+													? emptyCellText
+													: _.isFunction(cellValue)
+													? cellValue(columnProps.width)
+													: cellValue}
 											</Td>
 										);
 									}


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [X] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
