### PR TITLE
BUDE-1280: Rough draft of validated input warning and info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- #1237 [minor] Add info prop to TextFieldValidated
+  https://github.com/appnexus/lucid/pull/1237
+
 ## 8.0.0
 
 - #1231 [major] Updated storybook to v6 

--- a/src/components/TextFieldValidated/TextFieldValidated.less
+++ b/src/components/TextFieldValidated/TextFieldValidated.less
@@ -9,5 +9,15 @@
 			border: 2px solid @featured-color-danger;
 			box-shadow: inset 0 1px 2px 0 rgba(33, 31, 31, 0.16);
 		}
+
+		&.-info {
+			.lucid-Validation-error-content {
+				color: @color-disabledText;
+			}
+
+			input {
+				border-color: @color-primary;
+			}
+		}
 	}
 }

--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -31,6 +31,8 @@ TextFieldValidatedError.propName = 'Error';
 export interface ITextFieldValidatedProps
 	extends ITextFieldPropsWithPassThroughs {
 	Error?: React.ReactNode;
+	warning?: React.ReactNode;
+	info?: React.ReactNode;
 }
 
 export interface ITextFieldValidatedState {
@@ -66,6 +68,14 @@ class TextFieldValidated extends React.Component<
 		Error: any`
 			Prop alternative to Error child component
 		`,
+
+		warning: any`
+			Prop alternative to Error child component
+		`,
+
+		info: any`
+			Prop alternative to Error child component
+		`,
 	};
 
 	static defaultProps = TextField.defaultProps;
@@ -83,12 +93,16 @@ class TextFieldValidated extends React.Component<
 			findTypes(this.props, TextFieldValidated.Error),
 			'props'
 		);
+		const warningChildProps = this.props.warning;
+		const infoChildProps = this.props.info;
 
 		return (
 			<Validation
-				className={cx('&', className)}
+				className={cx('&', className, {
+					'-info': !errorChildProps && !warningChildProps && infoChildProps,
+				})}
 				style={style}
-				Error={errorChildProps}
+				Error={errorChildProps || warningChildProps || infoChildProps}
 			>
 				<TextField
 					{...omitProps(

--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -31,8 +31,7 @@ TextFieldValidatedError.propName = 'Error';
 export interface ITextFieldValidatedProps
 	extends ITextFieldPropsWithPassThroughs {
 	Error?: React.ReactNode;
-	warning?: React.ReactNode;
-	info?: React.ReactNode;
+	Info?: string;
 }
 
 export interface ITextFieldValidatedState {
@@ -69,12 +68,8 @@ class TextFieldValidated extends React.Component<
 			Prop alternative to Error child component
 		`,
 
-		warning: any`
-			Prop alternative to Error child component
-		`,
-
-		info: any`
-			Prop alternative to Error child component
+		Info: string`
+			Optional information text that is styled less aggressively than an error
 		`,
 	};
 
@@ -89,20 +84,24 @@ class TextFieldValidated extends React.Component<
 	render() {
 		const { className, style, ...passThroughs } = this.props;
 
-		const errorChildProps = _.map(
-			findTypes(this.props, TextFieldValidated.Error),
-			'props'
-		);
-		const warningChildProps = this.props.warning;
-		const infoChildProps = this.props.info;
+		let childProps;
+
+		if (this.props.Error) {
+			childProps = _.map(
+				findTypes(this.props, TextFieldValidated.Error),
+				'props'
+			);
+		} else if (this.props.Info) {
+			childProps = [this.props.Info];
+		}
 
 		return (
 			<Validation
 				className={cx('&', className, {
-					'-info': !errorChildProps && !warningChildProps && infoChildProps,
+					'-info': !this.props.Error && this.props.Info,
 				})}
 				style={style}
-				Error={errorChildProps || warningChildProps || infoChildProps}
+				Error={childProps}
 			>
 				<TextField
 					{...omitProps(

--- a/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
+++ b/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
@@ -58,3 +58,65 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
   />
 </Validation>
 `;
+
+exports[`TextFieldValidated [common] example testing should match snapshot(s) for 03.error_types 1`] = `
+<Validation
+  Error={
+    Array [
+      Object {
+        "children": "This is an error",
+      },
+    ]
+  }
+  className="lucid-TextFieldValidated"
+  style={
+    Object {
+      "marginBottom": "10px",
+    }
+  }
+>
+  <TextField
+    debounceLevel={500}
+    isDisabled={false}
+    isMultiLine={false}
+    lazyLevel={1000}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onChangeDebounced={[Function]}
+    onKeyDown={[Function]}
+    onSubmit={[Function]}
+    rows={5}
+    value=""
+  />
+</Validation>
+`;
+
+exports[`TextFieldValidated [common] example testing should match snapshot(s) for 03.error_types 2`] = `
+<Validation
+  Error={
+    Array [
+      "This is an info",
+    ]
+  }
+  className="lucid-TextFieldValidated -info"
+  style={
+    Object {
+      "marginBottom": "10px",
+    }
+  }
+>
+  <TextField
+    debounceLevel={500}
+    isDisabled={false}
+    isMultiLine={false}
+    lazyLevel={1000}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onChangeDebounced={[Function]}
+    onKeyDown={[Function]}
+    onSubmit={[Function]}
+    rows={5}
+    value=""
+  />
+</Validation>
+`;

--- a/src/components/TextFieldValidated/examples/03.error_types.tsx
+++ b/src/components/TextFieldValidated/examples/03.error_types.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import createClass from 'create-react-class';
+
+import { TextFieldValidated } from '../../../index';
+
+const style = {
+	marginBottom: '10px',
+};
+
+export default createClass({
+	getInitialState() {
+		return {
+			value: '',
+		};
+	},
+
+	render() {
+		return (
+			<div>
+				<TextFieldValidated
+					style={style}
+					value={this.state.value}
+					onChangeDebounced={() => {}}
+					Error={'This is an error'}
+				/>
+				<TextFieldValidated
+					style={style}
+					value={this.state.value}
+					onChangeDebounced={() => {}}
+					Error={null}
+					Info={'This is an info'}
+				/>
+			</div>
+		);
+	},
+});

--- a/src/components/Validation/Validation.less
+++ b/src/components/Validation/Validation.less
@@ -3,7 +3,6 @@
 
 .@{prefix}-Validation {
 	&-error-content {
-		margin-top: @size-XXS;
 		color: @featured-color-danger;
 		font-size: @fontSize * 0.9;
 	}


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BUDE-1280/?path=/docs/controls-textfieldvalidated--basic)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval


<img width="668" alt="Screen Shot 2021-05-24 at 12 33 35 PM" src="https://user-images.githubusercontent.com/14900449/119398343-48ef0780-bc8c-11eb-815d-08d3d26bbd55.png">