### PR TITLE
Small update to recent DataTable change

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -423,7 +423,9 @@ export const DataTable = (props: IDataTableProps) => {
 									({ props: columnProps }, columnIndex) => {
 										const cellValue = _.get(row, columnProps.field);
 										const isEmpty = _.isEmpty(_.toString(cellValue));
-
+										const currentWidth =
+											state.activeWidth[columnProps.field || columnIndex] ||
+											columnProps.width;
 										return (
 											<Td
 												{..._.omit(columnProps, [
@@ -442,13 +444,7 @@ export const DataTable = (props: IDataTableProps) => {
 														  columnIndex + 1 + (isSelectable ? 1 : 0) ===
 																endColumn
 												}
-												style={{
-													width:
-														// @ts-ignore
-														state.activeWidth[
-															columnProps.field || columnIndex
-														] || columnProps.width,
-												}}
+												style={{ width: currentWidth }}
 												key={
 													'row' +
 													index +
@@ -459,7 +455,7 @@ export const DataTable = (props: IDataTableProps) => {
 												{isEmpty
 													? emptyCellText
 													: _.isFunction(cellValue)
-													? cellValue(columnProps.width)
+													? cellValue(currentWidth)
 													: cellValue}
 											</Td>
 										);


### PR DESCRIPTION
## PR Checklist

#### Short Summary
In recent [PR for exposing a columns width](https://github.com/appnexus/lucid/pull/1235), unfortunately the change I made did not update width to child components on column resize. This change fixes that

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
