### PR TITLE
Cxp 2149 bug react syntax highlighter paths

### DIFF
--- a/.storybook/lucid-docs-addon/ChildComponents.tsx
+++ b/.storybook/lucid-docs-addon/ChildComponents.tsx
@@ -3,14 +3,11 @@ import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import marksy from 'marksy/components';
 import PropTypes from './PropTypes';
-import { stripIndent } from './util';
 
-import SyntaxHighlighter, {
-	registerLanguage,
-} from 'react-syntax-highlighter/prism-light';
-import jsx from 'react-syntax-highlighter/languages/prism/jsx';
-import json from 'react-syntax-highlighter/languages/prism/json';
-import coy from 'react-syntax-highlighter/styles/prism/coy';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism-light';
+import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
+import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
+import coy from 'react-syntax-highlighter/dist/cjs/styles/prism/coy';
 
 const coyCustom = {
 	...coy,
@@ -25,8 +22,8 @@ const coyCustom = {
 	},
 };
 
-registerLanguage('jsx', jsx);
-registerLanguage('json', json);
+SyntaxHighlighter.registerLanguage('jsx', jsx);
+SyntaxHighlighter.registerLanguage('json', json);
 
 const compile = marksy({
 	createElement: React.createElement,

--- a/.storybook/lucid-docs-addon/PropTypes.tsx
+++ b/.storybook/lucid-docs-addon/PropTypes.tsx
@@ -4,12 +4,10 @@ import _ from 'lodash';
 import marksy from 'marksy/components';
 import { stripIndent } from './util';
 
-import SyntaxHighlighter, {
-	registerLanguage,
-} from 'react-syntax-highlighter/prism-light';
-import jsx from 'react-syntax-highlighter/languages/prism/jsx';
-import json from 'react-syntax-highlighter/languages/prism/json';
-import coy from 'react-syntax-highlighter/styles/prism/coy';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism-light';
+import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
+import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
+import coy from 'react-syntax-highlighter/dist/cjs/styles/prism/coy';
 
 const coyCustom = {
 	...coy,
@@ -24,8 +22,8 @@ const coyCustom = {
 	},
 };
 
-registerLanguage('jsx', jsx);
-registerLanguage('json', json);
+SyntaxHighlighter.registerLanguage('jsx', jsx);
+SyntaxHighlighter.registerLanguage('json', json);
 
 const compile = marksy({
 	createElement: React.createElement,

--- a/.storybook/lucid-docs-addon/register.tsx
+++ b/.storybook/lucid-docs-addon/register.tsx
@@ -27,7 +27,7 @@ class PropsPanel extends React.Component<any, any> {
 				props: JSON.parse(propsJSON || '{}'),
 			});
 		} catch (err) {
-			console.log('Error parsing props JSON.');
+			console.warn('Error parsing props JSON.');
 			console.error(err.stack);
 			this.setState({
 				props: null,
@@ -47,7 +47,7 @@ class PropsPanel extends React.Component<any, any> {
 				childComponents: JSON.parse(childComponentJSON),
 			});
 		} catch (err) {
-			console.log('Error parsing props JSON.');
+			console.warn('Error parsing props JSON.');
 			console.error(err.stack);
 			this.setState({
 				childComponents: null,

--- a/docs/index.stories.tsx
+++ b/docs/index.stories.tsx
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import { storiesOf } from '@storybook/react';
 import { exampleStory } from '../.storybook/lucid-docs-addon';
 import { stripIndent, formatSource } from '../.storybook/lucid-docs-addon/util';
-import { registerLanguage } from 'react-syntax-highlighter/prism-light';
-import jsx from 'react-syntax-highlighter/languages/prism/jsx';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism-light';
+import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
 import isChromatic from 'storybook-chromatic/isChromatic';
 
 import '../src/index.less';
@@ -15,7 +15,7 @@ if (!isChromatic()) {
 
 import './index.less'; // very minimal overrides
 
-registerLanguage('jsx', jsx);
+SyntaxHighlighter.registerLanguage('jsx', jsx);
 
 const examplePageOptions = { showPanel: true, panelPosition: 'right' };
 


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/cxp-2041-update-primaryLight/?path=/docs/documentation-intro--page)

- Manually tested across supported browsers

  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
