### PR TITLE
chore: add double chevron and pin icons

### DIFF
--- a/docs/icons/load-icons.ts
+++ b/docs/icons/load-icons.ts
@@ -898,6 +898,23 @@ export default [
 	},
 
 	{
+		name: 'MegaphoneIcon',
+		component: getDefaultExport(
+			require('../../src/components/Icon/MegaphoneIcon/MegaphoneIcon')
+		),
+		examplesContext: require.context(
+			'../../src/components/Icon/MegaphoneIcon/examples',
+			true,
+			/\.(j|t)sx?$/
+		),
+		examplesContextRaw: require.context(
+			'!!raw-loader!../../src/components/Icon/MegaphoneIcon/examples',
+			true,
+			/\.(j|t)sx?$/
+		),
+	},
+
+	{
 		name: 'MinimizeIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/MinimizeIcon/MinimizeIcon')

--- a/docs/icons/load-icons.ts
+++ b/docs/icons/load-icons.ts
@@ -415,6 +415,13 @@ export default [
 	},
 
 	{
+		name: 'DoubleChevronIcon',
+		component: getDefaultExport(
+			require('../../src/components/Icon/DoubleChevronIcon/DoubleChevronIcon')
+		),
+	},
+
+	{
 		name: 'DownloadIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/DownloadIcon/DownloadIcon')
@@ -891,23 +898,6 @@ export default [
 	},
 
 	{
-		name: 'MegaphoneIcon',
-		component: getDefaultExport(
-			require('../../src/components/Icon/MegaphoneIcon/MegaphoneIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/MegaphoneIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/MegaphoneIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-	},
-
-	{
 		name: 'MinimizeIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/MinimizeIcon/MinimizeIcon')
@@ -1006,6 +996,13 @@ export default [
 			'!!raw-loader!../../src/components/Icon/OutwardArrowsIcon/examples',
 			true,
 			/\.(j|t)sx?$/
+		),
+	},
+
+	{
+		name: 'PinIcon',
+		component: getDefaultExport(
+			require('../../src/components/Icon/PinIcon/PinIcon')
 		),
 	},
 

--- a/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.less
+++ b/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.less
@@ -1,0 +1,9 @@
+@import (reference) '../../../styles/variables.less';
+@import (reference) '../../../styles/mixins.less';
+
+.@{prefix}-DoubleChevronIcon {
+	&-is-down { transform: rotate(0deg); }
+	&-is-up { transform: rotate(180deg); }
+	&-is-left { transform: rotate(90deg); }
+	&-is-right { transform: rotate(270deg); }
+}

--- a/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.spec.tsx
+++ b/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { icons, common } from '../../../util/generic-tests';
+import assert from 'assert';
+
+import DoubleChevronIcon from './DoubleChevronIcon';
+
+describe('DoubleChevronIcon', () => {
+	common(DoubleChevronIcon);
+	icons(DoubleChevronIcon);
+
+	describe('`direction` prop', () => {
+		it('should render the correct icon with "up"', () => {
+			const wrapper = shallow(<DoubleChevronIcon direction='up' />);
+
+			assert.equal(wrapper.find('.lucid-DoubleChevronIcon-is-up').length, 1);
+		});
+
+		it('should render the correct icon with "down"', () => {
+			const wrapper = shallow(<DoubleChevronIcon direction='down' />);
+
+			assert.equal(wrapper.find('.lucid-DoubleChevronIcon-is-down').length, 1);
+		});
+
+		it('should render the correct icon with "left"', () => {
+			const wrapper = shallow(<DoubleChevronIcon direction='left' />);
+
+			assert.equal(wrapper.find('.lucid-DoubleChevronIcon-is-left').length, 1);
+		});
+
+		it('should render the correct icon with "right"', () => {
+			const wrapper = shallow(<DoubleChevronIcon direction='right' />);
+
+			assert.equal(wrapper.find('.lucid-DoubleChevronIcon-is-right').length, 1);
+		});
+	});
+});

--- a/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.stories.tsx
+++ b/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.stories.tsx
@@ -1,64 +1,11 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { IIconWithDirectionProps } from '../../../util/component-types';
+import { IIconWithDirectionProps } from '../Icon';
 import { DoubleChevronIcon } from './DoubleChevronIcon';
 
 export default {
 	title: 'Icons/Icons/DoubleChevronIcon',
 	component: DoubleChevronIcon,
-	argTypes: {
-		direction: {
-			name: 'direction',
-			description: 'direction variations of the icon',
-			defaultValue: 'down',
-			options: ['up', 'down', 'left', 'right'],
-			control: { type: 'radio' },
-			table: {
-				category: 'Orientation',
-				defaultValue: { summary: 'down' },
-			},
-		},
-		height: {
-			name: 'height',
-			description: 'adjust the height of the icon',
-			defaultValue: 16,
-			control: { type: 'range' },
-			table: {
-				category: 'Transformation',
-				defaultValue: { summary: '16px' },
-			},
-		},
-		width: {
-			name: 'width',
-			description: 'adjust the width of the icon',
-			defaultValue: 16,
-			control: { type: 'range' },
-			table: {
-				category: 'Transformation',
-				defaultValue: { summary: '16px' },
-			},
-		},
-		isClickable: {
-			name: 'isClickable',
-			description: 'control the ability to click the icon',
-			defaultValue: false,
-			control: { type: 'boolean' },
-			table: {
-				category: 'Controls',
-				defaultValue: { summary: false },
-			},
-		},
-		isDisabled: {
-			name: 'isDisabled',
-			description: 'control the ability to diable the icon',
-			defaultValue: false,
-			control: { type: 'boolean' },
-			table: {
-				category: 'Controls',
-				defaultValue: { summary: false },
-			},
-		},
-	},
 } as Meta;
 
 //👇 We create a “template” of how args map to rendering

--- a/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.stories.tsx
+++ b/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.stories.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconWithDirectionProps } from '../../../util/component-types';
+import { DoubleChevronIcon } from './DoubleChevronIcon';
+
+export default {
+	title: 'Icons/Icons/DoubleChevronIcon',
+	component: DoubleChevronIcon,
+	argTypes: {
+		direction: {
+			name: 'direction',
+			description: 'direction variations of the icon',
+			defaultValue: 'down',
+			options: ['up', 'down', 'left', 'right'],
+			control: { type: 'radio' },
+			table: {
+				category: 'Orientation',
+				defaultValue: { summary: 'down' },
+			},
+		},
+		height: {
+			name: 'height',
+			description: 'adjust the height of the icon',
+			defaultValue: 16,
+			control: { type: 'range' },
+			table: {
+				category: 'Transformation',
+				defaultValue: { summary: '16px' },
+			},
+		},
+		width: {
+			name: 'width',
+			description: 'adjust the width of the icon',
+			defaultValue: 16,
+			control: { type: 'range' },
+			table: {
+				category: 'Transformation',
+				defaultValue: { summary: '16px' },
+			},
+		},
+		isClickable: {
+			name: 'isClickable',
+			description: 'control the ability to click the icon',
+			defaultValue: false,
+			control: { type: 'boolean' },
+			table: {
+				category: 'Controls',
+				defaultValue: { summary: false },
+			},
+		},
+		isDisabled: {
+			name: 'isDisabled',
+			description: 'control the ability to diable the icon',
+			defaultValue: false,
+			control: { type: 'boolean' },
+			table: {
+				category: 'Controls',
+				defaultValue: { summary: false },
+			},
+		},
+	},
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconWithDirectionProps> = (args) => (
+	<DoubleChevronIcon {...args} />
+);
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.tsx
+++ b/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.tsx
@@ -1,0 +1,51 @@
+import _ from 'lodash';
+import React from 'react';
+import Icon, { propTypes as iconPropTypes } from '../Icon';
+import { lucidClassNames } from '../../../util/style-helpers';
+import {
+	IIconWithDirectionProps,
+	omitProps,
+} from '../../../util/component-types';
+
+const cx = lucidClassNames.bind('&-DoubleChevronIcon');
+
+export const DoubleChevronIcon = ({
+	className,
+	direction = 'down',
+	...passThroughs
+}: IIconWithDirectionProps) => {
+	return (
+		<Icon
+			{...omitProps(
+				passThroughs,
+				undefined,
+				_.keys(DoubleChevronIcon.propTypes),
+				false
+			)}
+			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			className={cx(
+				'&',
+				{
+					'&-is-down': direction === 'down',
+					'&-is-up': direction === 'up',
+					'&-is-left': direction === 'left',
+					'&-is-right': direction === 'right',
+				},
+				className
+			)}
+		>
+			<path d='M.5 1.5l7.5 7 7.5-7' />
+			<path d='M.5 7.5l7.5 7 7.5-7' />
+		</Icon>
+	);
+};
+
+DoubleChevronIcon.displayName = 'DoubleChevronIcon';
+
+DoubleChevronIcon.propTypes = {
+	...iconPropTypes,
+};
+
+DoubleChevronIcon.defaultProps = Icon.defaultProps;
+
+export default DoubleChevronIcon;

--- a/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.tsx
+++ b/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.tsx
@@ -1,13 +1,70 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconWithDirectionProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import {
-	IIconWithDirectionProps,
-	omitProps,
-} from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-DoubleChevronIcon');
+
+export const iconPropTypes = {
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
+
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Sets the direction of the Icon, where applicable. */
+	direction: PropTypes.oneOf(['up', 'down', 'left', 'right']),
+};
 
 export const DoubleChevronIcon = ({
 	className,
@@ -16,13 +73,7 @@ export const DoubleChevronIcon = ({
 }: IIconWithDirectionProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(DoubleChevronIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx(
 				'&',
 				{
@@ -42,9 +93,7 @@ export const DoubleChevronIcon = ({
 
 DoubleChevronIcon.displayName = 'DoubleChevronIcon';
 
-DoubleChevronIcon.propTypes = {
-	...iconPropTypes,
-};
+DoubleChevronIcon.propTypes = iconPropTypes;
 
 DoubleChevronIcon.defaultProps = Icon.defaultProps;
 

--- a/src/components/Icon/DoubleChevronIcon/__snapshots__/DoubleChevronIcon.spec.tsx.snap
+++ b/src/components/Icon/DoubleChevronIcon/__snapshots__/DoubleChevronIcon.spec.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DoubleChevronIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<DoubleChevronIcon
+  aspectRatio="xMidYMid meet"
+  color="primary"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  viewBox="0 0 16 16"
+/>
+`;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -211,6 +211,10 @@ export const propTypes = {
 	`,
 };
 
+export interface IIconWithDirectionProps extends IIconProps {
+	direction?: 'up' | 'down' | 'left' | 'right';
+}
+
 Icon.propTypes = propTypes;
 
 export default Icon;

--- a/src/components/Icon/PinIcon/PinIcon.less
+++ b/src/components/Icon/PinIcon/PinIcon.less
@@ -1,0 +1,7 @@
+@import (reference) '../../../styles/variables.less';
+@import (reference) '../../../styles/mixins.less';
+
+.@{prefix}-PinIcon {
+	&-is-left { transform: scaleX(-1);}
+	&-is-right { transform: scaleX(1); }
+}

--- a/src/components/Icon/PinIcon/PinIcon.spec.tsx
+++ b/src/components/Icon/PinIcon/PinIcon.spec.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { icons, common } from '../../../util/generic-tests';
+import assert from 'assert';
+
+import PinIcon from './PinIcon';
+
+describe('PinIcon', () => {
+	common(PinIcon);
+	icons(PinIcon);
+
+	describe('`direction` prop', () => {
+		it('should render the correct icon with "left"', () => {
+			const wrapper = shallow(<PinIcon direction='left' />);
+
+			assert.equal(wrapper.find('.lucid-PinIcon-is-left').length, 1);
+		});
+
+		it('should render the correct icon with "right"', () => {
+			const wrapper = shallow(<PinIcon direction='right' />);
+
+			assert.equal(wrapper.find('.lucid-PinIcon-is-right').length, 1);
+		});
+	});
+});

--- a/src/components/Icon/PinIcon/PinIcon.stories.tsx
+++ b/src/components/Icon/PinIcon/PinIcon.stories.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconWithDirectionProps } from '../../../util/component-types';
+import { PinIcon } from './PinIcon';
+
+export default {
+	title: 'Icons/Icons/PinIcon',
+	component: PinIcon,
+	argTypes: {
+		direction: {
+			name: 'direction',
+			description: 'direction variations of the icon',
+			defaultValue: 'right',
+			options: ['left', 'right'],
+			control: { type: 'radio' },
+			table: {
+				category: 'Orientation',
+				defaultValue: { summary: 'right' },
+			},
+		},
+
+		height: {
+			name: 'height',
+			description: 'adjust the height of the icon',
+			defaultValue: 16,
+			control: { type: 'range' },
+			table: {
+				category: 'Transformation',
+				defaultValue: { summary: '16px' },
+			},
+		},
+		width: {
+			name: 'width',
+			description: 'adjust the width of the icon',
+			defaultValue: 16,
+			control: { type: 'range' },
+			table: {
+				category: 'Transformation',
+				defaultValue: { summary: '16px' },
+			},
+		},
+		isClickable: {
+			name: 'isClickable',
+			description: 'control the ability to click the icon',
+			defaultValue: false,
+			control: { type: 'boolean' },
+			table: {
+				category: 'Controls',
+				defaultValue: { summary: false },
+			},
+		},
+		isDisabled: {
+			name: 'isDisabled',
+			description: 'control the ability to diable the icon',
+			defaultValue: false,
+			control: { type: 'boolean' },
+			table: {
+				category: 'Controls',
+				defaultValue: { summary: false },
+			},
+		},
+	},
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconWithDirectionProps> = (args) => (
+	<PinIcon {...args} />
+);
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/PinIcon/PinIcon.stories.tsx
+++ b/src/components/Icon/PinIcon/PinIcon.stories.tsx
@@ -1,65 +1,11 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { IIconWithDirectionProps } from '../../../util/component-types';
+import { IIconWithDirectionProps } from '../Icon';
 import { PinIcon } from './PinIcon';
 
 export default {
 	title: 'Icons/Icons/PinIcon',
 	component: PinIcon,
-	argTypes: {
-		direction: {
-			name: 'direction',
-			description: 'direction variations of the icon',
-			defaultValue: 'right',
-			options: ['left', 'right'],
-			control: { type: 'radio' },
-			table: {
-				category: 'Orientation',
-				defaultValue: { summary: 'right' },
-			},
-		},
-
-		height: {
-			name: 'height',
-			description: 'adjust the height of the icon',
-			defaultValue: 16,
-			control: { type: 'range' },
-			table: {
-				category: 'Transformation',
-				defaultValue: { summary: '16px' },
-			},
-		},
-		width: {
-			name: 'width',
-			description: 'adjust the width of the icon',
-			defaultValue: 16,
-			control: { type: 'range' },
-			table: {
-				category: 'Transformation',
-				defaultValue: { summary: '16px' },
-			},
-		},
-		isClickable: {
-			name: 'isClickable',
-			description: 'control the ability to click the icon',
-			defaultValue: false,
-			control: { type: 'boolean' },
-			table: {
-				category: 'Controls',
-				defaultValue: { summary: false },
-			},
-		},
-		isDisabled: {
-			name: 'isDisabled',
-			description: 'control the ability to diable the icon',
-			defaultValue: false,
-			control: { type: 'boolean' },
-			table: {
-				category: 'Controls',
-				defaultValue: { summary: false },
-			},
-		},
-	},
 } as Meta;
 
 //👇 We create a “template” of how args map to rendering

--- a/src/components/Icon/PinIcon/PinIcon.tsx
+++ b/src/components/Icon/PinIcon/PinIcon.tsx
@@ -1,13 +1,70 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconWithDirectionProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import {
-	IIconWithDirectionProps,
-	omitProps,
-} from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-PinIcon');
+
+export const iconPropTypes = {
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
+
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Sets the direction of the Icon, where applicable. */
+	direction: PropTypes.oneOf(['left', 'right']),
+};
 
 export const PinIcon = ({
 	className,
@@ -16,8 +73,7 @@ export const PinIcon = ({
 }: IIconWithDirectionProps) => {
 	return (
 		<Icon
-			{...omitProps(passThroughs, undefined, _.keys(PinIcon.propTypes), false)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx(
 				'&',
 				{
@@ -34,10 +90,8 @@ export const PinIcon = ({
 
 PinIcon.displayName = 'PinIcon';
 
-PinIcon.propTypes = {
-	...iconPropTypes,
-};
-
 PinIcon.defaultProps = Icon.defaultProps;
+
+PinIcon.propTypes = iconPropTypes;
 
 export default PinIcon;

--- a/src/components/Icon/PinIcon/PinIcon.tsx
+++ b/src/components/Icon/PinIcon/PinIcon.tsx
@@ -1,0 +1,43 @@
+import _ from 'lodash';
+import React from 'react';
+import Icon, { propTypes as iconPropTypes } from '../Icon';
+import { lucidClassNames } from '../../../util/style-helpers';
+import {
+	IIconWithDirectionProps,
+	omitProps,
+} from '../../../util/component-types';
+
+const cx = lucidClassNames.bind('&-PinIcon');
+
+export const PinIcon = ({
+	className,
+	direction = 'right',
+	...passThroughs
+}: IIconWithDirectionProps) => {
+	return (
+		<Icon
+			{...omitProps(passThroughs, undefined, _.keys(PinIcon.propTypes), false)}
+			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			className={cx(
+				'&',
+				{
+					'&-is-left': direction === 'left',
+					'&-is-right': direction === 'right',
+				},
+				className
+			)}
+		>
+			<path d='M4.811.5l1.66 1.659-.731.731 3.169 2.03 1.709-.57 2.85 1.709-7.409 7.409-1.709-2.85.57-1.709L2.89 5.74l-.731.731L.5 4.811zM10 10l5.5 5.5' />
+		</Icon>
+	);
+};
+
+PinIcon.displayName = 'PinIcon';
+
+PinIcon.propTypes = {
+	...iconPropTypes,
+};
+
+PinIcon.defaultProps = Icon.defaultProps;
+
+export default PinIcon;

--- a/src/components/Icon/PinIcon/__snapshots__/PinIcon.spec.tsx.snap
+++ b/src/components/Icon/PinIcon/__snapshots__/PinIcon.spec.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PinIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<PinIcon
+  aspectRatio="xMidYMid meet"
+  color="primary"
+  isClickable={false}
+  isDisabled={false}
+  onClick={[Function]}
+  onSelect={[Function]}
+  size={16}
+  viewBox="0 0 16 16"
+/>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ import DangerLightIcon from './components/Icon/DangerLightIcon/DangerLightIcon';
 import DataTable from './components/DataTable/DataTable';
 import DeleteIcon from './components/Icon/DeleteIcon/DeleteIcon';
 import DotsIcon from './components/Icon/DotsIcon/DotsIcon';
+import DoubleChevronIcon from './components/Icon/DoubleChevronIcon/DoubleChevronIcon';
 import Dialog from './components/Dialog/Dialog';
 import DownloadIcon from './components/Icon/DownloadIcon/DownloadIcon';
 import DragCaptureZone from './components/DragCaptureZone/DragCaptureZone';
@@ -151,6 +152,7 @@ import OutwardArrowsIcon from './components/Icon/OutwardArrowsIcon/OutwardArrows
 import Overlay from './components/Overlay/Overlay';
 import OverlayWrapper from './components/OverlayWrapper/OverlayWrapper';
 import Panel from './components/Panel/Panel';
+import PinIcon from './components/Icon/PinIcon/PinIcon';
 import PlusIcon from './components/Icon/PlusIcon/PlusIcon';
 import Point from './components/Point/Point';
 import Points from './components/Points/Points';
@@ -293,6 +295,7 @@ export {
 	DeleteIcon,
 	Dialog,
 	DotsIcon,
+	DoubleChevronIcon,
 	DownloadIcon,
 	DragCaptureZone,
 	DraggableLineChart,
@@ -358,6 +361,7 @@ export {
 	Panel,
 	PieChart,
 	PieChartDumb,
+	PinIcon,
 	PlusIcon,
 	Point,
 	Points,

--- a/src/styles/components.less
+++ b/src/styles/components.less
@@ -33,6 +33,7 @@
 @import '../components/Icon/DangerIcon/DangerIcon';
 @import '../components/Icon/DangerLightIcon/DangerLightIcon';
 @import '../components/Icon/DotsIcon/DotsIcon';
+@import '../components/Icon/DoubleChevronIcon/DoubleChevronIcon';
 @import '../components/Icon/EligibilityIcon/EligibilityIcon';
 @import '../components/Icon/EligibilityLightIcon/EligibilityLightIcon';
 @import '../components/Icon/InfoIcon/InfoIcon';
@@ -41,6 +42,7 @@
 @import '../components/Icon/LoadingIcon/LoadingIcon';
 @import '../components/Icon/MinusCircleIcon/MinusCircleIcon';
 @import '../components/Icon/MinusCircleLightIcon/MinusCircleLightIcon';
+@import '../components/Icon/PinIcon/PinIcon';
 @import '../components/Icon/StarIcon/StarIcon';
 @import '../components/Icon/SuccessIcon/SuccessIcon';
 @import '../components/Icon/SuccessLightIcon/SuccessLightIcon';

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -7,6 +7,7 @@ import {
 	omitFunctionPropsDeep,
 } from './state-management';
 import { ValidationMap } from 'prop-types';
+import { IIconProps } from '../../src/components/Icon/Icon';
 
 export interface StandardProps {
 	/** Appended to the component-specific class names set on the root element.
@@ -304,3 +305,7 @@ export function omitProps<P extends object>(
 		_.keys(component.propTypes).concat(keys).concat(additionalOmittedKeys)
 	);
 }
+
+export type IIconWithDirectionProps = IIconProps & {
+	direction?: 'up' | 'down' | 'left' | 'right';
+};

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -305,7 +305,3 @@ export function omitProps<P extends object>(
 		_.keys(component.propTypes).concat(keys).concat(additionalOmittedKeys)
 	);
 }
-
-export type IIconWithDirectionProps = IIconProps & {
-	direction?: 'up' | 'down' | 'left' | 'right';
-};


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/CXP-2163-Add-Icons-Lucid/?path=/docs/documentation-intro--page)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
