### PR TITLE
refactor: update T, U, V and W icons to SB6

### DIFF
--- a/docs/icons/load-icons.ts
+++ b/docs/icons/load-icons.ts
@@ -1264,32 +1264,12 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/TableIcon/TableIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/TableIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/TableIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 
 	{
 		name: 'TextIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/TextIcon/TextIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/TextIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/TextIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 
@@ -1298,31 +1278,11 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/TicketIcon/TicketIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/TicketIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/TicketIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 	{
 		name: 'UnlinkedIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/UnlinkedIcon/UnlinkedIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/UnlinkedIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/UnlinkedIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 
@@ -1331,32 +1291,12 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/UnlockedIcon/UnlockedIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/UnlockedIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/UnlockedIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 
 	{
 		name: 'UploadIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/UploadIcon/UploadIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/UploadIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/UploadIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 
@@ -1365,32 +1305,12 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/UserIcon/UserIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/UserIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/UserIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 
 	{
 		name: 'VideoIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/VideoIcon/VideoIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/VideoIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/VideoIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 
@@ -1399,32 +1319,12 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/VideoLiveIcon/VideoLiveIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/VideoLiveIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/VideoLiveIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 
 	{
 		name: 'VideoLongIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/VideoLongIcon/VideoLongIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/VideoLongIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/VideoLongIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 
@@ -1433,32 +1333,12 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/VideoOnDemandIcon/VideoOnDemandIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/VideoOnDemandIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/VideoOnDemandIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 
 	{
 		name: 'VideoShortIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/VideoShortIcon/VideoShortIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/VideoShortIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/VideoShortIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 
@@ -1467,32 +1347,12 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/ViewIcon/ViewIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/ViewIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/ViewIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 
 	{
 		name: 'ViewTableIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/ViewTableIcon/ViewTableIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/ViewTableIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/ViewTableIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 
@@ -1501,16 +1361,6 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/WarningIcon/WarningIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/WarningIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/WarningIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 
 	{
@@ -1518,31 +1368,11 @@ export default [
 		component: getDefaultExport(
 			require('../../src/components/Icon/WarningLightIcon/WarningLightIcon')
 		),
-		examplesContext: require.context(
-			'../../src/components/Icon/WarningLightIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/WarningLightIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
 	},
 	{
 		name: 'WrenchIcon',
 		component: getDefaultExport(
 			require('../../src/components/Icon/WrenchIcon/WrenchIcon')
-		),
-		examplesContext: require.context(
-			'../../src/components/Icon/WrenchIcon/examples',
-			true,
-			/\.(j|t)sx?$/
-		),
-		examplesContextRaw: require.context(
-			'!!raw-loader!../../src/components/Icon/WrenchIcon/examples',
-			true,
-			/\.(j|t)sx?$/
 		),
 	},
 ];

--- a/src/components/Icon/TableIcon/TableIcon.stories.tsx
+++ b/src/components/Icon/TableIcon/TableIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { TableIcon } from './TableIcon';
+
+export default {
+	title: 'Icons/Icons/TableIcon',
+	component: TableIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <TableIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/TableIcon/TableIcon.tsx
+++ b/src/components/Icon/TableIcon/TableIcon.tsx
@@ -1,23 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-TableIcon');
 
-interface ITableIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const TableIcon = ({ className, ...passThroughs }: ITableIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const TableIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(TableIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(TableIcon.propTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path
@@ -33,15 +82,9 @@ export const TableIcon = ({ className, ...passThroughs }: ITableIconProps) => {
 };
 
 TableIcon.displayName = 'TableIcon';
-TableIcon.peek = {
-	description: `
-		An icon with columns, rows and a header row - a table icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 TableIcon.propTypes = iconPropTypes;
+
 TableIcon.defaultProps = Icon.defaultProps;
 
 export default TableIcon;

--- a/src/components/Icon/TableIcon/__snapshots__/TableIcon.spec.tsx.snap
+++ b/src/components/Icon/TableIcon/__snapshots__/TableIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`TableIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<TableIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-TableIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,16 +10,5 @@ exports[`TableIcon [common] example testing should match snapshot(s) for 1.basic
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M.5.5h15v15H.5z"
-    fill="none"
-    strokeLinecap="square"
-    strokeMiterlimit="10"
-    strokeWidth="1.3"
-  />
-  <path
-    d="M15.5 4.5H.5M15.5 10H.5M5.5 4.5v11M10.5 4.5v11"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/TableIcon/examples/1.basic.tsx
+++ b/src/components/Icon/TableIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { TableIcon } from '../../../../index';
-
-export default () => <TableIcon />;

--- a/src/components/Icon/TextIcon/TextIcon.stories.tsx
+++ b/src/components/Icon/TextIcon/TextIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { TextIcon } from './TextIcon';
+
+export default {
+	title: 'Icons/Icons/TextIcon',
+	component: TextIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <TextIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/TextIcon/TextIcon.tsx
+++ b/src/components/Icon/TextIcon/TextIcon.tsx
@@ -1,18 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-TextIcon');
 
-interface ITextIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const TextIcon = ({ className, ...passThroughs }: ITextIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const TextIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(passThroughs, undefined, _.keys(TextIcon.propTypes), false)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M.5 2.5v-2h15v2' />
@@ -23,15 +77,9 @@ export const TextIcon = ({ className, ...passThroughs }: ITextIconProps) => {
 };
 
 TextIcon.displayName = 'TextIcon';
-TextIcon.peek = {
-	description: `
-		A text icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 TextIcon.propTypes = iconPropTypes;
+
 TextIcon.defaultProps = Icon.defaultProps;
 
 export default TextIcon;

--- a/src/components/Icon/TextIcon/__snapshots__/TextIcon.spec.tsx.snap
+++ b/src/components/Icon/TextIcon/__snapshots__/TextIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`TextIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<TextIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-TextIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,15 +10,5 @@ exports[`TextIcon [common] example testing should match snapshot(s) for 1.basic 
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M.5 2.5v-2h15v2"
-  />
-  <path
-    d="M8 15.5V.5"
-  />
-  <path
-    d="M4.5 15.5h7"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/TextIcon/examples/1.basic.tsx
+++ b/src/components/Icon/TextIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { TextIcon } from '../../../../index';
-
-export default () => <TextIcon />;

--- a/src/components/Icon/TicketIcon/TicketIcon.stories.tsx
+++ b/src/components/Icon/TicketIcon/TicketIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { TicketIcon } from './TicketIcon';
+
+export default {
+	title: 'Icons/Icons/TicketIcon',
+	component: TicketIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <TicketIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/TicketIcon/TicketIcon.tsx
+++ b/src/components/Icon/TicketIcon/TicketIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-TicketIcon');
 
-interface ITicketIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const TicketIcon = ({
-	className,
-	...passThroughs
-}: ITicketIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const TicketIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(TicketIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(TicketIcon.propTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M13.5 8c0-1.105.895-2 2-2V2.5H.5V6c1.105 0 2 .895 2 2s-.895 2-2 2v3.5h15V10c-1.105 0-2-.895-2-2zM8 2.5v1M8 13.5v-1M8 6.7v-.6M8 9.883v-.6' />
@@ -29,15 +75,9 @@ export const TicketIcon = ({
 };
 
 TicketIcon.displayName = 'TicketIcon';
-TicketIcon.peek = {
-	description: `
-		A ticket icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 TicketIcon.propTypes = iconPropTypes;
+
 TicketIcon.defaultProps = Icon.defaultProps;
 
 export default TicketIcon;

--- a/src/components/Icon/TicketIcon/__snapshots__/TicketIcon.spec.tsx.snap
+++ b/src/components/Icon/TicketIcon/__snapshots__/TicketIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TicketIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`TicketIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<TicketIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-TicketIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,9 +10,5 @@ exports[`TicketIcon [common] example testing should match snapshot(s) for 1.basi
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M13.5 8c0-1.105.895-2 2-2V2.5H.5V6c1.105 0 2 .895 2 2s-.895 2-2 2v3.5h15V10c-1.105 0-2-.895-2-2zM8 2.5v1M8 13.5v-1M8 6.7v-.6M8 9.883v-.6"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/TicketIcon/examples/1.basic.tsx
+++ b/src/components/Icon/TicketIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { TicketIcon } from '../../../../index';
-
-export default () => <TicketIcon />;

--- a/src/components/Icon/UnlinkedIcon/UnlinkedIcon.stories.tsx
+++ b/src/components/Icon/UnlinkedIcon/UnlinkedIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { UnlinkedIcon } from './UnlinkedIcon';
+
+export default {
+	title: 'Icons/Icons/UnlinkedIcon',
+	component: UnlinkedIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <UnlinkedIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/UnlinkedIcon/UnlinkedIcon.tsx
+++ b/src/components/Icon/UnlinkedIcon/UnlinkedIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-UnlinkedIcon');
 
-interface IUnlinkedIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const UnlinkedIcon = ({
-	className,
-	...passThroughs
-}: IUnlinkedIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const UnlinkedIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(UnlinkedIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M5.5 3.5l-1-2m8 9l2 1m-4 1l1 2m-8-9l-2-1' />
@@ -30,15 +76,9 @@ export const UnlinkedIcon = ({
 };
 
 UnlinkedIcon.displayName = 'UnlinkedIcon';
-UnlinkedIcon.peek = {
-	description: `
-		For all those times you just need to break away.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 UnlinkedIcon.propTypes = iconPropTypes;
+
 UnlinkedIcon.defaultProps = Icon.defaultProps;
 
 export default UnlinkedIcon;

--- a/src/components/Icon/UnlinkedIcon/__snapshots__/UnlinkedIcon.spec.tsx.snap
+++ b/src/components/Icon/UnlinkedIcon/__snapshots__/UnlinkedIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UnlinkedIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`UnlinkedIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<UnlinkedIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-UnlinkedIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,12 +10,5 @@ exports[`UnlinkedIcon [common] example testing should match snapshot(s) for 1.ba
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M5.5 3.5l-1-2m8 9l2 1m-4 1l1 2m-8-9l-2-1"
-  />
-  <path
-    d="M10.232 7.768a2.993 2.993 0 0 0 2.979-.737l1.414-1.414a3.009 3.009 0 0 0 0-4.243 3.009 3.009 0 0 0-4.243 0L8.968 2.789c-.804.804-1.04 1.956-.737 2.979M5.769 8.231c-1.023-.303-2.176-.067-2.98.737l-1.414 1.414a3.009 3.009 0 0 0 0 4.243 3.009 3.009 0 0 0 4.243 0l1.414-1.414c.804-.804 1.04-1.956.737-2.979"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/UnlinkedIcon/examples/1.basic.tsx
+++ b/src/components/Icon/UnlinkedIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { UnlinkedIcon } from '../../../../index';
-
-export default () => <UnlinkedIcon />;

--- a/src/components/Icon/UnlockedIcon/UnlockedIcon.stories.tsx
+++ b/src/components/Icon/UnlockedIcon/UnlockedIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { UnlockedIcon } from './UnlockedIcon';
+
+export default {
+	title: 'Icons/Icons/UnlockedIcon',
+	component: UnlockedIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <UnlockedIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/UnlockedIcon/UnlockedIcon.tsx
+++ b/src/components/Icon/UnlockedIcon/UnlockedIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-UnlockedIcon');
 
-interface IUnlockedIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const UnlockedIcon = ({
-	className,
-	...passThroughs
-}: IUnlockedIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const UnlockedIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(UnlockedIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M1.5 6.5h13v9h-13zm2 0V5a4.5 4.5 0 0 1 8.741-1.508M7.99 13.293v-3' />
@@ -30,15 +76,9 @@ export const UnlockedIcon = ({
 };
 
 UnlockedIcon.displayName = 'UnlockedIcon';
-UnlockedIcon.peek = {
-	description: `
-		Unlock it.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 UnlockedIcon.propTypes = iconPropTypes;
+
 UnlockedIcon.defaultProps = Icon.defaultProps;
 
 export default UnlockedIcon;

--- a/src/components/Icon/UnlockedIcon/__snapshots__/UnlockedIcon.spec.tsx.snap
+++ b/src/components/Icon/UnlockedIcon/__snapshots__/UnlockedIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UnlockedIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`UnlockedIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<UnlockedIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-UnlockedIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,14 +10,5 @@ exports[`UnlockedIcon [common] example testing should match snapshot(s) for 1.ba
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M1.5 6.5h13v9h-13zm2 0V5a4.5 4.5 0 0 1 8.741-1.508M7.99 13.293v-3"
-  />
-  <circle
-    cx="8"
-    cy="10"
-    r=".5"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/UnlockedIcon/examples/1.basic.tsx
+++ b/src/components/Icon/UnlockedIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { UnlockedIcon } from '../../../../index';
-
-export default () => <UnlockedIcon />;

--- a/src/components/Icon/UploadIcon/UploadIcon.stories.tsx
+++ b/src/components/Icon/UploadIcon/UploadIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { UploadIcon } from './UploadIcon';
+
+export default {
+	title: 'Icons/Icons/UploadIcon',
+	component: UploadIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <UploadIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/UploadIcon/UploadIcon.tsx
+++ b/src/components/Icon/UploadIcon/UploadIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-UploadIcon');
 
-interface IUploadIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const UploadIcon = ({
-	className,
-	...passThroughs
-}: IUploadIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const UploadIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(UploadIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M8 12V.5m5 5l-5-5-5 5' />
@@ -30,15 +76,9 @@ export const UploadIcon = ({
 };
 
 UploadIcon.displayName = 'UploadIcon';
-UploadIcon.peek = {
-	description: `
-		Upload files
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 UploadIcon.propTypes = iconPropTypes;
+
 UploadIcon.defaultProps = Icon.defaultProps;
 
 export default UploadIcon;

--- a/src/components/Icon/UploadIcon/__snapshots__/UploadIcon.spec.tsx.snap
+++ b/src/components/Icon/UploadIcon/__snapshots__/UploadIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UploadIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`UploadIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<UploadIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-UploadIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,12 +10,5 @@ exports[`UploadIcon [common] example testing should match snapshot(s) for 1.basi
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M8 12V.5m5 5l-5-5-5 5"
-  />
-  <path
-    d="M.5 13.5v2h15v-2"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/UploadIcon/examples/1.basic.tsx
+++ b/src/components/Icon/UploadIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { UploadIcon } from '../../../../index';
-
-export default () => <UploadIcon />;

--- a/src/components/Icon/UserIcon/UserIcon.stories.tsx
+++ b/src/components/Icon/UserIcon/UserIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { UserIcon } from './UserIcon';
+
+export default {
+	title: 'Icons/Icons/UserIcon',
+	component: UserIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <UserIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/UserIcon/UserIcon.tsx
+++ b/src/components/Icon/UserIcon/UserIcon.tsx
@@ -1,18 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-UserIcon');
 
-interface IUserIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const UserIcon = ({ className, ...passThroughs }: IUserIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const UserIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(passThroughs, undefined, _.keys(UserIcon.propTypes), false)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M.5 16a7.5 7.5 0 0 1 15 0' />
@@ -22,15 +76,9 @@ export const UserIcon = ({ className, ...passThroughs }: IUserIconProps) => {
 };
 
 UserIcon.displayName = 'UserIcon';
-UserIcon.peek = {
-	description: `
-		It's all about you.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 UserIcon.propTypes = iconPropTypes;
+
 UserIcon.defaultProps = Icon.defaultProps;
 
 export default UserIcon;

--- a/src/components/Icon/UserIcon/__snapshots__/UserIcon.spec.tsx.snap
+++ b/src/components/Icon/UserIcon/__snapshots__/UserIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`UserIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<UserIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-UserIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,14 +10,5 @@ exports[`UserIcon [common] example testing should match snapshot(s) for 1.basic 
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M.5 16a7.5 7.5 0 0 1 15 0"
-  />
-  <circle
-    cx="8"
-    cy="4.5"
-    r="4"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/UserIcon/examples/1.basic.tsx
+++ b/src/components/Icon/UserIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { UserIcon } from '../../../../index';
-
-export default () => <UserIcon />;

--- a/src/components/Icon/VideoIcon/VideoIcon.stories.tsx
+++ b/src/components/Icon/VideoIcon/VideoIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { VideoIcon } from './VideoIcon';
+
+export default {
+	title: 'Icons/Icons/VideoIcon',
+	component: VideoIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <VideoIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/VideoIcon/VideoIcon.tsx
+++ b/src/components/Icon/VideoIcon/VideoIcon.tsx
@@ -1,23 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-VideoIcon');
 
-interface IVideoIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const VideoIcon = ({ className, ...passThroughs }: IVideoIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const VideoIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(VideoIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<circle cx='8' cy='8' r='7.5' />
@@ -27,15 +76,9 @@ export const VideoIcon = ({ className, ...passThroughs }: IVideoIconProps) => {
 };
 
 VideoIcon.displayName = 'VideoIcon';
-VideoIcon.peek = {
-	description: `
-		A video icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 VideoIcon.propTypes = iconPropTypes;
+
 VideoIcon.defaultProps = Icon.defaultProps;
 
 export default VideoIcon;

--- a/src/components/Icon/VideoIcon/__snapshots__/VideoIcon.spec.tsx.snap
+++ b/src/components/Icon/VideoIcon/__snapshots__/VideoIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VideoIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`VideoIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<VideoIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-VideoIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,14 +10,5 @@ exports[`VideoIcon [common] example testing should match snapshot(s) for 1.basic
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <circle
-    cx="8"
-    cy="8"
-    r="7.5"
-  />
-  <path
-    d="M6.25 5v6l4.5-3z"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/VideoIcon/examples/1.basic.tsx
+++ b/src/components/Icon/VideoIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { VideoIcon } from '../../../../index';
-
-export default () => <VideoIcon />;

--- a/src/components/Icon/VideoLiveIcon/VideoLiveIcon.stories.tsx
+++ b/src/components/Icon/VideoLiveIcon/VideoLiveIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { VideoLiveIcon } from './VideoLiveIcon';
+
+export default {
+	title: 'Icons/Icons/VideoLiveIcon',
+	component: VideoLiveIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <VideoLiveIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/VideoLiveIcon/VideoLiveIcon.tsx
+++ b/src/components/Icon/VideoLiveIcon/VideoLiveIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-VideoLiveIcon');
 
-interface IVideoLiveIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const VideoLiveIcon = ({
-	className,
-	...passThroughs
-}: IVideoLiveIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const VideoLiveIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(VideoLiveIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M2.697 13.303a7.5 7.5 0 010-10.607M13.303 2.697a7.5 7.5 0 010 10.607M11.536 4.465a5 5 0 010 7.071M4.464 11.536a5 5 0 010-7.071M7.188 6.25v3.5L9.812 8z' />
@@ -29,15 +75,9 @@ export const VideoLiveIcon = ({
 };
 
 VideoLiveIcon.displayName = 'VideoLiveIcon';
-VideoLiveIcon.peek = {
-	description: `
-		A video live icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 VideoLiveIcon.propTypes = iconPropTypes;
+
 VideoLiveIcon.defaultProps = Icon.defaultProps;
 
 export default VideoLiveIcon;

--- a/src/components/Icon/VideoLiveIcon/__snapshots__/VideoLiveIcon.spec.tsx.snap
+++ b/src/components/Icon/VideoLiveIcon/__snapshots__/VideoLiveIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VideoLiveIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`VideoLiveIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<VideoLiveIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-VideoLiveIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,9 +10,5 @@ exports[`VideoLiveIcon [common] example testing should match snapshot(s) for 1.b
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M2.697 13.303a7.5 7.5 0 010-10.607M13.303 2.697a7.5 7.5 0 010 10.607M11.536 4.465a5 5 0 010 7.071M4.464 11.536a5 5 0 010-7.071M7.188 6.25v3.5L9.812 8z"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/VideoLiveIcon/examples/1.basic.tsx
+++ b/src/components/Icon/VideoLiveIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { VideoLiveIcon } from '../../../../index';
-
-export default () => <VideoLiveIcon />;

--- a/src/components/Icon/VideoLongIcon/VideoLongIcon.stories.tsx
+++ b/src/components/Icon/VideoLongIcon/VideoLongIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { VideoLongIcon } from './VideoLongIcon';
+
+export default {
+	title: 'Icons/Icons/VideoLongIcon',
+	component: VideoLongIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <VideoLongIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/VideoLongIcon/VideoLongIcon.tsx
+++ b/src/components/Icon/VideoLongIcon/VideoLongIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-VideoLongIcon');
 
-interface IVideoLongIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const VideoLongIcon = ({
-	className,
-	...passThroughs
-}: IVideoLongIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const VideoLongIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(VideoLongIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M6.5 4v5l3.75-2.5zM15.5 12.5H.5' />
@@ -33,15 +79,9 @@ export const VideoLongIcon = ({
 };
 
 VideoLongIcon.displayName = 'VideoLongIcon';
-VideoLongIcon.peek = {
-	description: `
-		A video long icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 VideoLongIcon.propTypes = iconPropTypes;
+
 VideoLongIcon.defaultProps = Icon.defaultProps;
 
 export default VideoLongIcon;

--- a/src/components/Icon/VideoLongIcon/__snapshots__/VideoLongIcon.spec.tsx.snap
+++ b/src/components/Icon/VideoLongIcon/__snapshots__/VideoLongIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VideoLongIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`VideoLongIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<VideoLongIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-VideoLongIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,13 +10,5 @@ exports[`VideoLongIcon [common] example testing should match snapshot(s) for 1.b
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M6.5 4v5l3.75-2.5zM15.5 12.5H.5"
-  />
-  <path
-    d="M.5.5h15v15H.5zM2 15.5l3-3M.5 14L2 12.5M5 15.5l3-3M8 15.5l3-3M11 15.5l3-3M14 15.5l1.5-1.5"
-    strokeLinecap="butt"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/VideoLongIcon/examples/1.basic.tsx
+++ b/src/components/Icon/VideoLongIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { VideoLongIcon } from '../../../../index';
-
-export default () => <VideoLongIcon />;

--- a/src/components/Icon/VideoOnDemandIcon/VideoOnDemandIcon.stories.tsx
+++ b/src/components/Icon/VideoOnDemandIcon/VideoOnDemandIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { VideoOnDemandIcon } from './VideoOnDemandIcon';
+
+export default {
+	title: 'Icons/Icons/VideoOnDemandIcon',
+	component: VideoOnDemandIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <VideoOnDemandIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/VideoOnDemandIcon/VideoOnDemandIcon.tsx
+++ b/src/components/Icon/VideoOnDemandIcon/VideoOnDemandIcon.tsx
@@ -1,26 +1,75 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-VideoOnDemandIcon');
 
-interface IVideoOnDemandIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
+
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
 
 export const VideoOnDemandIcon = ({
 	className,
 	...passThroughs
-}: IVideoOnDemandIconProps) => {
+}: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(VideoOnDemandIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M7.188 6.5V10l2.625-1.75z' />
@@ -30,15 +79,9 @@ export const VideoOnDemandIcon = ({
 };
 
 VideoOnDemandIcon.displayName = 'VideoOnDemandIcon';
-VideoOnDemandIcon.peek = {
-	description: `
-		A video on demand (VOD) icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 VideoOnDemandIcon.propTypes = iconPropTypes;
+
 VideoOnDemandIcon.defaultProps = Icon.defaultProps;
 
 export default VideoOnDemandIcon;

--- a/src/components/Icon/VideoOnDemandIcon/__snapshots__/VideoOnDemandIcon.spec.tsx.snap
+++ b/src/components/Icon/VideoOnDemandIcon/__snapshots__/VideoOnDemandIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VideoOnDemandIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`VideoOnDemandIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<VideoOnDemandIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-VideoOnDemandIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,12 +10,5 @@ exports[`VideoOnDemandIcon [common] example testing should match snapshot(s) for
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M7.188 6.5V10l2.625-1.75z"
-  />
-  <path
-    d="M12.256 6.01a4.515 4.515 0 00-8.742.989C1.857 6.999.5 8.343.5 10s1.343 3 3 3H12a3.5 3.5 0 003.5-3.5 3.508 3.508 0 00-3.244-3.49z"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/VideoOnDemandIcon/examples/1.basic.tsx
+++ b/src/components/Icon/VideoOnDemandIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { VideoOnDemandIcon } from '../../../../index';
-
-export default () => <VideoOnDemandIcon />;

--- a/src/components/Icon/VideoShortIcon/VideoShortIcon.stories.tsx
+++ b/src/components/Icon/VideoShortIcon/VideoShortIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { VideoShortIcon } from './VideoShortIcon';
+
+export default {
+	title: 'Icons/Icons/VideoShortIcon',
+	component: VideoShortIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <VideoShortIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/VideoShortIcon/VideoShortIcon.tsx
+++ b/src/components/Icon/VideoShortIcon/VideoShortIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-VideoShortIcon');
 
-interface IVideoShortIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const VideoShortIcon = ({
-	className,
-	...passThroughs
-}: IVideoShortIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const VideoShortIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(VideoShortIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M6.5 4v5l3.75-2.5zM15.5 12.5H.5' />
@@ -33,15 +79,9 @@ export const VideoShortIcon = ({
 };
 
 VideoShortIcon.displayName = 'VideoShortIcon';
-VideoShortIcon.peek = {
-	description: `
-		A video short icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 VideoShortIcon.propTypes = iconPropTypes;
+
 VideoShortIcon.defaultProps = Icon.defaultProps;
 
 export default VideoShortIcon;

--- a/src/components/Icon/VideoShortIcon/__snapshots__/VideoShortIcon.spec.tsx.snap
+++ b/src/components/Icon/VideoShortIcon/__snapshots__/VideoShortIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VideoShortIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`VideoShortIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<VideoShortIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-VideoShortIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,13 +10,5 @@ exports[`VideoShortIcon [common] example testing should match snapshot(s) for 1.
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M6.5 4v5l3.75-2.5zM15.5 12.5H.5"
-  />
-  <path
-    d="M.5.5h15v15H.5zM8 12.5v3M2 15.5l3-3M.5 14L2 12.5M5 15.5l3-3"
-    strokeLinecap="butt"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/VideoShortIcon/examples/1.basic.tsx
+++ b/src/components/Icon/VideoShortIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { VideoShortIcon } from '../../../../index';
-
-export default () => <VideoShortIcon />;

--- a/src/components/Icon/ViewIcon/ViewIcon.stories.tsx
+++ b/src/components/Icon/ViewIcon/ViewIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { ViewIcon } from './ViewIcon';
+
+export default {
+	title: 'Icons/Icons/ViewIcon',
+	component: ViewIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <ViewIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/ViewIcon/ViewIcon.tsx
+++ b/src/components/Icon/ViewIcon/ViewIcon.tsx
@@ -1,18 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-ViewIcon');
 
-interface IViewIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const ViewIcon = ({ className, ...passThroughs }: IViewIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const ViewIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(passThroughs, undefined, _.keys(ViewIcon.propTypes), false)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M15.5 8s-3-4.5-7.5-4.5S.5 8 .5 8 4 12.5 8 12.5 15.5 8 15.5 8z' />
@@ -22,16 +76,9 @@ export const ViewIcon = ({ className, ...passThroughs }: IViewIconProps) => {
 };
 
 ViewIcon.displayName = 'ViewIcon';
-ViewIcon.peek = {
-	description: `
-		This icon is pretty generic and should be used a last case resort to
-		another icon that's more descriptive.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 ViewIcon.propTypes = iconPropTypes;
+
 ViewIcon.defaultProps = Icon.defaultProps;
 
 export default ViewIcon;

--- a/src/components/Icon/ViewIcon/__snapshots__/ViewIcon.spec.tsx.snap
+++ b/src/components/Icon/ViewIcon/__snapshots__/ViewIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ViewIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`ViewIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<ViewIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-ViewIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,14 +10,5 @@ exports[`ViewIcon [common] example testing should match snapshot(s) for 1.basic 
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M15.5 8s-3-4.5-7.5-4.5S.5 8 .5 8 4 12.5 8 12.5 15.5 8 15.5 8z"
-  />
-  <circle
-    cx="8"
-    cy="8"
-    r="1.25"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/ViewIcon/examples/1.basic.tsx
+++ b/src/components/Icon/ViewIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { ViewIcon } from '../../../../index';
-
-export default () => <ViewIcon />;

--- a/src/components/Icon/ViewTableIcon/ViewTableIcon.stories.tsx
+++ b/src/components/Icon/ViewTableIcon/ViewTableIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { ViewTableIcon } from './ViewTableIcon';
+
+export default {
+	title: 'Icons/Icons/ViewTableIcon',
+	component: ViewTableIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <ViewTableIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/ViewTableIcon/ViewTableIcon.tsx
+++ b/src/components/Icon/ViewTableIcon/ViewTableIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-ViewTableIcon');
 
-interface IViewTableIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const ViewTableIcon = ({
-	className,
-	...passThroughs
-}: IViewTableIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const ViewTableIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(ViewTableIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M7.25 13.5h8.25' />
@@ -31,15 +77,9 @@ export const ViewTableIcon = ({
 };
 
 ViewTableIcon.displayName = 'ViewTableIcon';
-ViewTableIcon.peek = {
-	description: `
-		Would you just look at it?!
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 ViewTableIcon.propTypes = iconPropTypes;
+
 ViewTableIcon.defaultProps = Icon.defaultProps;
 
 export default ViewTableIcon;

--- a/src/components/Icon/ViewTableIcon/__snapshots__/ViewTableIcon.spec.tsx.snap
+++ b/src/components/Icon/ViewTableIcon/__snapshots__/ViewTableIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ViewTableIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`ViewTableIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<ViewTableIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-ViewTableIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,15 +10,5 @@ exports[`ViewTableIcon [common] example testing should match snapshot(s) for 1.b
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M7.25 13.5h8.25"
-  />
-  <path
-    d="M13.5 15.5l2-2-2-2m2-3v-8H.5v13h4"
-  />
-  <path
-    d="M15.5 4.5H.5"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/ViewTableIcon/examples/1.basic.tsx
+++ b/src/components/Icon/ViewTableIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { ViewTableIcon } from '../../../../index';
-
-export default () => <ViewTableIcon />;

--- a/src/components/Icon/WarningIcon/WarningIcon.stories.tsx
+++ b/src/components/Icon/WarningIcon/WarningIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { WarningIcon } from './WarningIcon';
+
+export default {
+	title: 'Icons/Icons/WarningIcon',
+	component: WarningIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <WarningIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/WarningIcon/WarningIcon.tsx
+++ b/src/components/Icon/WarningIcon/WarningIcon.tsx
@@ -1,28 +1,63 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-WarningIcon');
 
-interface IWarningIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
+
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
 
 export const WarningIcon = ({
 	className,
 	isClickable,
 	isDisabled,
 	...passThroughs
-}: IWarningIconProps) => {
+}: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(WarningIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState', 'color'])}
 			isClickable={isClickable}
 			isDisabled={isDisabled}
 			className={cx(
@@ -40,15 +75,9 @@ export const WarningIcon = ({
 };
 
 WarningIcon.displayName = 'WarningIcon';
-WarningIcon.peek = {
-	description: `
-		A warning Icon.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 WarningIcon.propTypes = iconPropTypes;
+
 WarningIcon.defaultProps = Icon.defaultProps;
 
 export default WarningIcon;

--- a/src/components/Icon/WarningIcon/__snapshots__/WarningIcon.spec.tsx.snap
+++ b/src/components/Icon/WarningIcon/__snapshots__/WarningIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WarningIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`WarningIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<WarningIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-WarningIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,20 +10,5 @@ exports[`WarningIcon [common] example testing should match snapshot(s) for 1.bas
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    className="lucid-WarningIcon-background"
-    d="M.5 15h15L8 .5z"
-  />
-  <path
-    className="lucid-WarningIcon-mark"
-    d="M7.99 5v4"
-  />
-  <circle
-    className="lucid-WarningIcon-mark"
-    cx="7.99"
-    cy="12"
-    r=".293"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/WarningIcon/examples/1.basic.tsx
+++ b/src/components/Icon/WarningIcon/examples/1.basic.tsx
@@ -1,4 +1,0 @@
-import React from 'react';
-import { WarningIcon } from '../../../../index';
-
-export default () => <WarningIcon />;

--- a/src/components/Icon/WrenchIcon/WrenchIcon.stories.tsx
+++ b/src/components/Icon/WrenchIcon/WrenchIcon.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { IIconProps } from '../Icon';
+import { WrenchIcon } from './WrenchIcon';
+
+export default {
+	title: 'Icons/Icons/WrenchIcon',
+	component: WrenchIcon,
+} as Meta;
+
+//👇 We create a “template” of how args map to rendering
+const Template: Story<IIconProps> = (args) => <WrenchIcon {...args} />;
+
+//👇 Each story then reuses that template
+export const Primary = Template.bind({});

--- a/src/components/Icon/WrenchIcon/WrenchIcon.tsx
+++ b/src/components/Icon/WrenchIcon/WrenchIcon.tsx
@@ -1,26 +1,72 @@
 import _ from 'lodash';
 import React from 'react';
-import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
+import PropTypes from 'prop-types';
+import Icon, { IIconProps } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-WrenchIcon');
 
-interface IWrenchIconProps extends IIconProps {}
+export const iconPropTypes = {
+	/** Size variations of the icons. \`size\` directly effects height and width
+		but the developer should also be conscious of the relationship with
+		\`viewBox\`. */
+	size: PropTypes.number,
 
-export const WrenchIcon = ({
-	className,
-	...passThroughs
-}: IWrenchIconProps) => {
+	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
+	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** Size handles width and height, whereas \`height\` can manually override the height that would be set by size. */
+	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+	/** \`viewBox\` is very important for SVGs. You can think of \`viewBox\` as
+		the "artboard" for our SVG while \`size\` is the presented height and
+		width. */
+	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+	]),
+
+	/** Any valid SVG aspect ratio. */
+	aspectRatio: PropTypes.string,
+
+	/** Adds styling that makes the icon appear clickable. */
+	isClickable: PropTypes.bool,
+
+	/** Adds styling that makes the icon appear disabled.  Also forces
+		isClickable to be false. */
+	isDisabled: PropTypes.bool,
+
+	/** Called when the user clicks the \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onClick: PropTypes.func,
+
+	/** Called when the user clicks an active, clickable \`Icon\`. Signature:
+		\`({event, props}) => {}\` */
+	onSelect: PropTypes.func,
+
+	/** Any valid React children. */
+	children: PropTypes.element,
+
+	/** Classes that are appended to the component defaults. This prop is run
+		through the \`classnames\` library. */
+	className: PropTypes.string,
+};
+
+export const WrenchIcon = ({ className, ...passThroughs }: IIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(WrenchIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{..._.omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M15.18 4.728l-2.576 1.451-1.844-1.075-.01-2.134 2.577-1.451.003-.367c-1.368-.826-3.134-.899-4.611-.029C7.014 2.127 6.203 4.145 6.625 6.01l-5.427 5.427c-.93.93-.93 2.439 0 3.369.93.93 2.439.93 3.369 0l5.422-5.422c1.072.248 2.236.107 3.264-.486 1.471-.85 2.247-2.419 2.247-3.989l-.32-.181z' />
@@ -30,15 +76,9 @@ export const WrenchIcon = ({
 };
 
 WrenchIcon.displayName = 'WrenchIcon';
-WrenchIcon.peek = {
-	description: `
-		A wrench icon, used for indicating something you forcibly pull, twist, turn or jerk.
-	`,
-	categories: ['visual design', 'icons'],
-	extend: 'Icon',
-	madeFrom: ['Icon'],
-};
+
 WrenchIcon.propTypes = iconPropTypes;
+
 WrenchIcon.defaultProps = Icon.defaultProps;
 
 export default WrenchIcon;

--- a/src/components/Icon/WrenchIcon/__snapshots__/WrenchIcon.spec.tsx.snap
+++ b/src/components/Icon/WrenchIcon/__snapshots__/WrenchIcon.spec.tsx.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WrenchIcon [common] example testing should match snapshot(s) for 1.basic 1`] = `
-<Icon
+exports[`WrenchIcon [common] example testing should match snapshot(s) for Primary 1`] = `
+<WrenchIcon
   aspectRatio="xMidYMid meet"
-  className="lucid-WrenchIcon"
   color="primary"
   isClickable={false}
   isDisabled={false}
@@ -11,14 +10,5 @@ exports[`WrenchIcon [common] example testing should match snapshot(s) for 1.basi
   onSelect={[Function]}
   size={16}
   viewBox="0 0 16 16"
->
-  <path
-    d="M15.18 4.728l-2.576 1.451-1.844-1.075-.01-2.134 2.577-1.451.003-.367c-1.368-.826-3.134-.899-4.611-.029C7.014 2.127 6.203 4.145 6.625 6.01l-5.427 5.427c-.93.93-.93 2.439 0 3.369.93.93 2.439.93 3.369 0l5.422-5.422c1.072.248 2.236.107 3.264-.486 1.471-.85 2.247-2.419 2.247-3.989l-.32-.181z"
-  />
-  <circle
-    cx="2.864"
-    cy="13.144"
-    r=".25"
-  />
-</Icon>
+/>
 `;

--- a/src/components/Icon/WrenchIcon/examples/1.basic.tsx
+++ b/src/components/Icon/WrenchIcon/examples/1.basic.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import createClass from 'create-react-class';
-import { WrenchIcon } from '../../../../index';
-
-export default createClass({
-	render() {
-		return <WrenchIcon />;
-	},
-});


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/CXP-2164-Update-Icons-SB6-Part-7/?path=/docs/documentation-intro--page)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

* PR Updates T, U, V and W icons to StoryBook 6 format. Completes icon conversion to SB6
