### PR TITLE
remove `npm start` reference from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ First of all, thank you for contributing. It’s appreciated.
 
 4. Below are some important commands for developing. Don't commit before fixing all errors and warnings.
 
-- `npm start` runs the docs page and watches for changes
 - `npm run dev` starts a blank storybook sandbox for quick, iterative development
 - `npm run watch` runs tests and watches for changes, optimized for speed
 


### PR DESCRIPTION
Looks like the `start` script got removed a couple years ago... https://github.com/appnexus/lucid/commit/549452a501fb622dd767ba3049a5e734f0bce6e5

## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari

(N/A - only markdown changes)

- [ ] Unit tests written (`common` at minimum) - N/A (only markdown changes)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
