### PR TITLE
Bugfix/TARG-917: Prevent user from pressing enter on SearchableMultiSelect component

### DIFF
--- a/src/components/DateSelect/__snapshots__/DateSelect.spec.tsx.snap
+++ b/src/components/DateSelect/__snapshots__/DateSelect.spec.tsx.snap
@@ -53,475 +53,6 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      December 2021
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
-                    >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Sun
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mon
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tue
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          Wed
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Thu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fri
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sat
-                        </abbr>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--tuesday DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 01 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 02 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 03 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 04 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 06 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 07 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 08 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 09 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 10 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 11 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 13 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 14 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 15 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 16 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 17 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 18 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 20 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 21 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 22 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 23 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 24 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 25 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 27 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 28 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 29 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 30 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 31 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
-          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
-        >
-          <div
-            class="lucid-DateSelect-slide-content"
-          >
-            <div
-              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
-              lang="en"
-              role="application"
-            >
-              <div
-                class="DayPicker-wrapper"
-                tabindex="-1"
-              >
-                <div
-                  class="DayPicker-Month"
-                  role="grid"
-                >
-                  <div
-                    class="DayPicker-Caption"
-                    role="heading"
-                  >
-                    <div>
                       January 2022
                     </div>
                   </div>
@@ -1475,7 +1006,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      September 2021
+                      March 2022
                     </div>
                   </div>
                   <div
@@ -1575,14 +1106,10 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
                       <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--tuesday DayPicker-Day--outside"
-                      />
-                      <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 01 2021"
+                        aria-label="Tue Mar 01 2022"
                         aria-selected="false"
-                        class="DayPicker-Day"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
                         role="gridcell"
                         tabindex="0"
                       >
@@ -1590,7 +1117,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 02 2021"
+                        aria-label="Wed Mar 02 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1600,7 +1127,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 03 2021"
+                        aria-label="Thu Mar 03 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1610,13 +1137,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 04 2021"
+                        aria-label="Fri Mar 04 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         4
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 05 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
                       </div>
                     </div>
                     <div
@@ -1625,17 +1162,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 06 2021"
+                        aria-label="Sun Mar 06 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1645,9 +1172,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 07 2021"
+                        aria-label="Mon Mar 07 2022"
                         aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1655,9 +1182,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 08 2021"
+                        aria-label="Tue Mar 08 2022"
                         aria-selected="false"
-                        class="DayPicker-Day"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1665,7 +1192,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 09 2021"
+                        aria-label="Wed Mar 09 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1675,7 +1202,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 10 2021"
+                        aria-label="Thu Mar 10 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1685,13 +1212,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 11 2021"
+                        aria-label="Fri Mar 11 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         11
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 12 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
                       </div>
                     </div>
                     <div
@@ -1700,17 +1237,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 13 2021"
+                        aria-label="Sun Mar 13 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1720,9 +1247,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 14 2021"
+                        aria-label="Mon Mar 14 2022"
                         aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1730,9 +1257,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 15 2021"
+                        aria-label="Tue Mar 15 2022"
                         aria-selected="false"
-                        class="DayPicker-Day"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1740,7 +1267,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 16 2021"
+                        aria-label="Wed Mar 16 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1750,7 +1277,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 17 2021"
+                        aria-label="Thu Mar 17 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1760,13 +1287,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 18 2021"
+                        aria-label="Fri Mar 18 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         18
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 19 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
                       </div>
                     </div>
                     <div
@@ -1775,17 +1312,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 20 2021"
+                        aria-label="Sun Mar 20 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1795,9 +1322,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 21 2021"
+                        aria-label="Mon Mar 21 2022"
                         aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1805,9 +1332,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 22 2021"
+                        aria-label="Tue Mar 22 2022"
                         aria-selected="false"
-                        class="DayPicker-Day"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1815,7 +1342,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 23 2021"
+                        aria-label="Wed Mar 23 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1825,7 +1352,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 24 2021"
+                        aria-label="Thu Mar 24 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1835,13 +1362,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 25 2021"
+                        aria-label="Fri Mar 25 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         25
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 26 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
                       </div>
                     </div>
                     <div
@@ -1850,17 +1387,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 27 2021"
+                        aria-label="Sun Mar 27 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -1870,9 +1397,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 28 2021"
+                        aria-label="Mon Mar 28 2022"
                         aria-selected="false"
-                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1880,9 +1407,9 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 29 2021"
+                        aria-label="Tue Mar 29 2022"
                         aria-selected="false"
-                        class="DayPicker-Day"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
                         role="gridcell"
                         tabindex="-1"
                       >
@@ -1890,13 +1417,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 30 2021"
+                        aria-label="Wed Mar 30 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Mar 31 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
                       </div>
                       <div
                         aria-disabled="true"
@@ -2878,6 +2415,475 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
             </div>
           </div>
         </div>
+        <div
+          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
+          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
+        >
+          <div
+            class="lucid-DateSelect-slide-content"
+          >
+            <div
+              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
+              lang="en"
+              role="application"
+            >
+              <div
+                class="DayPicker-wrapper"
+                tabindex="-1"
+              >
+                <div
+                  class="DayPicker-Month"
+                  role="grid"
+                >
+                  <div
+                    class="DayPicker-Caption"
+                    role="heading"
+                  >
+                    <div>
+                      December 2021
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Weekdays"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-WeekdaysRow"
+                      role="row"
+                    >
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Sunday"
+                        >
+                          Sun
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Monday"
+                        >
+                          Mon
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Tuesday"
+                        >
+                          Tue
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Wednesday"
+                        >
+                          Wed
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Thursday"
+                        >
+                          Thu
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Friday"
+                        >
+                          Fri
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Saturday"
+                        >
+                          Sat
+                        </abbr>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Body"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--tuesday DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 01 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="0"
+                      >
+                        1
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 02 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        2
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 03 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        3
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 04 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        4
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 05 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 06 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        6
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 07 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        7
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 08 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        8
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 09 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        9
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 10 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        10
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 11 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        11
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 12 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 13 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        13
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 14 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        14
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 15 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        15
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 16 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        16
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 17 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        17
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 18 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        18
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 19 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 20 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        20
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 21 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        21
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 22 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        22
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 23 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        23
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 24 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        24
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 25 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        25
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 26 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 27 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        27
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 28 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day DayPicker-Day--tuesday"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        28
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 29 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        29
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 30 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 31 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
+                      </div>
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div>
@@ -2921,474 +2927,6 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
     <div
       class="lucid-DateSelect-slidePanel lucid-DateSelect-slidePanel-simple"
     >
-      <div
-        class="lucid-DateSelect-slide lucid-DateSelect-slide-simple"
-      >
-        <div
-          class="lucid-DateSelect-slide-content"
-        >
-          <div
-            class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
-            lang="en"
-            role="application"
-          >
-            <div
-              class="DayPicker-wrapper"
-              tabindex="-1"
-            >
-              <div
-                class="DayPicker-Month"
-                role="grid"
-              >
-                <div
-                  class="DayPicker-Caption"
-                  role="heading"
-                >
-                  <div>
-                    December 2021
-                  </div>
-                </div>
-                <div
-                  class="DayPicker-Weekdays"
-                  role="rowgroup"
-                >
-                  <div
-                    class="DayPicker-WeekdaysRow"
-                    role="row"
-                  >
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Sunday"
-                      >
-                        Sun
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Monday"
-                      >
-                        Mon
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Tuesday"
-                      >
-                        Tue
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Wednesday"
-                      >
-                        Wed
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Thursday"
-                      >
-                        Thu
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Friday"
-                      >
-                        Fri
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Saturday"
-                      >
-                        Sat
-                      </abbr>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="DayPicker-Body"
-                  role="rowgroup"
-                >
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 01 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="0"
-                    >
-                      1
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 02 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      2
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 03 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      3
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 04 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      4
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 05 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      5
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 06 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      6
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 07 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      7
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 08 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      8
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 09 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      9
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 10 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      10
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 11 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      11
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 12 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      12
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 13 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      13
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 14 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      14
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 15 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      15
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 16 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      16
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 17 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      17
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 18 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      18
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 19 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      19
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 20 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      20
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 21 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      21
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 22 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      22
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 23 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      23
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 24 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      24
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 25 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      25
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 26 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      26
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 27 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      27
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 28 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      28
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 29 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      29
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 30 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      30
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 31 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      31
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
       <div
         class="lucid-DateSelect-slide lucid-DateSelect-slide-simple"
       >
@@ -3890,6 +3428,456 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
           </div>
         </div>
       </div>
+      <div
+        class="lucid-DateSelect-slide lucid-DateSelect-slide-simple"
+      >
+        <div
+          class="lucid-DateSelect-slide-content"
+        >
+          <div
+            class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
+            lang="en"
+            role="application"
+          >
+            <div
+              class="DayPicker-wrapper"
+              tabindex="-1"
+            >
+              <div
+                class="DayPicker-Month"
+                role="grid"
+              >
+                <div
+                  class="DayPicker-Caption"
+                  role="heading"
+                >
+                  <div>
+                    February 2022
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Weekdays"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-WeekdaysRow"
+                    role="row"
+                  >
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Sunday"
+                      >
+                        Sun
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Monday"
+                      >
+                        Mon
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Tuesday"
+                      >
+                        Tue
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Wednesday"
+                      >
+                        Wed
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Thursday"
+                      >
+                        Thu
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Friday"
+                      >
+                        Fri
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Saturday"
+                      >
+                        Sat
+                      </abbr>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Body"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Feb 01 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="0"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Feb 02 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Feb 03 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      3
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Feb 04 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Feb 05 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      5
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Feb 06 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      6
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Feb 07 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      7
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Feb 08 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      8
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Feb 09 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      9
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Feb 10 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      10
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Feb 11 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      11
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Feb 12 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      12
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Feb 13 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      13
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Feb 14 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      14
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Feb 15 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      15
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Feb 16 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      16
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Feb 17 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      17
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Feb 18 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      18
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Feb 19 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      19
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Feb 20 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      20
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Feb 21 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      21
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Feb 22 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      22
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Feb 23 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      23
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Feb 24 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      24
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Feb 25 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      25
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Feb 26 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      26
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Feb 27 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      27
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Feb 28 2022"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      28
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <div>
       <svg
@@ -3939,475 +3927,6 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
       >
         <div
           class="lucid-SlidePanel-Slide lucid-InfiniteSlidePanel-Slide-in-frame lucid-DateSelect-slide"
-          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
-        >
-          <div
-            class="lucid-DateSelect-slide-content"
-          >
-            <div
-              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
-              lang="en"
-              role="application"
-            >
-              <div
-                class="DayPicker-wrapper"
-                tabindex="-1"
-              >
-                <div
-                  class="DayPicker-Month"
-                  role="grid"
-                >
-                  <div
-                    class="DayPicker-Caption"
-                    role="heading"
-                  >
-                    <div>
-                      December 2021
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
-                    >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Sun
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mon
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tue
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          Wed
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Thu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fri
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sat
-                        </abbr>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 01 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 02 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 03 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 04 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 06 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 07 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 08 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 09 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 10 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 11 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 13 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 14 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 15 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 16 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 17 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 18 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 20 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 21 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 22 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 23 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 24 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 25 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 27 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 28 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 29 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 30 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 31 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
           style="flex-grow:1;flex-shrink:0;flex-basis:100%"
         >
           <div
@@ -5384,7 +4903,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      September 2021
+                      March 2022
                     </div>
                   </div>
                   <div
@@ -5484,12 +5003,8 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
                       <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 01 2021"
+                        aria-label="Tue Mar 01 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5499,7 +5014,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 02 2021"
+                        aria-label="Wed Mar 02 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5509,7 +5024,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 03 2021"
+                        aria-label="Thu Mar 03 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5519,13 +5034,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 04 2021"
+                        aria-label="Fri Mar 04 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         4
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 05 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
                       </div>
                     </div>
                     <div
@@ -5534,17 +5059,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 06 2021"
+                        aria-label="Sun Mar 06 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5554,7 +5069,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 07 2021"
+                        aria-label="Mon Mar 07 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5564,7 +5079,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 08 2021"
+                        aria-label="Tue Mar 08 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5574,7 +5089,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 09 2021"
+                        aria-label="Wed Mar 09 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5584,7 +5099,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 10 2021"
+                        aria-label="Thu Mar 10 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5594,13 +5109,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 11 2021"
+                        aria-label="Fri Mar 11 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         11
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 12 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
                       </div>
                     </div>
                     <div
@@ -5609,17 +5134,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 13 2021"
+                        aria-label="Sun Mar 13 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5629,7 +5144,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 14 2021"
+                        aria-label="Mon Mar 14 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5639,7 +5154,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 15 2021"
+                        aria-label="Tue Mar 15 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5649,7 +5164,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 16 2021"
+                        aria-label="Wed Mar 16 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5659,7 +5174,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 17 2021"
+                        aria-label="Thu Mar 17 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5669,13 +5184,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 18 2021"
+                        aria-label="Fri Mar 18 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         18
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 19 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
                       </div>
                     </div>
                     <div
@@ -5684,17 +5209,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 20 2021"
+                        aria-label="Sun Mar 20 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5704,7 +5219,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 21 2021"
+                        aria-label="Mon Mar 21 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5714,7 +5229,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 22 2021"
+                        aria-label="Tue Mar 22 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5724,7 +5239,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 23 2021"
+                        aria-label="Wed Mar 23 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5734,7 +5249,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 24 2021"
+                        aria-label="Thu Mar 24 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5744,13 +5259,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 25 2021"
+                        aria-label="Fri Mar 25 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         25
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 26 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
                       </div>
                     </div>
                     <div
@@ -5759,17 +5284,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 27 2021"
+                        aria-label="Sun Mar 27 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5779,7 +5294,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 28 2021"
+                        aria-label="Mon Mar 28 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5789,7 +5304,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 29 2021"
+                        aria-label="Tue Mar 29 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -5799,13 +5314,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 30 2021"
+                        aria-label="Wed Mar 30 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Mar 31 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
                       </div>
                       <div
                         aria-disabled="true"
@@ -6776,6 +6301,475 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
+          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
+        >
+          <div
+            class="lucid-DateSelect-slide-content"
+          >
+            <div
+              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
+              lang="en"
+              role="application"
+            >
+              <div
+                class="DayPicker-wrapper"
+                tabindex="-1"
+              >
+                <div
+                  class="DayPicker-Month"
+                  role="grid"
+                >
+                  <div
+                    class="DayPicker-Caption"
+                    role="heading"
+                  >
+                    <div>
+                      December 2021
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Weekdays"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-WeekdaysRow"
+                      role="row"
+                    >
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Sunday"
+                        >
+                          Sun
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Monday"
+                        >
+                          Mon
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Tuesday"
+                        >
+                          Tue
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Wednesday"
+                        >
+                          Wed
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Thursday"
+                        >
+                          Thu
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Friday"
+                        >
+                          Fri
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Saturday"
+                        >
+                          Sat
+                        </abbr>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Body"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 01 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="0"
+                      >
+                        1
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 02 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        2
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 03 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        3
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 04 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        4
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 05 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 06 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        6
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 07 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        7
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 08 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        8
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 09 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        9
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 10 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        10
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 11 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        11
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 12 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 13 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        13
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 14 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        14
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 15 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        15
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 16 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        16
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 17 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        17
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 18 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        18
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 19 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 20 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        20
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 21 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        21
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 22 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        22
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 23 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        23
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 24 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        24
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 25 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        25
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 26 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 27 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        27
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 28 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        28
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 29 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        29
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 30 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 31 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
+                      </div>
                       <div
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"
@@ -9726,475 +9720,6 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                   role="heading"
                 >
                   <div>
-                    December 2021
-                  </div>
-                </div>
-                <div
-                  class="DayPicker-Weekdays"
-                  role="rowgroup"
-                >
-                  <div
-                    class="DayPicker-WeekdaysRow"
-                    role="row"
-                  >
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Sunday"
-                      >
-                        Sun
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Monday"
-                      >
-                        Mon
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Tuesday"
-                      >
-                        Tue
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Wednesday"
-                      >
-                        Wed
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Thursday"
-                      >
-                        Thu
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Friday"
-                      >
-                        Fri
-                      </abbr>
-                    </div>
-                    <div
-                      class="DayPicker-Weekday"
-                      role="columnheader"
-                    >
-                      <abbr
-                        title="Saturday"
-                      >
-                        Sat
-                      </abbr>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="DayPicker-Body"
-                  role="rowgroup"
-                >
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 01 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="0"
-                    >
-                      1
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 02 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      2
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 03 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      3
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 04 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      4
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 05 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      5
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 06 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      6
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 07 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      7
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 08 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      8
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 09 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      9
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 10 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      10
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 11 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      11
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 12 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      12
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 13 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      13
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 14 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      14
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 15 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      15
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 16 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      16
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 17 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      17
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 18 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      18
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 19 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      19
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 20 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      20
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 21 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      21
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 22 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      22
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 23 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      23
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 24 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      24
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sat Dec 25 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      25
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Week"
-                    role="row"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Sun Dec 26 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      26
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Mon Dec 27 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      27
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Tue Dec 28 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      28
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Wed Dec 29 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      29
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Thu Dec 30 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      30
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Fri Dec 31 2021"
-                      aria-selected="false"
-                      class="DayPicker-Day"
-                      role="gridcell"
-                      tabindex="-1"
-                    >
-                      31
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      class="DayPicker-Day DayPicker-Day--outside"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="lucid-SlidePanel-Slide lucid-InfiniteSlidePanel-Slide-in-frame lucid-DateSelect-slide"
-        style="flex-grow:1;flex-shrink:0;flex-basis:33.333333333333336%"
-      >
-        <div
-          class="lucid-DateSelect-slide-content"
-        >
-          <div
-            class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
-            lang="en"
-            role="application"
-          >
-            <div
-              class="DayPicker-wrapper"
-              tabindex="-1"
-            >
-              <div
-                class="DayPicker-Month"
-                role="grid"
-              >
-                <div
-                  class="DayPicker-Caption"
-                  role="heading"
-                >
-                  <div>
                     January 2022
                   </div>
                 </div>
@@ -11124,7 +10649,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
         </div>
       </div>
       <div
-        class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
+        class="lucid-SlidePanel-Slide lucid-InfiniteSlidePanel-Slide-in-frame lucid-DateSelect-slide"
         style="flex-grow:1;flex-shrink:0;flex-basis:33.333333333333336%"
       >
         <div
@@ -12080,7 +11605,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                   role="heading"
                 >
                   <div>
-                    August 2021
+                    May 2022
                   </div>
                 </div>
                 <div
@@ -12173,7 +11698,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                   >
                     <div
                       aria-disabled="false"
-                      aria-label="Sun Aug 01 2021"
+                      aria-label="Sun May 01 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12183,7 +11708,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Mon Aug 02 2021"
+                      aria-label="Mon May 02 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12193,7 +11718,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Tue Aug 03 2021"
+                      aria-label="Tue May 03 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12203,7 +11728,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Wed Aug 04 2021"
+                      aria-label="Wed May 04 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12213,7 +11738,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Thu Aug 05 2021"
+                      aria-label="Thu May 05 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12223,7 +11748,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Fri Aug 06 2021"
+                      aria-label="Fri May 06 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12233,7 +11758,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Sat Aug 07 2021"
+                      aria-label="Sat May 07 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12248,7 +11773,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                   >
                     <div
                       aria-disabled="false"
-                      aria-label="Sun Aug 08 2021"
+                      aria-label="Sun May 08 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12258,7 +11783,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Mon Aug 09 2021"
+                      aria-label="Mon May 09 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12268,7 +11793,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Tue Aug 10 2021"
+                      aria-label="Tue May 10 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12278,7 +11803,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Wed Aug 11 2021"
+                      aria-label="Wed May 11 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12288,7 +11813,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Thu Aug 12 2021"
+                      aria-label="Thu May 12 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12298,7 +11823,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Fri Aug 13 2021"
+                      aria-label="Fri May 13 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12308,7 +11833,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Sat Aug 14 2021"
+                      aria-label="Sat May 14 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12323,7 +11848,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                   >
                     <div
                       aria-disabled="false"
-                      aria-label="Sun Aug 15 2021"
+                      aria-label="Sun May 15 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12333,7 +11858,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Mon Aug 16 2021"
+                      aria-label="Mon May 16 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12343,7 +11868,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Tue Aug 17 2021"
+                      aria-label="Tue May 17 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12353,7 +11878,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Wed Aug 18 2021"
+                      aria-label="Wed May 18 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12363,7 +11888,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Thu Aug 19 2021"
+                      aria-label="Thu May 19 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12373,7 +11898,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Fri Aug 20 2021"
+                      aria-label="Fri May 20 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12383,7 +11908,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Sat Aug 21 2021"
+                      aria-label="Sat May 21 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12398,7 +11923,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                   >
                     <div
                       aria-disabled="false"
-                      aria-label="Sun Aug 22 2021"
+                      aria-label="Sun May 22 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12408,7 +11933,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Mon Aug 23 2021"
+                      aria-label="Mon May 23 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12418,7 +11943,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Tue Aug 24 2021"
+                      aria-label="Tue May 24 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12428,7 +11953,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Wed Aug 25 2021"
+                      aria-label="Wed May 25 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12438,7 +11963,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Thu Aug 26 2021"
+                      aria-label="Thu May 26 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12448,7 +11973,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Fri Aug 27 2021"
+                      aria-label="Fri May 27 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12458,7 +11983,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Sat Aug 28 2021"
+                      aria-label="Sat May 28 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12473,7 +11998,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                   >
                     <div
                       aria-disabled="false"
-                      aria-label="Sun Aug 29 2021"
+                      aria-label="Sun May 29 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12483,7 +12008,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Mon Aug 30 2021"
+                      aria-label="Mon May 30 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -12493,7 +12018,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     </div>
                     <div
                       aria-disabled="false"
-                      aria-label="Tue Aug 31 2021"
+                      aria-label="Tue May 31 2022"
                       aria-selected="false"
                       class="DayPicker-Day"
                       role="gridcell"
@@ -13952,6 +13477,475 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
           </div>
         </div>
       </div>
+      <div
+        class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
+        style="flex-grow:1;flex-shrink:0;flex-basis:33.333333333333336%"
+      >
+        <div
+          class="lucid-DateSelect-slide-content"
+        >
+          <div
+            class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
+            lang="en"
+            role="application"
+          >
+            <div
+              class="DayPicker-wrapper"
+              tabindex="-1"
+            >
+              <div
+                class="DayPicker-Month"
+                role="grid"
+              >
+                <div
+                  class="DayPicker-Caption"
+                  role="heading"
+                >
+                  <div>
+                    December 2021
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Weekdays"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-WeekdaysRow"
+                    role="row"
+                  >
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Sunday"
+                      >
+                        Sun
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Monday"
+                      >
+                        Mon
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Tuesday"
+                      >
+                        Tue
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Wednesday"
+                      >
+                        Wed
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Thursday"
+                      >
+                        Thu
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Friday"
+                      >
+                        Fri
+                      </abbr>
+                    </div>
+                    <div
+                      class="DayPicker-Weekday"
+                      role="columnheader"
+                    >
+                      <abbr
+                        title="Saturday"
+                      >
+                        Sat
+                      </abbr>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="DayPicker-Body"
+                  role="rowgroup"
+                >
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Dec 01 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="0"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Dec 02 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      2
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Dec 03 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      3
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Dec 04 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      4
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Dec 05 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      5
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Dec 06 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      6
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Dec 07 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      7
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Dec 08 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      8
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Dec 09 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      9
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Dec 10 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      10
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Dec 11 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      11
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Dec 12 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      12
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Dec 13 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      13
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Dec 14 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      14
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Dec 15 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      15
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Dec 16 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      16
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Dec 17 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      17
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Dec 18 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      18
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Dec 19 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      19
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Dec 20 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      20
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Dec 21 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      21
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Dec 22 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      22
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Dec 23 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      23
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Dec 24 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      24
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sat Dec 25 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      25
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Week"
+                    role="row"
+                  >
+                    <div
+                      aria-disabled="false"
+                      aria-label="Sun Dec 26 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      26
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Mon Dec 27 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      27
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Tue Dec 28 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      28
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Wed Dec 29 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      29
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Thu Dec 30 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      30
+                    </div>
+                    <div
+                      aria-disabled="false"
+                      aria-label="Fri Dec 31 2021"
+                      aria-selected="false"
+                      class="DayPicker-Day"
+                      role="gridcell"
+                      tabindex="-1"
+                    >
+                      31
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      class="DayPicker-Day DayPicker-Day--outside"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div>
@@ -13998,475 +13992,6 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
       >
         <div
           class="lucid-SlidePanel-Slide lucid-InfiniteSlidePanel-Slide-in-frame lucid-DateSelect-slide"
-          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
-        >
-          <div
-            class="lucid-DateSelect-slide-content"
-          >
-            <div
-              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
-              lang="en"
-              role="application"
-            >
-              <div
-                class="DayPicker-wrapper"
-                tabindex="-1"
-              >
-                <div
-                  class="DayPicker-Month"
-                  role="grid"
-                >
-                  <div
-                    class="DayPicker-Caption"
-                    role="heading"
-                  >
-                    <div>
-                      December 2021
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
-                    >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Sun
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mon
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tue
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          Wed
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Thu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fri
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sat
-                        </abbr>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 01 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 02 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 03 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 04 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 06 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 07 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 08 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 09 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 10 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 11 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 13 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 14 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 15 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 16 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 17 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 18 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 20 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 21 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 22 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 23 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 24 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 25 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 27 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 28 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 29 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 30 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 31 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
           style="flex-grow:1;flex-shrink:0;flex-basis:100%"
         >
           <div
@@ -15443,7 +14968,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      September 2021
+                      March 2022
                     </div>
                   </div>
                   <div
@@ -15543,12 +15068,8 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
                       <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 01 2021"
+                        aria-label="Tue Mar 01 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15558,7 +15079,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 02 2021"
+                        aria-label="Wed Mar 02 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15568,7 +15089,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 03 2021"
+                        aria-label="Thu Mar 03 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15578,13 +15099,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 04 2021"
+                        aria-label="Fri Mar 04 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         4
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 05 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
                       </div>
                     </div>
                     <div
@@ -15593,17 +15124,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 06 2021"
+                        aria-label="Sun Mar 06 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15613,7 +15134,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 07 2021"
+                        aria-label="Mon Mar 07 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15623,7 +15144,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 08 2021"
+                        aria-label="Tue Mar 08 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15633,7 +15154,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 09 2021"
+                        aria-label="Wed Mar 09 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15643,7 +15164,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 10 2021"
+                        aria-label="Thu Mar 10 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15653,13 +15174,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 11 2021"
+                        aria-label="Fri Mar 11 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         11
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 12 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
                       </div>
                     </div>
                     <div
@@ -15668,17 +15199,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 13 2021"
+                        aria-label="Sun Mar 13 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15688,7 +15209,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 14 2021"
+                        aria-label="Mon Mar 14 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15698,7 +15219,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 15 2021"
+                        aria-label="Tue Mar 15 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15708,7 +15229,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 16 2021"
+                        aria-label="Wed Mar 16 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15718,7 +15239,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 17 2021"
+                        aria-label="Thu Mar 17 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15728,13 +15249,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 18 2021"
+                        aria-label="Fri Mar 18 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         18
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 19 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
                       </div>
                     </div>
                     <div
@@ -15743,17 +15274,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 20 2021"
+                        aria-label="Sun Mar 20 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15763,7 +15284,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 21 2021"
+                        aria-label="Mon Mar 21 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15773,7 +15294,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 22 2021"
+                        aria-label="Tue Mar 22 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15783,7 +15304,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 23 2021"
+                        aria-label="Wed Mar 23 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15793,7 +15314,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 24 2021"
+                        aria-label="Thu Mar 24 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15803,13 +15324,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 25 2021"
+                        aria-label="Fri Mar 25 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         25
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 26 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
                       </div>
                     </div>
                     <div
@@ -15818,17 +15349,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 27 2021"
+                        aria-label="Sun Mar 27 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15838,7 +15359,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 28 2021"
+                        aria-label="Mon Mar 28 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15848,7 +15369,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 29 2021"
+                        aria-label="Tue Mar 29 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -15858,13 +15379,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 30 2021"
+                        aria-label="Wed Mar 30 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Mar 31 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
                       </div>
                       <div
                         aria-disabled="true"
@@ -16835,6 +16366,475 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
+          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
+        >
+          <div
+            class="lucid-DateSelect-slide-content"
+          >
+            <div
+              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
+              lang="en"
+              role="application"
+            >
+              <div
+                class="DayPicker-wrapper"
+                tabindex="-1"
+              >
+                <div
+                  class="DayPicker-Month"
+                  role="grid"
+                >
+                  <div
+                    class="DayPicker-Caption"
+                    role="heading"
+                  >
+                    <div>
+                      December 2021
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Weekdays"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-WeekdaysRow"
+                      role="row"
+                    >
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Sunday"
+                        >
+                          Sun
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Monday"
+                        >
+                          Mon
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Tuesday"
+                        >
+                          Tue
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Wednesday"
+                        >
+                          Wed
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Thursday"
+                        >
+                          Thu
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Friday"
+                        >
+                          Fri
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Saturday"
+                        >
+                          Sat
+                        </abbr>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Body"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 01 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="0"
+                      >
+                        1
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 02 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        2
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 03 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        3
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 04 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        4
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 05 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 06 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        6
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 07 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        7
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 08 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        8
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 09 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        9
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 10 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        10
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 11 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        11
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 12 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 13 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        13
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 14 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        14
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 15 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        15
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 16 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        16
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 17 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        17
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 18 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        18
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 19 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 20 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        20
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 21 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        21
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 22 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        22
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 23 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        23
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 24 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        24
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 25 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        25
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 26 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 27 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        27
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 28 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        28
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 29 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        29
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 30 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 31 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
+                      </div>
                       <div
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"
@@ -16919,475 +16919,6 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      December 2021
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
-                    >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Sun
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mon
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tue
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          Wed
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Thu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fri
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sat
-                        </abbr>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 01 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 02 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 03 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 04 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 06 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 07 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 08 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 09 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 10 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 11 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 13 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 14 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 15 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 16 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 17 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 18 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 20 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 21 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 22 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 23 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 24 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 25 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 27 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 28 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 29 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 30 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 31 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
-          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
-        >
-          <div
-            class="lucid-DateSelect-slide-content"
-          >
-            <div
-              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
-              lang="en"
-              role="application"
-            >
-              <div
-                class="DayPicker-wrapper"
-                tabindex="-1"
-              >
-                <div
-                  class="DayPicker-Month"
-                  role="grid"
-                >
-                  <div
-                    class="DayPicker-Caption"
-                    role="heading"
-                  >
-                    <div>
                       January 2022
                     </div>
                   </div>
@@ -18341,7 +17872,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      September 2021
+                      March 2022
                     </div>
                   </div>
                   <div
@@ -18441,12 +17972,8 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
                       <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 01 2021"
+                        aria-label="Tue Mar 01 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18456,7 +17983,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 02 2021"
+                        aria-label="Wed Mar 02 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18466,7 +17993,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 03 2021"
+                        aria-label="Thu Mar 03 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18476,13 +18003,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 04 2021"
+                        aria-label="Fri Mar 04 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         4
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 05 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
                       </div>
                     </div>
                     <div
@@ -18491,17 +18028,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 06 2021"
+                        aria-label="Sun Mar 06 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18511,7 +18038,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 07 2021"
+                        aria-label="Mon Mar 07 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18521,7 +18048,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 08 2021"
+                        aria-label="Tue Mar 08 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18531,7 +18058,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 09 2021"
+                        aria-label="Wed Mar 09 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18541,7 +18068,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 10 2021"
+                        aria-label="Thu Mar 10 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18551,13 +18078,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 11 2021"
+                        aria-label="Fri Mar 11 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         11
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 12 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
                       </div>
                     </div>
                     <div
@@ -18566,17 +18103,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 13 2021"
+                        aria-label="Sun Mar 13 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18586,7 +18113,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 14 2021"
+                        aria-label="Mon Mar 14 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18596,7 +18123,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 15 2021"
+                        aria-label="Tue Mar 15 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18606,7 +18133,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 16 2021"
+                        aria-label="Wed Mar 16 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18616,7 +18143,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 17 2021"
+                        aria-label="Thu Mar 17 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18626,13 +18153,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 18 2021"
+                        aria-label="Fri Mar 18 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         18
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 19 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
                       </div>
                     </div>
                     <div
@@ -18641,17 +18178,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 20 2021"
+                        aria-label="Sun Mar 20 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18661,7 +18188,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 21 2021"
+                        aria-label="Mon Mar 21 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18671,7 +18198,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 22 2021"
+                        aria-label="Tue Mar 22 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18681,7 +18208,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 23 2021"
+                        aria-label="Wed Mar 23 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18691,7 +18218,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 24 2021"
+                        aria-label="Thu Mar 24 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18701,13 +18228,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 25 2021"
+                        aria-label="Fri Mar 25 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         25
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 26 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
                       </div>
                     </div>
                     <div
@@ -18716,17 +18253,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 27 2021"
+                        aria-label="Sun Mar 27 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18736,7 +18263,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 28 2021"
+                        aria-label="Mon Mar 28 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18746,7 +18273,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 29 2021"
+                        aria-label="Tue Mar 29 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -18756,13 +18283,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 30 2021"
+                        aria-label="Wed Mar 30 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Mar 31 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
                       </div>
                       <div
                         aria-disabled="true"
@@ -19733,6 +19270,475 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
+          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
+        >
+          <div
+            class="lucid-DateSelect-slide-content"
+          >
+            <div
+              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
+              lang="en"
+              role="application"
+            >
+              <div
+                class="DayPicker-wrapper"
+                tabindex="-1"
+              >
+                <div
+                  class="DayPicker-Month"
+                  role="grid"
+                >
+                  <div
+                    class="DayPicker-Caption"
+                    role="heading"
+                  >
+                    <div>
+                      December 2021
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Weekdays"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-WeekdaysRow"
+                      role="row"
+                    >
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Sunday"
+                        >
+                          Sun
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Monday"
+                        >
+                          Mon
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Tuesday"
+                        >
+                          Tue
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Wednesday"
+                        >
+                          Wed
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Thursday"
+                        >
+                          Thu
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Friday"
+                        >
+                          Fri
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Saturday"
+                        >
+                          Sat
+                        </abbr>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Body"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 01 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="0"
+                      >
+                        1
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 02 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        2
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 03 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        3
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 04 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        4
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 05 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 06 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        6
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 07 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        7
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 08 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        8
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 09 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        9
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 10 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        10
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 11 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        11
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 12 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 13 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        13
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 14 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        14
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 15 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        15
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 16 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        16
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 17 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        17
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 18 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        18
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 19 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 20 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        20
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 21 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        21
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 22 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        22
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 23 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        23
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 24 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        24
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 25 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        25
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 26 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 27 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        27
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 28 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        28
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 29 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        29
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 30 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 31 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
+                      </div>
                       <div
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"
@@ -19817,475 +19823,6 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      December 2021
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Weekdays"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-WeekdaysRow"
-                      role="row"
-                    >
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Sunday"
-                        >
-                          Sun
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Monday"
-                        >
-                          Mon
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Tuesday"
-                        >
-                          Tue
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Wednesday"
-                        >
-                          Wed
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Thursday"
-                        >
-                          Thu
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Friday"
-                        >
-                          Fri
-                        </abbr>
-                      </div>
-                      <div
-                        class="DayPicker-Weekday"
-                        role="columnheader"
-                      >
-                        <abbr
-                          title="Saturday"
-                        >
-                          Sat
-                        </abbr>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="DayPicker-Body"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 01 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="0"
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 02 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 03 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 04 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        4
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 06 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 07 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 08 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 09 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        9
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 10 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 11 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        11
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 13 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 14 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 15 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 16 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        16
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 17 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 18 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        18
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 20 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 21 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 22 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 23 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        23
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 24 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sat Dec 25 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        25
-                      </div>
-                    </div>
-                    <div
-                      class="DayPicker-Week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Sun Dec 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Dec 27 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Tue Dec 28 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Wed Dec 29 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Thu Dec 30 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Fri Dec 31 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
-          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
-        >
-          <div
-            class="lucid-DateSelect-slide-content"
-          >
-            <div
-              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
-              lang="en"
-              role="application"
-            >
-              <div
-                class="DayPicker-wrapper"
-                tabindex="-1"
-              >
-                <div
-                  class="DayPicker-Month"
-                  role="grid"
-                >
-                  <div
-                    class="DayPicker-Caption"
-                    role="heading"
-                  >
-                    <div>
                       January 2022
                     </div>
                   </div>
@@ -21239,7 +20776,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     role="heading"
                   >
                     <div>
-                      September 2021
+                      March 2022
                     </div>
                   </div>
                   <div
@@ -21339,12 +20876,8 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
                       <div
-                        aria-disabled="true"
-                        class="DayPicker-Day DayPicker-Day--outside"
-                      />
-                      <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 01 2021"
+                        aria-label="Tue Mar 01 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21354,7 +20887,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 02 2021"
+                        aria-label="Wed Mar 02 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21364,7 +20897,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 03 2021"
+                        aria-label="Thu Mar 03 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21374,13 +20907,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 04 2021"
+                        aria-label="Fri Mar 04 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         4
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 05 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
                       </div>
                     </div>
                     <div
@@ -21389,17 +20932,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 05 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 06 2021"
+                        aria-label="Sun Mar 06 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21409,7 +20942,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 07 2021"
+                        aria-label="Mon Mar 07 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21419,7 +20952,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 08 2021"
+                        aria-label="Tue Mar 08 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21429,7 +20962,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 09 2021"
+                        aria-label="Wed Mar 09 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21439,7 +20972,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 10 2021"
+                        aria-label="Thu Mar 10 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21449,13 +20982,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 11 2021"
+                        aria-label="Fri Mar 11 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         11
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 12 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
                       </div>
                     </div>
                     <div
@@ -21464,17 +21007,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 12 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 13 2021"
+                        aria-label="Sun Mar 13 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21484,7 +21017,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 14 2021"
+                        aria-label="Mon Mar 14 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21494,7 +21027,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 15 2021"
+                        aria-label="Tue Mar 15 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21504,7 +21037,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 16 2021"
+                        aria-label="Wed Mar 16 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21514,7 +21047,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 17 2021"
+                        aria-label="Thu Mar 17 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21524,13 +21057,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 18 2021"
+                        aria-label="Fri Mar 18 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         18
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 19 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
                       </div>
                     </div>
                     <div
@@ -21539,17 +21082,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 19 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 20 2021"
+                        aria-label="Sun Mar 20 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21559,7 +21092,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 21 2021"
+                        aria-label="Mon Mar 21 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21569,7 +21102,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 22 2021"
+                        aria-label="Tue Mar 22 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21579,7 +21112,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 23 2021"
+                        aria-label="Wed Mar 23 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21589,7 +21122,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Fri Sep 24 2021"
+                        aria-label="Thu Mar 24 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21599,13 +21132,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Sat Sep 25 2021"
+                        aria-label="Fri Mar 25 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         25
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Mar 26 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
                       </div>
                     </div>
                     <div
@@ -21614,17 +21157,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                     >
                       <div
                         aria-disabled="false"
-                        aria-label="Sun Sep 26 2021"
-                        aria-selected="false"
-                        class="DayPicker-Day"
-                        role="gridcell"
-                        tabindex="-1"
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Mon Sep 27 2021"
+                        aria-label="Sun Mar 27 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21634,7 +21167,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Tue Sep 28 2021"
+                        aria-label="Mon Mar 28 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21644,7 +21177,7 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Wed Sep 29 2021"
+                        aria-label="Tue Mar 29 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
@@ -21654,13 +21187,23 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                       </div>
                       <div
                         aria-disabled="false"
-                        aria-label="Thu Sep 30 2021"
+                        aria-label="Wed Mar 30 2022"
                         aria-selected="false"
                         class="DayPicker-Day"
                         role="gridcell"
                         tabindex="-1"
                       >
                         30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Mar 31 2022"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
                       </div>
                       <div
                         aria-disabled="true"
@@ -22631,6 +22174,475 @@ exports[`DateSelect common tests [common] example testing should match snapshot(
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"
                       />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="lucid-SlidePanel-Slide lucid-DateSelect-slide"
+          style="flex-grow:1;flex-shrink:0;flex-basis:100%"
+        >
+          <div
+            class="lucid-DateSelect-slide-content"
+          >
+            <div
+              class="DayPicker lucid-CalendarMonth lucid-DateSelect-CalendarMonth"
+              lang="en"
+              role="application"
+            >
+              <div
+                class="DayPicker-wrapper"
+                tabindex="-1"
+              >
+                <div
+                  class="DayPicker-Month"
+                  role="grid"
+                >
+                  <div
+                    class="DayPicker-Caption"
+                    role="heading"
+                  >
+                    <div>
+                      December 2021
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Weekdays"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-WeekdaysRow"
+                      role="row"
+                    >
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Sunday"
+                        >
+                          Sun
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Monday"
+                        >
+                          Mon
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Tuesday"
+                        >
+                          Tue
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Wednesday"
+                        >
+                          Wed
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Thursday"
+                        >
+                          Thu
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Friday"
+                        >
+                          Fri
+                        </abbr>
+                      </div>
+                      <div
+                        class="DayPicker-Weekday"
+                        role="columnheader"
+                      >
+                        <abbr
+                          title="Saturday"
+                        >
+                          Sat
+                        </abbr>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="DayPicker-Body"
+                    role="rowgroup"
+                  >
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="true"
+                        class="DayPicker-Day DayPicker-Day--outside"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 01 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="0"
+                      >
+                        1
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 02 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        2
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 03 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        3
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 04 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        4
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 05 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        5
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 06 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        6
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 07 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        7
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 08 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        8
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 09 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        9
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 10 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        10
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 11 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        11
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 12 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        12
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 13 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        13
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 14 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        14
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 15 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        15
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 16 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        16
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 17 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        17
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 18 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        18
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 19 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        19
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 20 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        20
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 21 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        21
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 22 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        22
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 23 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        23
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 24 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        24
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sat Dec 25 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        25
+                      </div>
+                    </div>
+                    <div
+                      class="DayPicker-Week"
+                      role="row"
+                    >
+                      <div
+                        aria-disabled="false"
+                        aria-label="Sun Dec 26 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        26
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Mon Dec 27 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        27
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Tue Dec 28 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        28
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Wed Dec 29 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        29
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Thu Dec 30 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        30
+                      </div>
+                      <div
+                        aria-disabled="false"
+                        aria-label="Fri Dec 31 2021"
+                        aria-selected="false"
+                        class="DayPicker-Day"
+                        role="gridcell"
+                        tabindex="-1"
+                      >
+                        31
+                      </div>
                       <div
                         aria-disabled="true"
                         class="DayPicker-Day DayPicker-Day--outside"

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
@@ -68,8 +68,8 @@ describe('SearchableMultiSelect', () => {
 				);
 
 				const event = {
-					target: { value: 'ero'}
-				}
+					target: { value: 'ero' },
+				};
 				const expected = {
 					event: 'ero',
 					props: {
@@ -81,7 +81,10 @@ describe('SearchableMultiSelect', () => {
 					},
 				};
 
-				wrapper.find('SearchField').prop('onKeyDown')(event.target.value, event);
+				wrapper.find('SearchField').prop('onKeyDown')(
+					event.target.value,
+					event
+				);
 
 				expect(onSearch).toHaveBeenCalledWith(undefined, 0, expected);
 			});

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
@@ -66,8 +66,12 @@ describe('SearchableMultiSelect', () => {
 						<Option callbackId={'one'}>One</Option>
 					</SearchableMultiSelect>
 				);
+
+				const event = {
+					target: { value: 'ero'}
+				}
 				const expected = {
-					event: 'fake',
+					event: 'ero',
 					props: {
 						callbackId: 'zero',
 						children: 'Zero',
@@ -77,9 +81,9 @@ describe('SearchableMultiSelect', () => {
 					},
 				};
 
-				wrapper.find('SearchField').prop('onChange')('ero', { event: 'fake' });
+				wrapper.find('SearchField').prop('onKeyDown')(event.target.value, event);
 
-				expect(onSearch).toHaveBeenCalledWith('ero', 0, expected);
+				expect(onSearch).toHaveBeenCalledWith(undefined, 0, expected);
 			});
 		});
 

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -229,7 +229,7 @@ export interface ISearchableMultiSelectProps extends StandardProps {
 export interface ISearchableMultiSelectState {
 	DropMenu: IDropMenuState;
 	selectedIndices: number[];
-	searchText: string | null;
+	searchText: string;
 	optionGroups: IDropMenuOptionGroupProps[];
 	flattenedOptionsData: IOptionsData[];
 	ungroupedOptionData: IOptionsData[];
@@ -520,9 +520,8 @@ class SearchableMultiSelect extends React.Component<
 
 	handleSearch = (
 		searchText: string,
-		{ event }: { event: React.KeyboardEvent | React.MouseEvent }
+		{ event }: { event: React.KeyboardEvent }
 	): void => {
-		// @ts-ignore
 		if (event.keyCode !== 13) {
 			const {
 				props,
@@ -818,8 +817,8 @@ class SearchableMultiSelect extends React.Component<
 							)}
 							value={searchText}
 							onKeyDown={(event) => {
-								// @ts-ignore
-								this.handleSearch(event.target?.value, { event });
+								const text = event.target as HTMLInputElement;
+								this.handleSearch(text.value, { event });
 							}}
 						/>
 					</DropMenu.Control>

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -818,7 +818,7 @@ class SearchableMultiSelect extends React.Component<
 							value={searchText}
 							onKeyDown={(event) => {
 								const text = event.target as HTMLInputElement;
-								this.handleSearch(text.value, { event });
+								this.handleSearch(text?.value, { event });
 							}}
 						/>
 					</DropMenu.Control>

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -556,6 +556,14 @@ class SearchableMultiSelect extends React.Component<
 		}
 	};
 
+	handleEnter = (event) => {
+		if (event.keyCode === 13) {
+			event.stopPropagation();
+		} else {
+			this.handleSearch(event.target.value, event);
+		}
+	};
+
 	UNSAFE_componentWillMount(): void {
 		// preprocess the options data before rendering
 		const {

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -522,8 +522,8 @@ class SearchableMultiSelect extends React.Component<
 		searchText: string,
 		{ event }: { event: React.KeyboardEvent | React.MouseEvent }
 	): void => {
-
-		if (event.keyCode !== 13 ) {
+		// @ts-ignore
+		if (event.keyCode !== 13) {
 			const {
 				props,
 				props: {
@@ -532,7 +532,6 @@ class SearchableMultiSelect extends React.Component<
 					DropMenu: { onExpand },
 				},
 			} = this;
-	
 			const options = _.map(
 				findTypes(props, SearchableMultiSelect.Option),
 				'props'
@@ -542,7 +541,6 @@ class SearchableMultiSelect extends React.Component<
 			});
 			const firstVisibleProps = options[firstVisibleIndex];
 			const dropMenuProps = this.props.DropMenu;
-	
 			// Just an extra call to make sure the search results show up when a user
 			// is typing
 			onExpand &&
@@ -550,15 +548,13 @@ class SearchableMultiSelect extends React.Component<
 					event,
 					props: dropMenuProps,
 				});
-	
 			return onSearch(searchText, firstVisibleIndex, {
 				event,
 				props: firstVisibleProps,
 			});
 		} else {
-				event.stopPropagation();
+			event.stopPropagation();
 		}
-		
 	};
 
 	UNSAFE_componentWillMount(): void {
@@ -821,8 +817,10 @@ class SearchableMultiSelect extends React.Component<
 								searchFieldProps.className
 							)}
 							value={searchText}
-							onKeyDown={(event)=>{this.handleSearch(event.target?.value, {event});
-						}}
+							onKeyDown={(event) => {
+								// @ts-ignore
+								this.handleSearch(event.target?.value, { event });
+							}}
 						/>
 					</DropMenu.Control>
 					{isLoading ? (

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -531,6 +531,7 @@ class SearchableMultiSelect extends React.Component<
 					DropMenu: { onExpand },
 				},
 			} = this;
+
 			const options = _.map(
 				findTypes(props, SearchableMultiSelect.Option),
 				'props'
@@ -540,6 +541,7 @@ class SearchableMultiSelect extends React.Component<
 			});
 			const firstVisibleProps = options[firstVisibleIndex];
 			const dropMenuProps = this.props.DropMenu;
+
 			// Just an extra call to make sure the search results show up when a user
 			// is typing
 			onExpand &&
@@ -547,6 +549,7 @@ class SearchableMultiSelect extends React.Component<
 					event,
 					props: dropMenuProps,
 				});
+
 			return onSearch(searchText, firstVisibleIndex, {
 				event,
 				props: firstVisibleProps,

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -555,6 +555,14 @@ class SearchableMultiSelect extends React.Component<
 		});
 	};
 
+	handleEnter = (event) => {
+		if (event.keyCode === 13) {
+			event.stopPropagation()
+		} else {
+			this.handleSearch(event.target.value, event)
+			}
+		}
+
 	UNSAFE_componentWillMount(): void {
 		// preprocess the options data before rendering
 		const {
@@ -815,7 +823,7 @@ class SearchableMultiSelect extends React.Component<
 								searchFieldProps.className
 							)}
 							value={searchText}
-							onChange={this.handleSearch}
+							onKeyDown={this.handleEnter}
 						/>
 					</DropMenu.Control>
 					{isLoading ? (

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -557,11 +557,10 @@ class SearchableMultiSelect extends React.Component<
 
 	handleEnter = (event) => {
 		if (event.keyCode === 13) {
-			event.stopPropagation()
+			event.stopPropagation();
 		} else {
-			this.handleSearch(event.target.value, event)
-			}
-		}
+			this.handleSearch(event.target.value, event);
+		}};
 
 	UNSAFE_componentWillMount(): void {
 		// preprocess the options data before rendering

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -522,45 +522,44 @@ class SearchableMultiSelect extends React.Component<
 		searchText: string,
 		{ event }: { event: React.KeyboardEvent | React.MouseEvent }
 	): void => {
-		const {
-			props,
-			props: {
-				onSearch,
-				optionFilter,
-				DropMenu: { onExpand },
-			},
-		} = this;
 
-		const options = _.map(
-			findTypes(props, SearchableMultiSelect.Option),
-			'props'
-		);
-		const firstVisibleIndex = _.findIndex(options, (option) => {
-			return optionFilter(searchText, option);
-		});
-		const firstVisibleProps = options[firstVisibleIndex];
-		const dropMenuProps = this.props.DropMenu;
-
-		// Just an extra call to make sure the search results show up when a user
-		// is typing
-		onExpand &&
-			onExpand({
-				event,
-				props: dropMenuProps,
+		if (event.keyCode !== 13 ) {
+			const {
+				props,
+				props: {
+					onSearch,
+					optionFilter,
+					DropMenu: { onExpand },
+				},
+			} = this;
+	
+			const options = _.map(
+				findTypes(props, SearchableMultiSelect.Option),
+				'props'
+			);
+			const firstVisibleIndex = _.findIndex(options, (option) => {
+				return optionFilter(searchText, option);
 			});
-
-		return onSearch(searchText, firstVisibleIndex, {
-			event,
-			props: firstVisibleProps,
-		});
-	};
-
-	handleEnter = (event) => {
-		if (event.keyCode === 13) {
-			event.stopPropagation();
+			const firstVisibleProps = options[firstVisibleIndex];
+			const dropMenuProps = this.props.DropMenu;
+	
+			// Just an extra call to make sure the search results show up when a user
+			// is typing
+			onExpand &&
+				onExpand({
+					event,
+					props: dropMenuProps,
+				});
+	
+			return onSearch(searchText, firstVisibleIndex, {
+				event,
+				props: firstVisibleProps,
+			});
 		} else {
-			this.handleSearch(event.target.value, event);
-		}};
+				event.stopPropagation();
+		}
+		
+	};
 
 	UNSAFE_componentWillMount(): void {
 		// preprocess the options data before rendering
@@ -822,7 +821,8 @@ class SearchableMultiSelect extends React.Component<
 								searchFieldProps.className
 							)}
 							value={searchText}
-							onKeyDown={this.handleEnter}
+							onKeyDown={(event)=>{this.handleSearch(event.target?.value, {event});
+						}}
 						/>
 					</DropMenu.Control>
 					{isLoading ? (

--- a/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.tsx.snap
+++ b/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.tsx.snap
@@ -1310,6 +1310,7 @@ exports[`SearchableMultiSelect custom formatting should render Option child func
         isDisabled={false}
         onChange={[Function]}
         onChangeDebounced={[Function]}
+        onKeyDown={[Function]}
         onSubmit={[Function]}
         value="tion"
       />
@@ -1444,6 +1445,7 @@ exports[`SearchableMultiSelect custom formatting should render Option.Selected i
         isDisabled={false}
         onChange={[Function]}
         onChangeDebounced={[Function]}
+        onKeyDown={[Function]}
         onSubmit={[Function]}
         value=""
       />
@@ -1674,6 +1676,7 @@ exports[`SearchableMultiSelect custom formatting should render OptionGroup.Selec
         isDisabled={false}
         onChange={[Function]}
         onChangeDebounced={[Function]}
+        onKeyDown={[Function]}
         onSubmit={[Function]}
         value=""
       />


### PR DESCRIPTION
## PR Checklist

Current Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/latest/?path=/docs/controls-searchablemultiselect-sb5--basic)

Proposed Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/bugfix_TARG-917/?path=/docs/controls-searchablemultiselect-sb5--basic)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval


When pressing enter after typing into the `SearchField` a selection is made that is not relevant to the search text. Please see the gif below for an example. 'Maine' is typed in and Louisiana is the option that is selected.

Fix: Prevent the user from hitting enter at all in the SearchableMultiSelect component. Have the user click specific choices. 


**Before**
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/21188892/139470946-670c3cf3-3203-4a5e-9dc4-1776a68a5749.gif)


**After**
![ezgif com-gif-maker](https://user-images.githubusercontent.com/21188892/139470762-279cec39-1154-4c3a-ad59-31e4deca4e45.gif)

