### PR TITLE
fix: update hover and active styling

### DIFF
--- a/src/components/Tabs/Tabs.less
+++ b/src/components/Tabs/Tabs.less
@@ -37,9 +37,11 @@
 		cursor: pointer;
 		color: @color-neutral-9;
 		user-select: none;
+		margin-bottom: 3px;
 
 		&:hover {
 			border-bottom: 3px solid @color-primary;
+			margin-bottom: 0px;
 		}
 
 		&-is-active {
@@ -106,6 +108,7 @@
 		border-bottom: 3px solid @color-primary;
 		color: @color-neutral-9;
 		cursor: initial;
+		margin-bottom: 0px;
 	}
 
 	&-Tab-content {


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/Update-Tabs-Hover/?path=/docs/navigation-tabs--title-as-prop)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

* To account for the displacement of the content on hover, adding an initial margin bottom value to to be replaced on hover and if is active
