### PR TITLE
make IBannerProps optional

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 import { lucidClassNames } from '../../util/style-helpers';
-import { omitProps, StandardProps, FC } from '../../util/component-types';
+import { omitProps, StandardProps } from '../../util/component-types';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
 import { IIconProps } from '../Icon/Icon';
 
@@ -52,21 +52,21 @@ export interface IBannerProps
 			HTMLDivElement
 		> {
 	/** Pass in a icon component for custom icons within `Banner`. */
-	icon: React.ReactElement | null;
+	icon?: React.ReactElement | null;
 
 	/** Set this to `true` if you want to have a `x` close icon. */
-	isCloseable: boolean;
+	isCloseable?: boolean;
 
 	/** If set to `false` the banner will not be filled in.
 	 * @default = true
 	 */
-	isFilled: boolean;
+	isFilled?: boolean;
 
 	/** If set to `true` the banner have smaller padding on the inside. */
-	isSmall: boolean;
+	isSmall?: boolean;
 
 	/** Style variations of the `Banner`. */
-	kind: 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'default';
+	kind?: 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'default';
 
 	/** Called when the user closes the `Banner`. */
 	onClose: ({
@@ -78,7 +78,7 @@ export interface IBannerProps
 	}) => void;
 
 	/** Controls the visibility of the `Banner`. */
-	isClosed: boolean;
+	isClosed?: boolean;
 }
 
 const defaultProps = {
@@ -91,18 +91,20 @@ const defaultProps = {
 	isClosed: false,
 };
 
-export const Banner: FC<IBannerProps> = ({
-	icon,
-	kind,
-	className,
-	children,
-	isCloseable,
-	isClosed,
-	isFilled,
-	isSmall,
-	onClose,
-	...passThroughs
-}): React.ReactElement => {
+export const Banner = (props: IBannerProps): React.ReactElement => {
+	const {
+		icon,
+		kind,
+		className,
+		children,
+		isCloseable,
+		isClosed,
+		isFilled,
+		isSmall,
+		onClose,
+		...passThroughs
+	} = props;
+
 	const handleClose = ({
 		event,
 		props,


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/fix-banner-propTypes)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
