### PR TITLE
Replaced Object.keys with lodash keys to fix propType checks in prod builds

### DIFF
--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -191,7 +191,7 @@ class Collapsible extends React.Component<
 							...omitProps(
 								passThroughs,
 								undefined,
-								Object.keys(Collapsible.propTypes)
+								_.keys(Collapsible.propTypes)
 							),
 							ref: this.rootRef,
 							className: cx('&', className),

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -177,7 +177,7 @@ class Overlay extends React.Component<IOverlayProps, IOverlayState, {}> {
 
 		const overlayElement = (
 			<div
-				{...omitProps(passThroughs, undefined, Object.keys(Overlay.propTypes))}
+				{...omitProps(passThroughs, undefined, _.keys(Overlay.propTypes))}
 				className={cx(className, '&', {
 					'&-is-not-modal': !isModal,
 					'&-is-animated': isAnimated,

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { omitProps, StandardProps } from '../../util/component-types';

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -81,7 +81,7 @@ class Portal extends React.Component<IPortalProps, IPortalState, {}> {
 			? ReactDOM.createPortal(
 					<div
 						className={classNames(cx('&'), this.props.className)}
-						{...omitProps(this.props, undefined, Object.keys(Portal.propTypes))}
+						{...omitProps(this.props, undefined, _.keys(Portal.propTypes))}
 					>
 						{this.props.children}
 					</div>,

--- a/src/components/SlidePanel/SlidePanel.tsx
+++ b/src/components/SlidePanel/SlidePanel.tsx
@@ -245,11 +245,7 @@ class SlidePanel extends React.Component<
 
 		return (
 			<div
-				{...omitProps(
-					passThroughs,
-					undefined,
-					Object.keys(SlidePanel.propTypes)
-				)}
+				{...omitProps(passThroughs, undefined, _.keys(SlidePanel.propTypes))}
 				ref={this.rootHTMLDivElement}
 				className={cx('&', className)}
 			>
@@ -277,7 +273,7 @@ class SlidePanel extends React.Component<
 							{...omitProps(
 								passThroughs,
 								undefined,
-								Object.keys(SlidePanel.propTypes)
+								_.keys(SlidePanel.propTypes)
 							)}
 							className={cx('&-slidestrip', className)}
 							style={{

--- a/src/components/SplitHorizontal/SplitHorizontal.tsx
+++ b/src/components/SplitHorizontal/SplitHorizontal.tsx
@@ -492,11 +492,7 @@ class SplitHorizontal extends React.Component<
 
 		return (
 			<div
-				{...omitProps(
-					this.props,
-					undefined,
-					Object.keys(SplitHorizontal.propTypes)
-				)}
+				{...omitProps(this.props, undefined, _.keys(SplitHorizontal.propTypes))}
 				className={cx(
 					'&',
 					{

--- a/src/components/StickySection/StickySection.tsx
+++ b/src/components/StickySection/StickySection.tsx
@@ -193,7 +193,7 @@ class StickySection extends React.Component<
 				{...omitProps<IStickySectionProps>(
 					passThroughs,
 					undefined,
-					Object.keys(StickySection.propTypes)
+					_.keys(StickySection.propTypes)
 				)}
 				className={cx('&', className)}
 				style={{

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -347,7 +347,7 @@ class TextField extends React.Component<
 
 		const finalProps = {
 			...omitProps(passThroughs, undefined, [
-				...Object.keys(TextField.propTypes),
+				..._.keys(TextField.propTypes),
 				'children',
 			]),
 			className: cx(


### PR DESCRIPTION

## PR Checklist

Storybook can be viewed [here](DOCSPOT_URL)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
