### PR TITLE
fix typo in the border-color css declaration

### DIFF
--- a/src/components/Table/Table.less
+++ b/src/components/Table/Table.less
@@ -106,7 +106,7 @@
 	// Table header styles
 	&.@{prefix}-Table-has-light-header > &-Thead {
 		background-color: @color-table-header-light-background;
-		border-color: 1px solid @color-table-row-border;
+		border-color: @color-table-row-border;
 		& > .@{prefix}-Table-Tr > .@{prefix}-Table-Th {
 			&.@{prefix}-Table-is-sortable {
 				&:hover {


### PR DESCRIPTION
Border-color CSS should only specify color.