### PR TITLE
1311: Updated the padding in the dialog box.

### DIFF
--- a/src/components/Dialog/Dialog.less
+++ b/src/components/Dialog/Dialog.less
@@ -7,6 +7,7 @@
 @Dialog-size-smallWidth: 30%;
 @Dialog-size-mediumWidth: 60%;
 @Dialog-size-largeWidth: 90%;
+@Dialog-size-padding: 20px;
 
 .@{prefix}-Dialog {
 	&-window {
@@ -31,8 +32,6 @@
 		width: @Dialog-size-largeWidth;
 	}
 
-
-
 	&-header {
 		display: flex;
 		align-items: center;
@@ -40,13 +39,13 @@
 		font-size: @size-font-L;
 		color: @color-darkGray;
 		font-weight: @font-weight-medium;
-		padding: 26px @Dialog-size-spacing 21px;
+		padding: @Dialog-size-padding;
 
 		.@{prefix}-Dialog-close-button {
 			position: relative;
 			left: 0;
 			top: 0;
-			padding: 0 8px;
+			padding: 0;
 
 			.@{prefix}-Icon {
 				stroke: @color-neutral-6;
@@ -57,7 +56,7 @@
 	& &-is-complex &-header {
 		display: flex;
 		box-sizing: content-box;
-		padding: 22px @Dialog-size-spacing 18px;
+		padding: @Dialog-size-padding @Dialog-size-spacing;
 		border-bottom: 1px solid @color-neutral-4;
 		font-size: @size-font-L;
 		min-height: 28px;
@@ -66,7 +65,7 @@
 	&-body {
 		flex: 1 1 auto;
 		overflow: auto;
-		padding: 0 @Dialog-size-spacing;
+		padding: 0 @Dialog-size-padding;
 		max-height: 60vh; // fix for IE 11 bug, otherwise the body doesn't shrink properly
 		font-size: @fontSize;
 		line-height: 14px;
@@ -77,7 +76,7 @@
 	}
 
 	& &-no-footer &-body {
-		padding-bottom: 20px;
+		padding-bottom: @Dialog-size-padding;
 	}
 
 	&-body-no-gutters {
@@ -88,14 +87,13 @@
 		flex: 1 0 auto;
 		text-align: right;
 		background-color: @color-white;
-		padding: 20px @Dialog-size-spacing;
+		padding: @Dialog-size-padding;
 	}
 
 	& &-is-complex &-footer {
 		border-top: 1px solid @color-neutral-4;
-		padding: 19px @Dialog-size-spacing;
+		padding: @Dialog-size-padding @Dialog-size-spacing;
 		height: 30px;
 		box-sizing: content-box;
 	}
 }
-


### PR DESCRIPTION
To be consistent with other components, we'd like to update the internal padding in dialogs to 20px. The 20px update should be applied to the Header, Body, and Footer areas within dialogs. 

The body sections should maintain their 0px top/bottom padding.

## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/improvement_1311_CXP-1934-Update-Dialog-internal-padding)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
