### PR TITLE
Improvement/1313 cxp 1916 auto disable text input on paginator

### DIFF
--- a/src/components/Paginator/Paginator.spec.tsx
+++ b/src/components/Paginator/Paginator.spec.tsx
@@ -26,7 +26,7 @@ describe('Paginator', () => {
 			});
 			it('should render page size selector', () => {
 				const wrapper = shallow(<Paginator hasPageSizeSelector />);
-				assert.equal(
+				assert.strictEqual(
 					wrapper.find('.lucid-Paginator-page-size-container').length,
 					1,
 					'must be 1'
@@ -34,11 +34,11 @@ describe('Paginator', () => {
 			});
 			it('should render a TextField', () => {
 				const wrapper = shallow(<Paginator />);
-				assert.equal(wrapper.find(TextField).length, 1, 'must be 1');
+				assert.strictEqual(wrapper.find(TextField).length, 1, 'must be 1');
 			});
 			it('should render two buttons', () => {
 				const wrapper = shallow(<Paginator />);
-				assert.equal(wrapper.find(Button).length, 2, 'must be 2');
+				assert.strictEqual(wrapper.find(Button).length, 2, 'must be 2');
 			});
 		});
 	});
@@ -78,7 +78,7 @@ describe('Paginator', () => {
 			it('should set the value of the TextField to selectedPageIndex + 1', () => {
 				const wrapper = shallow(<Paginator selectedPageIndex={1} />);
 				const textFieldWrapper = wrapper.find(TextField).first().shallow();
-				assert.equal(textFieldWrapper.prop('value'), 2, 'must be 2');
+				assert.strictEqual(textFieldWrapper.prop('value'), 2, 'must be 2');
 			});
 		});
 
@@ -96,7 +96,7 @@ describe('Paginator', () => {
 					.first()
 					.shallow()
 					.find(SingleSelect);
-				assert.equal(
+				assert.strictEqual(
 					pageSizeSelectorWrapper.prop('selectedIndex'),
 					selectedPageSizeIndex,
 					'must be 1'
@@ -134,7 +134,7 @@ describe('Paginator', () => {
 			it('should appear in "of {totalPages}" span', () => {
 				const totalPages = 5;
 				const wrapper = shallow(<Paginator totalPages={totalPages} />);
-				assert.equal(
+				assert.strictEqual(
 					wrapper.find('span').text(),
 					`of ${totalPages}`,
 					'must be "of 5"'
@@ -152,7 +152,7 @@ describe('Paginator', () => {
 				const wrapper = shallow(
 					<HybridPaginator totalCount={totalCount} pageSizeOptions={[10]} />
 				);
-				assert.equal(
+				assert.strictEqual(
 					wrapper.find(Paginator).shallow().find('span').text(),
 					'of 10',
 					'must be "of 10"'
@@ -173,10 +173,10 @@ describe('Paginator', () => {
 					.first()
 					.children();
 
-				assert.equal(options.length, 5, 'must be 5');
+				assert.strictEqual(options.length, 5, 'must be 5');
 				options.forEach((option, i) => {
 					assert(option.is(SingleSelect.Option), 'must be true');
-					assert.equal(option.children().text(), pageSizeOptions[i]);
+					assert.strictEqual(option.children().text(), pageSizeOptions[i]);
 				});
 			});
 		});
@@ -224,8 +224,8 @@ describe('Paginator', () => {
 					wrapper.find('button').first().simulate('click');
 					assert(onPageSelect.calledOnce);
 					const [pageIndex, totalPages] = onPageSelect.firstCall.args;
-					assert.equal(pageIndex, 0, 'must be 0');
-					assert.equal(totalPages, 3, 'must be 3');
+					assert.strictEqual(pageIndex, 0, 'must be 0');
+					assert.strictEqual(totalPages, 3, 'must be 3');
 				});
 			});
 
@@ -242,8 +242,8 @@ describe('Paginator', () => {
 					wrapper.find('button').first().simulate('click');
 					assert(onPageSelect.calledOnce);
 					const [pageIndex, totalPages] = onPageSelect.firstCall.args;
-					assert.equal(pageIndex, 0, 'must be 0');
-					assert.equal(totalPages, 3, 'must be 3');
+					assert.strictEqual(pageIndex, 0, 'must be 0');
+					assert.strictEqual(totalPages, 3, 'must be 3');
 				});
 			});
 
@@ -261,8 +261,8 @@ describe('Paginator', () => {
 						wrapper.find(TextField).prop(propName)(1, 3);
 						assert(onPageSelect.calledOnce);
 						const [pageIndex, totalPages] = onPageSelect.firstCall.args;
-						assert.equal(pageIndex, 0, 'must be 0');
-						assert.equal(totalPages, 3, 'must be 3');
+						assert.strictEqual(pageIndex, 0, 'must be 0');
+						assert.strictEqual(totalPages, 3, 'must be 3');
 					});
 				});
 			});

--- a/src/components/Paginator/Paginator.spec.tsx
+++ b/src/components/Paginator/Paginator.spec.tsx
@@ -72,6 +72,12 @@ describe('Paginator', () => {
 					.shallow();
 				assert(pageSizeSelectorWrapper.prop('isDisabled'), 'must be true');
 			});
+
+			it('should render a disabled TextField', () => {
+				const wrapper = shallow(<Paginator totalPages={1} />);
+				const textField = wrapper.find(TextField);
+				assert(textField.prop('isDisabled'), 'must be true');
+			});
 		});
 
 		describe('selectedPageIndex', () => {
@@ -176,7 +182,10 @@ describe('Paginator', () => {
 				assert.strictEqual(options.length, 5, 'must be 5');
 				options.forEach((option, i) => {
 					assert(option.is(SingleSelect.Option), 'must be true');
-					assert.strictEqual(option.children().text(), pageSizeOptions[i]);
+					assert.strictEqual(
+						option.children().text(),
+						pageSizeOptions[i].toString()
+					);
 				});
 			});
 		});

--- a/src/components/Paginator/Paginator.tsx
+++ b/src/components/Paginator/Paginator.tsx
@@ -201,6 +201,8 @@ const Paginator: FC<IPaginatorProps> & ILucidComponent = (
 		);
 	};
 
+	const isTextFieldDisabled = isDisabled || totalPages === 1;
+
 	return (
 		<div style={style} className={cx('&', className)}>
 			{showTotalObjects && _.isNumber(totalCount) && (
@@ -245,7 +247,7 @@ const Paginator: FC<IPaginatorProps> & ILucidComponent = (
 				{...textFieldProps}
 				onBlur={handleTextFieldChange}
 				onSubmit={handleTextFieldChange}
-				isDisabled={isDisabled}
+				isDisabled={isTextFieldDisabled}
 				value={selectedPageIndex + 1}
 			/>
 			{!_.isNil(totalPages) && <span>of {totalPages.toLocaleString()}</span>}


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/improvement_1313_CXP-1916-Auto-disable-text-input-on-Paginator)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
