### PR TITLE
Improvement/cxp 2002 update icon colors

### DIFF
--- a/src/components/Icon/AddColumnIcon/AddColumnIcon.tsx
+++ b/src/components/Icon/AddColumnIcon/AddColumnIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/AddURLIcon/AddURLIcon.tsx
+++ b/src/components/Icon/AddURLIcon/AddURLIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/AnalyzeDataIcon/AnalyzeDataIcon.tsx
+++ b/src/components/Icon/AnalyzeDataIcon/AnalyzeDataIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ArrowIcon/ArrowIcon.tsx
+++ b/src/components/Icon/ArrowIcon/ArrowIcon.tsx
@@ -31,6 +31,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -38,6 +39,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/AsteriskIcon/AsteriskIcon.tsx
+++ b/src/components/Icon/AsteriskIcon/AsteriskIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/AttachIcon/AttachIcon.tsx
+++ b/src/components/Icon/AttachIcon/AttachIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/AudioIcon/AudioIcon.tsx
+++ b/src/components/Icon/AudioIcon/AudioIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/BackUpArrowIcon/BackUpArrowIcon.tsx
+++ b/src/components/Icon/BackUpArrowIcon/BackUpArrowIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/BarChartIcon/BarChartIcon.tsx
+++ b/src/components/Icon/BarChartIcon/BarChartIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/BellIcon/BellIcon.tsx
+++ b/src/components/Icon/BellIcon/BellIcon.tsx
@@ -26,26 +26,6 @@ export const iconPropTypes = {
 		\`viewBox\`. */
 	size: PropTypes.number,
 
-	/** Sets the color of the Icon.  May not be applicable for icons that are tied
-		to specific colors (e.g. DangerIcon). */
-	color: PropTypes.oneOf([
-		'neutral-dark',
-		'neutral-light',
-		'primary',
-		'white',
-		'success',
-		'warning',
-		'secondary-one',
-		'secondary-two',
-		'secondary-three',
-	]),
-
-	/** Show or hide a dot on the bell to indicate a notification. */
-	hasDot: PropTypes.bool,
-
-	/** Featured color of the dot */
-	featuredColor: PropTypes.oneOf(['info', 'success', 'warning', 'danger']),
-
 	/** Size handles width and height, whereas \`width\` can manually override the width that would be set by size. */
 	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
@@ -56,6 +36,22 @@ export const iconPropTypes = {
 		the "artboard" for our SVG while \`size\` is the presented height and
 		width. */
 	viewBox: PropTypes.string,
+
+	/** Sets the color of the Icon.  May not be applicable for icons that are tied
+		to specific colors (e.g. DangerIcon). */
+	color: PropTypes.oneOf([
+		'neutral-dark',
+		'neutral-light',
+		'neutral-extra-light',
+		'primary',
+		'white',
+		'success',
+		'warning',
+		'secondary-one',
+		'secondary-two',
+		'secondary-three',
+		'secondary-five',
+	]),
 
 	/** Any valid SVG aspect ratio. */
 	aspectRatio: PropTypes.string,
@@ -81,6 +77,12 @@ export const iconPropTypes = {
 	/** Classes that are appended to the component defaults. This prop is run
 		through the \`classnames\` library. */
 	className: PropTypes.string,
+
+	/** Show or hide a dot on the bell to indicate a notification. */
+	hasDot: PropTypes.bool,
+
+	/** Featured color of the dot */
+	featuredColor: PropTypes.oneOf(['info', 'success', 'warning', 'danger']),
 };
 
 export const BellIcon = ({

--- a/src/components/Icon/BookIcon/BookIcon.tsx
+++ b/src/components/Icon/BookIcon/BookIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/CalculatorIcon/CalculatorIcon.tsx
+++ b/src/components/Icon/CalculatorIcon/CalculatorIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/CalendarIcon/CalendarIcon.tsx
+++ b/src/components/Icon/CalendarIcon/CalendarIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ChatIcon/ChatIcon.tsx
+++ b/src/components/Icon/ChatIcon/ChatIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/CheckIcon/CheckIcon.tsx
+++ b/src/components/Icon/CheckIcon/CheckIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ChevronIcon/ChevronIcon.tsx
+++ b/src/components/Icon/ChevronIcon/ChevronIcon.tsx
@@ -31,6 +31,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -38,6 +39,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ClockIcon/ClockIcon.tsx
+++ b/src/components/Icon/ClockIcon/ClockIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/CodeIcon/CodeIcon.tsx
+++ b/src/components/Icon/CodeIcon/CodeIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/CrownIcon/CrownIcon.tsx
+++ b/src/components/Icon/CrownIcon/CrownIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/DeleteIcon/DeleteIcon.tsx
+++ b/src/components/Icon/DeleteIcon/DeleteIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/DotsIcon/DotsIcon.tsx
+++ b/src/components/Icon/DotsIcon/DotsIcon.tsx
@@ -35,6 +35,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -42,6 +43,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.tsx
+++ b/src/components/Icon/DoubleChevronIcon/DoubleChevronIcon.tsx
@@ -31,6 +31,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -38,6 +39,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/DownloadIcon/DownloadIcon.tsx
+++ b/src/components/Icon/DownloadIcon/DownloadIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/DuplicateIcon/DuplicateIcon.tsx
+++ b/src/components/Icon/DuplicateIcon/DuplicateIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/EditIcon/EditIcon.tsx
+++ b/src/components/Icon/EditIcon/EditIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/EnvelopeIcon/EnvelopeIcon.tsx
+++ b/src/components/Icon/EnvelopeIcon/EnvelopeIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/EqualsIcon/EqualsIcon.tsx
+++ b/src/components/Icon/EqualsIcon/EqualsIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/FileIcon/FileIcon.tsx
+++ b/src/components/Icon/FileIcon/FileIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/FilterIcon/FilterIcon.tsx
+++ b/src/components/Icon/FilterIcon/FilterIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/FlagIcon/FlagIcon.tsx
+++ b/src/components/Icon/FlagIcon/FlagIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/FolderIcon/FolderIcon.tsx
+++ b/src/components/Icon/FolderIcon/FolderIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/FourSquaresIcon/FourSquaresIcon.tsx
+++ b/src/components/Icon/FourSquaresIcon/FourSquaresIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/GetMaximumIcon/GetMaximumIcon.tsx
+++ b/src/components/Icon/GetMaximumIcon/GetMaximumIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/GlobeIcon/GlobeIcon.tsx
+++ b/src/components/Icon/GlobeIcon/GlobeIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/HamburgerMenuIcon/HamburgerMenuIcon.tsx
+++ b/src/components/Icon/HamburgerMenuIcon/HamburgerMenuIcon.tsx
@@ -12,6 +12,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -19,6 +20,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/HideIcon/HideIcon.tsx
+++ b/src/components/Icon/HideIcon/HideIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/HomeIcon/HomeIcon.tsx
+++ b/src/components/Icon/HomeIcon/HomeIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/HostedIcon/HostedIcon.tsx
+++ b/src/components/Icon/HostedIcon/HostedIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/Icon.less
+++ b/src/components/Icon/Icon.less
@@ -48,6 +48,18 @@
 		}
 	}
 
+	&-color-neutral-extra-light {
+		stroke: @color-neutral-1;
+
+		&.@{prefix}-Icon-is-clickable:hover {
+			stroke: darken(@color-neutral-1, 7%);
+		}
+
+		&.@{prefix}-Icon-is-disabled {
+			stroke: @color-darkGray;
+		}
+	}
+
 	&-color-primary {
 		stroke: @color-primary;
 
@@ -125,6 +137,18 @@
 
 		&.@{prefix}-Icon-is-clickable:hover {
 			stroke: darken(@color-secondary-3, 7%);
+		}
+
+		&.@{prefix}-Icon-is-disabled {
+			stroke: @color-darkGray;
+		}
+	}
+
+	&-color-secondary-five {
+		stroke: @color-secondary-5;
+
+		&.@{prefix}-Icon-is-clickable:hover {
+			stroke: darken(@color-secondary-5, 7%);
 		}
 
 		&.@{prefix}-Icon-is-disabled {

--- a/src/components/Icon/ImageIcon/ImageIcon.tsx
+++ b/src/components/Icon/ImageIcon/ImageIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/InheritedSettingsIcon/InheritedSettingsIcon.tsx
+++ b/src/components/Icon/InheritedSettingsIcon/InheritedSettingsIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/LightbulbIcon/LightbulbIcon.tsx
+++ b/src/components/Icon/LightbulbIcon/LightbulbIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/LinkedIcon/LinkedIcon.tsx
+++ b/src/components/Icon/LinkedIcon/LinkedIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/LockedIcon/LockedIcon.tsx
+++ b/src/components/Icon/LockedIcon/LockedIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/MaximizeIcon/MaximizeIcon.tsx
+++ b/src/components/Icon/MaximizeIcon/MaximizeIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/MegaphoneIcon/MegaphoneIcon.tsx
+++ b/src/components/Icon/MegaphoneIcon/MegaphoneIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/MinimizeIcon/MinimizeIcon.tsx
+++ b/src/components/Icon/MinimizeIcon/MinimizeIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/MinusIcon/MinusIcon.tsx
+++ b/src/components/Icon/MinusIcon/MinusIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/NewWindowIcon/NewWindowIcon.tsx
+++ b/src/components/Icon/NewWindowIcon/NewWindowIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/OutwardArrowsIcon/OutwardArrowsIcon.tsx
+++ b/src/components/Icon/OutwardArrowsIcon/OutwardArrowsIcon.tsx
@@ -51,6 +51,7 @@ export const outwardArrowsIconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -58,6 +59,7 @@ export const outwardArrowsIconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/PinIcon/PinIcon.tsx
+++ b/src/components/Icon/PinIcon/PinIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/PlusIcon/PlusIcon.tsx
+++ b/src/components/Icon/PlusIcon/PlusIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/QuestionMarkIcon/QuestionMarkIcon.tsx
+++ b/src/components/Icon/QuestionMarkIcon/QuestionMarkIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/RefreshIcon/RefreshIcon.tsx
+++ b/src/components/Icon/RefreshIcon/RefreshIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ReportIcon/ReportIcon.tsx
+++ b/src/components/Icon/ReportIcon/ReportIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ResizeIcon/ResizeIcon.tsx
+++ b/src/components/Icon/ResizeIcon/ResizeIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/RolloverIcon/RolloverIcon.tsx
+++ b/src/components/Icon/RolloverIcon/RolloverIcon.tsx
@@ -29,6 +29,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -36,6 +37,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/RunReportIcon/RunReportIcon.tsx
+++ b/src/components/Icon/RunReportIcon/RunReportIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/SaveIcon/SaveIcon.tsx
+++ b/src/components/Icon/SaveIcon/SaveIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/SearchIcon/SearchIcon.tsx
+++ b/src/components/Icon/SearchIcon/SearchIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/SettingsIcon/SettingsIcon.tsx
+++ b/src/components/Icon/SettingsIcon/SettingsIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ShareIcon/ShareIcon.tsx
+++ b/src/components/Icon/ShareIcon/ShareIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ShoppingCartIcon/ShoppingCartIcon.tsx
+++ b/src/components/Icon/ShoppingCartIcon/ShoppingCartIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/StarIcon/StarIcon.tsx
+++ b/src/components/Icon/StarIcon/StarIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/StarOutlineIcon/StarOutlineIcon.tsx
+++ b/src/components/Icon/StarOutlineIcon/StarOutlineIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/StopwatchIcon/StopwatchIcon.tsx
+++ b/src/components/Icon/StopwatchIcon/StopwatchIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/SwitchIcon/SwitchIcon.tsx
+++ b/src/components/Icon/SwitchIcon/SwitchIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/TableIcon/TableIcon.tsx
+++ b/src/components/Icon/TableIcon/TableIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/TextIcon/TextIcon.tsx
+++ b/src/components/Icon/TextIcon/TextIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/TicketIcon/TicketIcon.tsx
+++ b/src/components/Icon/TicketIcon/TicketIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/UnlinkedIcon/UnlinkedIcon.tsx
+++ b/src/components/Icon/UnlinkedIcon/UnlinkedIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/UnlockedIcon/UnlockedIcon.tsx
+++ b/src/components/Icon/UnlockedIcon/UnlockedIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/UploadIcon/UploadIcon.tsx
+++ b/src/components/Icon/UploadIcon/UploadIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/UserIcon/UserIcon.tsx
+++ b/src/components/Icon/UserIcon/UserIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/VideoIcon/VideoIcon.tsx
+++ b/src/components/Icon/VideoIcon/VideoIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/VideoLiveIcon/VideoLiveIcon.tsx
+++ b/src/components/Icon/VideoLiveIcon/VideoLiveIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/VideoLongIcon/VideoLongIcon.tsx
+++ b/src/components/Icon/VideoLongIcon/VideoLongIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/VideoOnDemandIcon/VideoOnDemandIcon.tsx
+++ b/src/components/Icon/VideoOnDemandIcon/VideoOnDemandIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/VideoShortIcon/VideoShortIcon.tsx
+++ b/src/components/Icon/VideoShortIcon/VideoShortIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ViewIcon/ViewIcon.tsx
+++ b/src/components/Icon/ViewIcon/ViewIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/ViewTableIcon/ViewTableIcon.tsx
+++ b/src/components/Icon/ViewTableIcon/ViewTableIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */

--- a/src/components/Icon/WrenchIcon/WrenchIcon.tsx
+++ b/src/components/Icon/WrenchIcon/WrenchIcon.tsx
@@ -28,6 +28,7 @@ export const iconPropTypes = {
 	color: PropTypes.oneOf([
 		'neutral-dark',
 		'neutral-light',
+		'neutral-extra-light',
 		'primary',
 		'white',
 		'success',
@@ -35,6 +36,7 @@ export const iconPropTypes = {
 		'secondary-one',
 		'secondary-two',
 		'secondary-three',
+		'secondary-five',
 	]),
 
 	/** Any valid SVG aspect ratio. */


### PR DESCRIPTION
Update the icons to include two new colors as specified by the designer.
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/improvement_CXP-2002_Update-Icon-Colors)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
