### PR TITLE
Replace omitProps in SearchableSelect and SearchableSingleSelect

### DIFF
--- a/src/components/SearchableSelect/SearchableSelect.stories.tsx
+++ b/src/components/SearchableSelect/SearchableSelect.stories.tsx
@@ -1,6 +1,7 @@
 import { map, isNil, escapeRegExp } from 'lodash';
 import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
+
 import SearchableSelect from './SearchableSelect';
 import Underline from '../Underline/Underline';
 
@@ -56,7 +57,7 @@ const Template: any = (args) => {
 
 //👇 Each story then reuses that template
 
-/** Default */
+/** Basic */
 export const Basic = Template.bind({});
 Basic.args = {
 	Placeholder: 'Select State',

--- a/src/components/SearchableSelect/SearchableSelect.tsx
+++ b/src/components/SearchableSelect/SearchableSelect.tsx
@@ -1,13 +1,8 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import {
-	StandardProps,
-	omitProps,
-	findTypes,
-	getFirst,
-} from '../../util/component-types';
+
+import { StandardProps, findTypes, getFirst } from '../../util/component-types';
 import { lucidClassNames } from '../../util/style-helpers';
 import { partitionText, propsSearch } from '../../util/text-manipulation';
 import { buildModernHybridComponent } from '../../util/state-management';
@@ -27,23 +22,18 @@ import { Validation } from '../Validation/Validation';
 
 const cx = lucidClassNames.bind('&-SearchableSelect');
 
-/** PropTypes */
 const { any, bool, func, node, number, object, shape, string, oneOfType } =
 	PropTypes;
 
+/** Placeholder Child Component */
 export interface ISearchableSelectPlaceholderProps extends StandardProps {
 	description?: string;
 }
 
-/** Placeholder Child Component */
 const Placeholder = (_props: ISearchableSelectPlaceholderProps): null => null;
 Placeholder.displayName = 'SearchableSelect.Placeholder';
 Placeholder.peek = {
-	description: `
-		The content rendered in the control when there is no
-		option is selected. Also rendered in the option list to remove current
-		selection.
-	`,
+	description: `The content rendered in the control when there is no option is selected. Also rendered in the option list to remove current selection.`,
 };
 Placeholder.propName = 'Placeholder';
 Placeholder.propTypes = {};
@@ -52,11 +42,7 @@ Placeholder.propTypes = {};
 const OptionGroup = (_props: IDropMenuOptionGroupProps): null => null;
 OptionGroup.displayName = 'SearchableSelect.OptionGroup';
 OptionGroup.peek = {
-	description: `
-		A special kind of \`Option\` that is always rendered at the top of
-		the menu and has an \`optionIndex\` of \`null\`. Useful for
-		unselect.
-	`,
+	description: `A special kind of \`Option\` that is always rendered at the top of the menu and has an \`optionIndex\` of \`null\`. Useful for unselect.`,
 };
 OptionGroup.propName = 'OptionGroup';
 OptionGroup.propTypes = DropMenu.OptionGroup.propTypes;
@@ -73,10 +59,7 @@ const Selected = (_props: { children?: React.ReactNode }): null => null;
 
 Selected.displayName = 'SearchableSelect.Option.Selected';
 Selected.peek = {
-	description: `
-		Customizes the rendering of the Option when it is selected
-		and is displayed instead of the Placeholder.
-	`,
+	description: `Customizes the rendering of the \`Option\` when it is selected and is displayed instead of the \`Placeholder\`.`,
 };
 Selected.propName = 'Selected';
 Selected.propTypes = {};
@@ -86,9 +69,7 @@ const Option = (_props: ISearchableSelectOptionProps): null => null;
 
 Option.displayName = 'SearchableSelect.Option';
 Option.peek = {
-	description: `
-		A selectable option in the list.
-	`,
+	description: `A selectable option in the list.`,
 };
 Option.Selected = Selected;
 Option.propName = 'Option';
@@ -104,6 +85,7 @@ Option.propTypes = {
 };
 Option.defaultProps = DropMenu.Option.defaultProps;
 
+/** Searchable Select */
 type ISearchableSelectDropMenuProps = Partial<IDropMenuProps>;
 
 export interface ISearchableSelectProps extends StandardProps {
@@ -610,7 +592,7 @@ class SearchableSelect extends React.Component<
 				errorChildProps.children &&
 				errorChildProps.children !== true ? (
 					<div
-						{...omitProps(errorChildProps, undefined)}
+						{..._.omit(errorChildProps, ['initialState', 'callbackId'])}
 						className={cx('&-error-content')}
 					>
 						{errorChildProps.children}

--- a/src/components/SearchableSingleSelect/SearchableSingleSelect.stories.tsx
+++ b/src/components/SearchableSingleSelect/SearchableSingleSelect.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lodash';
 import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
+
 import SearchableSingleSelect from './SearchableSingleSelect';
 import Underline from '../Underline/Underline';
 
@@ -52,7 +53,7 @@ const Template: any = (args) => {
 
 //👇 Each story then reuses that template
 
-/** Default */
+/** Basic */
 export const Basic = Template.bind({});
 Basic.args = {
 	SearchField: { placeholder: 'Search State' },

--- a/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
+++ b/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
@@ -2,12 +2,12 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import { buildModernHybridComponent } from '../../util/state-management';
 import { partitionText, propsSearch } from '../../util/text-manipulation';
 import {
 	StandardProps,
-	omitProps,
 	getFirst,
 	findTypes,
 	Overwrite,
@@ -33,7 +33,7 @@ const { any, bool, func, number, oneOfType, shape, string, node } = PropTypes;
 
 const cx = lucidClassNames.bind('&-SearchableSingleSelect');
 
-/** Option Group Child Component */
+/** Option Group */
 const OptionGroup = (_props: IDropMenuOptionGroupProps): null => null;
 OptionGroup.displayName = 'SearchableSingleSelect.OptionGroup';
 OptionGroup.peek = {
@@ -47,7 +47,7 @@ OptionGroup.propName = 'OptionGroup';
 OptionGroup.propTypes = DropMenu.OptionGroup.propTypes;
 OptionGroup.defaultProps = DropMenu.OptionGroup.defaultProps;
 
-/** Search Field Child Component */
+/** Search Field */
 const SearchFieldComponent = (_props: ISearchFieldProps): null => null;
 SearchFieldComponent.displayName = 'SearchableSingleSelect.SearchField';
 SearchFieldComponent.peek = {
@@ -59,14 +59,7 @@ SearchFieldComponent.propName = 'SearchField';
 SearchFieldComponent.propTypes = SearchField.propTypes;
 SearchFieldComponent.defaultProps = SearchField.defaultProps;
 
-/** Option Child Component w/ Selection property */
-export interface ISearchableSingleSelectOptionProps
-	extends IDropMenuOptionProps {
-	description?: string;
-	name?: string;
-	Selected?: React.ReactNode;
-}
-
+/** Selected */
 const Selected = (_props: { children?: React.ReactNode }): null => null;
 
 Selected.displayName = 'SearchableSingleSelect.Option.Selected';
@@ -78,6 +71,14 @@ Selected.peek = {
 };
 Selected.propName = 'Selected';
 Selected.propTypes = {};
+
+/** Option */
+export interface ISearchableSingleSelectOptionProps
+	extends IDropMenuOptionProps {
+	description?: string;
+	name?: string;
+	Selected?: React.ReactNode;
+}
 
 const Option = (_props: ISearchableSingleSelectOptionProps): null => null;
 
@@ -101,6 +102,7 @@ Option.propTypes = {
 };
 Option.defaultProps = DropMenu.Option.defaultProps;
 
+/** Searchable Single Select */
 export interface ISearchableSingleSelectPropsRaw extends StandardProps {
 	hasReset?: boolean;
 	hasSelections?: boolean;
@@ -156,6 +158,28 @@ export interface ISearchableSingleSelectState {
 	ungroupedOptionData: IOptionsData[];
 	optionGroupDataLookup: { [key: number]: IOptionsData[] };
 }
+
+const nonPassThroughs = [
+	'children',
+	'className',
+	'isDisabled',
+	'isLoading',
+	'maxMenuHeight',
+	'onSearch',
+	'onSelect',
+	'optionFilter',
+	'searchText',
+	'selectedIndex',
+	'DropMenu',
+	'Option',
+	'Error',
+	'FixedOption',
+	'NullOption',
+	'OptionGroup',
+	'SearchField',
+	'initialState',
+	'callbackId',
+];
 
 const defaultProps = {
 	isDisabled: false,
@@ -528,11 +552,7 @@ class SearchableSingleSelect extends React.Component<
 
 			return (
 				<div
-					{...omitProps(
-						passThroughs,
-						undefined,
-						_.keys(SearchableSingleSelect.propTypes)
-					)}
+					{..._.omit(passThroughs, nonPassThroughs)}
 					className={cx('&', className)}
 				>
 					<Selection
@@ -558,7 +578,7 @@ class SearchableSingleSelect extends React.Component<
 					errorChildProps.children &&
 					errorChildProps.children !== true ? (
 						<div
-							{...omitProps(errorChildProps, undefined)}
+							{..._.omit(errorChildProps, ['initialState', 'callbackId'])}
 							className={cx('&-error-select-content')}
 						>
 							{errorChildProps.children}
@@ -570,11 +590,7 @@ class SearchableSingleSelect extends React.Component<
 
 		return (
 			<div
-				{...omitProps(
-					passThroughs,
-					undefined,
-					_.keys(SearchableSingleSelect.propTypes)
-				)}
+				{..._.omit(passThroughs, nonPassThroughs)}
 				className={cx('&', className)}
 			>
 				<DropMenu
@@ -632,7 +648,7 @@ class SearchableSingleSelect extends React.Component<
 				errorChildProps.children &&
 				errorChildProps.children !== true ? (
 					<div
-						{...omitProps(errorChildProps, undefined)}
+						{..._.omit(errorChildProps, ['initialState', 'callbackId'])}
 						className={cx('&-error-content')}
 					>
 						{errorChildProps.children}

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -292,7 +292,8 @@ export function omitProps<P extends object>(
 	targetIsDOMElement = true
 ): { [key: string]: any } {
 	// We only want to exclude the `callbackId` key when we're omitting props
-	// destined for a dom element
+	// destined for a dom element.
+	// We always want to exclude the `initialState` key.
 	const additionalOmittedKeys = targetIsDOMElement
 		? ['initialState', 'callbackId']
 		: ['initialState'];


### PR DESCRIPTION
## PR Checklist
Replace omitProps in SearchableSelect and SearchableSingleSelect

Storybook can be viewed here:
[SearchableSelect](https://docspot.adnxs.net/projects/lucid/CXP-2537-SearchableSelect-SearchableSingleSelect/?path=/docs/controls-searchableselect--basic)
[SearchableSingleSelect](https://docspot.adnxs.net/projects/lucid/CXP-2537-SearchableSelect-SearchableSingleSelect/?path=/docs/controls-searchablesingleselect--basic)
- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
