### PR TITLE
Improvement/cxp 1767 update switches

### DIFF
--- a/src/components/Switch/Switch.less
+++ b/src/components/Switch/Switch.less
@@ -18,8 +18,8 @@
 @Switch-handle-radius: 5px;
 @Switch-handle-scale: scale(1.125);
 
-@Switch-disabled-color: fade(@color-neutral-9, 4%);
-@Switch-disabled-border-color: fade(@color-neutral-9, 15%);
+@Switch-disabled-color: @color-lightGray;
+@Switch-disabled-border-color: @color-gray;
 
 .@{prefix}-Switch {
 	cursor: pointer;
@@ -40,6 +40,7 @@
 	&-visualization-container {
 		.box-sizing();
 
+		background-color: @color-white;
 		border-radius: (@Switch-container-height / 2);
 		border: 1px solid @color-transparent-gray-30-new;
 		height: @Switch-container-height;

--- a/src/components/Switch/Switch.less
+++ b/src/components/Switch/Switch.less
@@ -2,7 +2,7 @@
 @import (reference) '../../styles/mixins.less';
 
 @Switch-height: 22px;
-@Switch-width: 50px;
+@Switch-width: 40px;
 @Switch-animation-timing: 0.1s linear;
 @Switch-selected-transform: translate(16px, 0);
 

--- a/src/components/Switch/Switch.less
+++ b/src/components/Switch/Switch.less
@@ -154,6 +154,7 @@
 	&-is-include-exclude {
 		.@{prefix}-Switch-visualization-handle {
 			background-color: @color-secondary-1;
+			border-color: @color-secondary-1;
 		}
 
 		.@{prefix}-Switch-visualization-container {
@@ -172,24 +173,31 @@
 		}
 
 		&:hover {
-			.@{prefix}-Switch-visualization-container,
 			.@{prefix}-Switch-visualization-handle {
-				border: 1px solid @color-secondary-1;
+				border-color: @color-secondary-1;
+				background-color: @color-secondary-1;
+				opacity: 0.8;
+			}
+			.@{prefix}-Switch-visualization-container {
+				border-color: @color-secondary-1;
 			}
 		}
 
 		&:hover.@{prefix}-Switch-is-selected {
-			.@{prefix}-Switch-visualization-container,
+			.@{prefix}-Switch-visualization-container{
+				border-color: @color-secondary-4;
+			}
 			.@{prefix}-Switch-visualization-handle {
-				border: 1px solid @color-secondary-4;
+				border-color: @color-secondary-4;
+				background-color: @color-secondary-4;
 			}
 		}
 
 		&.@{prefix}-Switch-is-disabled:not(.@{prefix}-Switch-is-selected) {
 			& .@{prefix}-Switch-visualization-container,
 			& .@{prefix}-Switch-visualization-handle {
-				background-color: @Switch-disabled-color;
-				border-color: @Switch-disabled-border-color;
+				opacity: 0.5;
+				border-color: @color-secondary-1;
 			}
 		}
 

--- a/src/components/SwitchLabeled/SwitchLabeled.less
+++ b/src/components/SwitchLabeled/SwitchLabeled.less
@@ -21,11 +21,6 @@
 	}
 
 	&:hover {
-		.@{prefix}-Switch-visualization-glow {
-			// .opacity();
-			// transform: @Switch-glow-scale;
-		}
-
 		.@{prefix}-Switch-visualization-container {
 			border: 1px solid @color-primary;
 		}
@@ -69,10 +64,6 @@
 		}
 	}
 
-	&&-is-disabled:hover .@{prefix}-Switch-visualization-handle {
-		// transform: none;
-	}
-
 	&-text {
 		.transition-group-animation-fade(@timing-animation-hover);
 
@@ -93,4 +84,3 @@
 		}
 	}
 }
-

--- a/src/components/SwitchLabeled/SwitchLabeled.less
+++ b/src/components/SwitchLabeled/SwitchLabeled.less
@@ -26,7 +26,6 @@
 		}
 
 		.@{prefix}-Switch-visualization-handle {
-			background-color: @color-white;
 			border: 1px solid @color-primary;
 		}
 	}


### PR DESCRIPTION
Switch Consistency & State Updates

**Consistency updates:**

- Update the disabled switch container and handle border color to #e8e6e6
- Update the disabled switch container and handle background color to #f4f2f2
- Add a background color of white to unselected switch. Currently the page background color shows through the switch which can cause it to look disabled on gray backgrounds.

**SwitchLabeled fixes**:

- On active SwitchLabeled components, hovering over the text causes the handle to lose its background color. The switch should have the same hover state whether the user is hovering over the switch or text.
- Currently lucid-SwitchLabled has a flex set to 0 0 50px. This causes the label to be too far from the switch. Let's update the flex to 0 0 40px.

**Switch Exclude:**

- The handle border color should be #fc5047
- On hover the switch opacity should update to 0.8
- On hover the handle should keep its background color of #fc5047
- The disabled state for an Exclude switch should have an opacity of 0.5 (currently in storybook it shows a standard disabled switch here)

**Switch Include:**

- On hover the handle color should be #49b27b 

## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/improvement_CXP-1767-update-switches)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
