### PR TITLE
Improvement/cxp 1902 update body top margin 20

### DIFF
--- a/src/components/Panel/Panel.less
+++ b/src/components/Panel/Panel.less
@@ -21,7 +21,7 @@
 	& > &-Header {
 		display: flex;
 		align-items: center;
-		margin: 20px 20px 16px;
+		margin: 20px;
 		font-size: @size-font-L;
 		font-weight: @font-weight-medium;
 
@@ -38,7 +38,7 @@
 		font-size: 12px;
 
 		.@{prefix}-Panel-is-not-gutterless& {
-			margin: 16px 0 20px;
+			margin: 20px 0;
 			padding: 0 20px;
 			overflow: auto;
 		}
@@ -51,7 +51,7 @@
 
 	& > &-Footer {
 		text-align: right;
-		margin: 16px 20px;
+		margin: 20px;
 
 		.@{prefix}-Panel-is-not-gutterless& {
 			margin-top: 0;

--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -318,4 +318,4 @@ export const NoMarginsOrContentPadding: Story<IPanelProps> = (args) => {
 		</Panel>
 	);
 };
-NoMarginsOrContentPadding.storyName = 'NoMarginsOrContentPadding';
+NoMarginsOrContentPadding.storyName = 'No Margins Or Content Padding';


### PR DESCRIPTION
Updated the margins so they are all 20. I missed two previously.
Also updated a title to add spaces so it's readable in storybook.

## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/improvement_CXP-1902-update-body-top-margin-20)

- Manually tested across supported browsers

  - [X] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
