### PR TITLE
updated handleSearch to handleFirstIndex+1 and specfile

### DIFF
--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
@@ -69,8 +69,8 @@ describe('SearchableMultiSelect', () => {
 				const expected = {
 					event: 'fake',
 					props: {
-						callbackId: 'zero',
-						children: 'Zero',
+						callbackId: 'one',
+						children: 'One',
 						isDisabled: false,
 						isHidden: false,
 						isWrapped: true,
@@ -79,7 +79,7 @@ describe('SearchableMultiSelect', () => {
 
 				wrapper.find('SearchField').prop('onChange')('ero', { event: 'fake' });
 
-				expect(onSearch).toHaveBeenCalledWith('ero', 0, expected);
+				expect(onSearch).toHaveBeenCalledWith('ero', 1, expected);
 			});
 		});
 

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -537,9 +537,10 @@ class SearchableMultiSelect extends React.Component<
 			findTypes(props, SearchableMultiSelect.Option),
 			'props'
 		);
-		const firstVisibleIndex = _.findIndex(options, (option) => {
-			return optionFilter(searchText, option);
-		});
+		const firstVisibleIndex =
+			_.findIndex(options, (option) => {
+				return optionFilter(searchText, option);
+			}) + 1;
 		const firstVisibleProps = options[firstVisibleIndex];
 		const dropMenuProps = this.props.DropMenu;
 


### PR DESCRIPTION
## PR Checklist

Current Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/latest/?path=/docs/controls-searchablemultiselect-sb5--basic)

Proposed Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/fix_TARG-917-v2/?path=/docs/controls-searchablemultiselect--basic)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval

When pressing enter after typing into the `SearchField` a selection is made that is not relevant to the search text. Please see the gif below for an example. 'Maine' is typed in and Louisiana is the option that is selected.

**Before**
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/21188892/139470946-670c3cf3-3203-4a5e-9dc4-1776a68a5749.gif)

**After**
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/21188892/149872143-b37b3f5f-8a73-40ff-8f0f-26543fefa5b7.gif)

