### PR TITLE
Improvement/1311 update the padding dialog box

### DIFF
--- a/src/components/Dialog/Dialog.less
+++ b/src/components/Dialog/Dialog.less
@@ -56,7 +56,7 @@
 	& &-is-complex &-header {
 		display: flex;
 		box-sizing: content-box;
-		padding: @Dialog-size-padding @Dialog-size-spacing;
+		padding: @Dialog-size-padding;
 		border-bottom: 1px solid @color-neutral-4;
 		font-size: @size-font-L;
 		min-height: 28px;
@@ -72,7 +72,7 @@
 	}
 
 	& &-is-complex &-body {
-		padding: 10px @Dialog-size-spacing;
+		padding: @Dialog-size-padding;
 	}
 
 	& &-no-footer &-body {
@@ -92,7 +92,7 @@
 
 	& &-is-complex &-footer {
 		border-top: 1px solid @color-neutral-4;
-		padding: @Dialog-size-padding @Dialog-size-spacing;
+		padding: @Dialog-size-padding;
 		height: 30px;
 		box-sizing: content-box;
 	}

--- a/src/components/Dialog/Dialog.less
+++ b/src/components/Dialog/Dialog.less
@@ -46,6 +46,7 @@
 			left: 0;
 			top: 0;
 			padding: 0;
+			width: @size-close-button;
 
 			.@{prefix}-Icon {
 				stroke: @color-neutral-6;

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -63,6 +63,7 @@
 @size-XXL: 30px;
 
 @size-expander-button: 28px;
+@size-close-button: 28px;
 @size-tag: 20px;
 
 @size-grid-padding: 20px;


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/improvement_1311-Update-the-padding-dialog-box)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
