### PR TITLE
Improvement/cxp 1992 add background to icons

### DIFF
--- a/src/components/Icon/MinusCircleLightIcon/MinusCircleLightIcon.less
+++ b/src/components/Icon/MinusCircleLightIcon/MinusCircleLightIcon.less
@@ -4,6 +4,11 @@
 .@{prefix}-MinusCircleLightIcon {
 	stroke: @color-secondary-1;
 
+	&-is-disabled &-dash,
+	&-is-active &-dash {
+		stroke: @color-secondary-1;
+	}
+
 	&-is-clickable:not(&-is-disabled):hover &-dash,
 	&-is-active &-dash {
 		stroke: @color-white;
@@ -11,6 +16,7 @@
 
 	&-background {
 		stroke: @color-secondary-1;
+		fill: @color-white;
 	}
 
 	&-is-clickable&-is-active:not(&-is-disabled):hover &-background {

--- a/src/components/Icon/SuccessIcon/SuccessIcon.less
+++ b/src/components/Icon/SuccessIcon/SuccessIcon.less
@@ -5,6 +5,7 @@
 	stroke: @featured-color-success;
 
 	&-background {
+		stroke: @featured-color-success;
 		fill: @featured-color-success;
 	}
 
@@ -17,4 +18,3 @@
 		stroke: @color-white;
 	}
 }
-

--- a/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
+++ b/src/components/Icon/SuccessLightIcon/SuccessLightIcon.less
@@ -4,6 +4,21 @@
 .@{prefix}-SuccessLightIcon {
 	stroke: @featured-color-success;
 
+	&-is-disabled &-check,
+	&-is-active &-check {
+		stroke: @featured-color-success;
+	}
+
+	&-is-clickable:not(&-is-disabled):hover &-check,
+	&-is-active &-check {
+		stroke: @color-white;
+	}
+
+	&-background {
+		stroke: @featured-color-success;
+		fill: @color-white;
+	}
+
 	&-is-clickable:not(&-is-disabled):hover &-background,
 	&-is-active &-background {
 		stroke: @featured-color-success;
@@ -13,10 +28,5 @@
 	&-is-clickable&-is-active:not(&-is-disabled):hover &-background {
 		fill: @featured-color-success-colorHover;
 		stroke: @featured-color-success-colorHover;
-	}
-
-	&-is-clickable:not(&-is-disabled):hover &-check,
-	&-is-active &-check {
-		stroke: @color-white;
 	}
 }


### PR DESCRIPTION
Updated the icons to have a white background.  Also, I fixed a few issues I noticed with the disabled states and hover states.

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/improvement_CXP-1992-add-background-to-icons)

**Before:** 
![image](https://user-images.githubusercontent.com/3836691/150593169-33ba5981-704c-4176-8411-fe5131b0b808.png)
![image](https://user-images.githubusercontent.com/3836691/150593258-5d2696cb-0daa-45d0-a5d9-b8845c6d77b9.png)
![image](https://user-images.githubusercontent.com/3836691/150593302-33ebdc33-e890-4bdb-8af7-490261ff99a5.png)

**After**
![image](https://user-images.githubusercontent.com/3836691/150593354-0aeab01c-26f7-42c8-9f11-1c46f88aeddc.png)
![image](https://user-images.githubusercontent.com/3836691/150593380-b90d348b-e420-42aa-a2dc-3fb0ea7ec8fe.png)
![image](https://user-images.githubusercontent.com/3836691/150593421-76a5712e-b1d7-4917-9853-9f3885f45449.png)


- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [x] One core team UX approval
