### PR TITLE
Remove Storybook named stories to fix a linting error

### DIFF
--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -318,4 +318,3 @@ export const NoMarginsOrContentPadding: Story<IPanelProps> = (args) => {
 		</Panel>
 	);
 };
-NoMarginsOrContentPadding.storyName = 'No Margins Or Content Padding';

--- a/src/components/RadioButtonLabeled/RadioButtonLabeled.stories.tsx
+++ b/src/components/RadioButtonLabeled/RadioButtonLabeled.stories.tsx
@@ -144,7 +144,6 @@ export const LabelAsChild: Story<IRadioButtonLabeledProps> = (args) => {
 		</section>
 	);
 };
-LabelAsChild.storyName = 'Label As Child';
 
 /* Label As Prop */
 export const LabelAsProp: Story<IRadioButtonLabeledProps> = (args) => {
@@ -185,4 +184,3 @@ export const LabelAsProp: Story<IRadioButtonLabeledProps> = (args) => {
 		</section>
 	);
 };
-LabelAsProp.storyName = 'Label As Prop';

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -11,7 +11,7 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (RadioGroup as any).peek.description,
+				component: RadioGroup.peek.description,
 			},
 		},
 	},
@@ -96,10 +96,7 @@ export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 			</RadioGroup.RadioButton>
 		</RadioGroup>
 	);
-
-	// end-hide-from-docs
 };
-NestedSelect.storyName = 'Nested Select';
 
 /* Selected Index As Prop */
 export const SelectedIndexAsProp: Story<IRadioGroupProps> = (args) => {
@@ -140,7 +137,6 @@ export const SelectedIndexAsProp: Story<IRadioGroupProps> = (args) => {
 		</section>
 	);
 };
-SelectedIndexAsProp.storyName = 'Selected Index As Prop';
 
 /* Selected Index From Child */
 export const SelectedIndexFromChild: Story<IRadioGroupProps> = (args) => {
@@ -176,7 +172,6 @@ export const SelectedIndexFromChild: Story<IRadioGroupProps> = (args) => {
 		</RadioGroup>
 	);
 };
-SelectedIndexFromChild.storyName = 'Selected Index From Child';
 
 /* Default Props */
 export const DefaultProps: Story<IRadioGroupProps> = (args) => {


### PR DESCRIPTION
## PR Checklist

Fixes Storybook linting warning:
`warning  Named exports should not use the name annotation if it is redundant to the name that would be generated by the export name  storybook/no-redundant-story-name`

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/Fix-Storyboo-Named-Exports-Linting-Error)
https://docspot.adnxs.net/projects/lucid/Fix-Storyboo-Named-Exports-Linting-Error

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
