### PR TITLE
OE-975 : add data-test-id to lucid portals

### DIFF
--- a/src/components/Portal/Portal.spec.tsx
+++ b/src/components/Portal/Portal.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import assert from 'assert';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import Portal from './Portal';
 
@@ -12,6 +12,15 @@ describe('Portal', () => {
 
 				assert(document.getElementById('test1234'));
 				wrapper.unmount();
+			});
+		});
+
+		describe('data-test-id', () => {
+			it('should set the data-test-id of the portal DOM element portalId', () => {
+				const wrapper = shallow(<Portal className='test-classname' />);
+				expect(
+					wrapper.find('[data-test-id="test-classname"]').exists()
+				).toEqual(true);
 			});
 		});
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -78,6 +78,7 @@ class Portal extends React.Component<IPortalProps, IPortalState, {}> {
 		return this.state.isReady
 			? ReactDOM.createPortal(
 					<div
+						data-test-id={this.props.className}
 						className={classNames(cx('&'), this.props.className)}
 						{...omitProps(this.props, undefined, _.keys(Portal.propTypes))}
 					>


### PR DESCRIPTION
## PR Checklist

This is about adding data-test-ids to portal so that we can use them in our cypress tests to verify the UI behaviour around the dialog and other UI Elements where portal is being used. 
I added className as data-test-id because it seems to be the best way, as if I used portalId, it was something autogenerated one which we can't use to test the behaviour.

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
