### PR TITLE
Cxp 2589 text field validated fix props

### DIFF
--- a/src/components/TextField/TextField.spec.tsx
+++ b/src/components/TextField/TextField.spec.tsx
@@ -9,6 +9,8 @@ import assert from 'assert';
 import TextField from './TextField';
 import { MOSTLY_STABLE_DELAY } from '../../../tests/constants';
 
+const defaultProps = TextField.defaultProps;
+
 describe('TextField', () => {
 	common(TextField);
 	controls(TextField, {
@@ -29,7 +31,11 @@ describe('TextField', () => {
 		};
 		const onChangeDebounced = sinon.spy();
 		const wrapper = shallow(
-			<TextField onChangeDebounced={onChangeDebounced} debounceLevel={0} />
+			<TextField
+				{...defaultProps}
+				onChangeDebounced={onChangeDebounced}
+				debounceLevel={0}
+			/>
 		);
 
 		wrapper.find('input').simulate('change', event);
@@ -44,7 +50,7 @@ describe('TextField', () => {
 	});
 
 	it('should accept a new `value` prop immediately if the user has not typed anything recently', () => {
-		const wrapper = shallow(<TextField value='start' />);
+		const wrapper = shallow(<TextField {...defaultProps} value='start' />);
 
 		wrapper.setProps({ value: 'end' });
 
@@ -53,7 +59,9 @@ describe('TextField', () => {
 
 	// This test had value, but it's been known to be flaky.
 	it('should postpone state changes if the user recently typed something in [mostly stable]', (done) => {
-		const wrapper = shallow(<TextField value='start' lazyLevel={1} />);
+		const wrapper = shallow(
+			<TextField {...defaultProps} value='start' lazyLevel={1} />
+		);
 
 		// Order of operations is crucial for this test
 		// 1) User starts typing something in
@@ -77,7 +85,9 @@ describe('TextField', () => {
 
 	it('should callback onSubmit when the user hits enter', () => {
 		const onSubmit = sinon.spy();
-		const wrapper = shallow(<TextField onSubmit={onSubmit} />);
+		const wrapper = shallow(
+			<TextField {...defaultProps} onSubmit={onSubmit} />
+		);
 
 		wrapper.find('input').simulate('keydown', {
 			keyCode: KEYCODE.Enter,
@@ -92,7 +102,7 @@ describe('TextField', () => {
 
 	it('should callback onBlur when the leaves input', () => {
 		const onBlur = sinon.spy();
-		const wrapper = shallow(<TextField onBlur={onBlur} />);
+		const wrapper = shallow(<TextField {...defaultProps} onBlur={onBlur} />);
 
 		wrapper.find('input').simulate('blur', {
 			target: {
@@ -105,13 +115,13 @@ describe('TextField', () => {
 	});
 
 	it('should respect isDisabled', () => {
-		const wrapper = shallow(<TextField isDisabled={true} />);
+		const wrapper = shallow(<TextField {...defaultProps} isDisabled={true} />);
 
 		assert.strictEqual(wrapper.find('input').prop('disabled'), true);
 	});
 
 	it('should respect isMultiLine', () => {
-		const wrapper = shallow(<TextField isMultiLine={true} />);
+		const wrapper = shallow(<TextField {...defaultProps} isMultiLine={true} />);
 
 		assert.strictEqual(wrapper.find('textarea').length, 1);
 		assert.strictEqual(
@@ -122,7 +132,9 @@ describe('TextField', () => {
 
 	it('should respect onKeyDown if passed in', () => {
 		const onKeyDown = jest.fn();
-		const wrapper = shallow(<TextField onKeyDown={onKeyDown} />);
+		const wrapper = shallow(
+			<TextField {...defaultProps} onKeyDown={onKeyDown} />
+		);
 
 		wrapper.find('input').simulate('keydown', {});
 
@@ -138,7 +150,7 @@ describe('TextField', () => {
 		};
 		const onChangeDebounced = () => {}; // intentionally not _.noop
 		const wrapper = shallow(
-			<TextField onChangeDebounced={onChangeDebounced} />
+			<TextField {...defaultProps} onChangeDebounced={onChangeDebounced} />
 		);
 
 		assert(event.persist.notCalled);
@@ -164,6 +176,7 @@ describe('TextField', () => {
 
 		const wrapper = shallow(
 			<TextField
+				{...defaultProps}
 				onBlur={onBlur}
 				debounceLevel={100}
 				onChangeDebounced={onChangeDebounced}
@@ -194,6 +207,7 @@ describe('TextField', () => {
 
 		const wrapper = shallow(
 			<TextField
+				{...defaultProps}
 				onSubmit={onSubmit}
 				debounceLevel={100}
 				onChangeDebounced={onChangeDebounced}

--- a/src/components/TextField/TextField.spec.tsx
+++ b/src/components/TextField/TextField.spec.tsx
@@ -22,6 +22,56 @@ describe('TextField', () => {
 		},
 	});
 
+	describe('props', () => {
+		it('should pass though some props to its underlying textarea or input element', () => {
+			//const onBlurFunc = () => {};
+			const style = { margin: 10 };
+			const wrapper = shallow(
+				<TextField
+					{...defaultProps}
+					isDisabled={true}
+					style={style}
+					rows={10}
+					value='test'
+				/>
+			);
+			console.warn(wrapper.debug());
+			assert.strictEqual(wrapper.find('input').prop('disabled'), true);
+			assert.strictEqual(wrapper.find('input').prop('style'), style);
+			assert.strictEqual(wrapper.find('input').prop('rows'), 10);
+			assert.strictEqual(wrapper.find('input').prop('value'), 'test');
+		});
+
+		it('should not pass though several props to its underlying textarea or input element', () => {
+			const nonFinalProps = [
+				'onChangeDebounced',
+				'onSubmit',
+				'debounceLevel',
+				'lazyLevel',
+				'ref',
+				'initialState',
+				'callbackId',
+				'children',
+			];
+			const refValue = {};
+			const onChangeDebounced = () => {};
+			const onSubmit = () => {};
+			const wrapper = shallow(
+				<TextField
+					{...defaultProps}
+					ref={refValue}
+					callbackId={0}
+					onChangeDebounced={onChangeDebounced}
+					onSubmit={onSubmit}
+					lazyLevel={500}
+				/>
+			);
+			nonFinalProps.forEach((nonFinalProp) => {
+				assert.strictEqual(wrapper.find('input').prop(nonFinalProp), undefined);
+			});
+		});
+	});
+
 	it('should correctly debounce onChangeDebounced [mostly stable]', (done) => {
 		const event = {
 			target: {

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 
 import TextField, { ITextFieldProps } from './TextField';
-import TextFieldPlain from './TextFieldPlain';
 import Button from '../Button/Button';
 
 export default {
@@ -40,12 +39,12 @@ export const Basic: Story<ITextFieldProps> = (args) => {
 export const Plain: Story<ITextFieldProps> = (args) => {
 	return (
 		<div>
-			<TextFieldPlain
+			<TextField
 				{...args}
 				style={style}
 				placeholder='Plain Textfield example'
 			/>
-			<TextFieldPlain
+			<TextField
 				{...args}
 				isMultiLine
 				rows={5}

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import createClass from 'create-react-class';
-import TextField from './TextField';
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
+
+import TextField, { ITextFieldProps } from './TextField';
 import TextFieldPlain from './TextFieldPlain';
 import Button from '../Button/Button';
 
@@ -10,52 +11,42 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (TextField as any).peek.description,
+				component: TextField.peek.description,
 			},
 		},
 	},
+} as Meta;
+
+const style = {
+	marginBottom: '10px',
 };
 
-/* Basic */
-export const Basic = () => {
-	const style = {
-		marginBottom: '10px',
-	};
-
-	const Component = createClass({
-		getInitialState() {
-			return {
-				value: '',
-			};
-		},
-
-		render() {
-			return (
-				<div>
-					<TextField
-						style={style}
-						placeholder='default'
-						value={this.state.value}
-						onChange={(value) => this.setState({ value })}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
-};
-
-/* Plain */
-export const Plain = () => {
-	const style = {
-		marginBottom: '10px',
-	};
+export const Basic: Story<ITextFieldProps> = (args) => {
+	const [value, setValue] = useState('');
 
 	return (
 		<div>
-			<TextFieldPlain style={style} placeholder='Plain Textfield example' />
+			<TextField
+				{...args}
+				style={style}
+				placeholder='default'
+				value={value}
+				onChange={(value) => setValue(value)}
+			/>
+		</div>
+	);
+};
+
+export const Plain: Story<ITextFieldProps> = (args) => {
+	return (
+		<div>
 			<TextFieldPlain
+				{...args}
+				style={style}
+				placeholder='Plain Textfield example'
+			/>
+			<TextFieldPlain
+				{...args}
 				isMultiLine
 				rows={5}
 				style={style}
@@ -65,152 +56,98 @@ export const Plain = () => {
 	);
 };
 
-/* On Submit */
-export const OnSubmit = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				value: 'Enter some text in and hit enter',
-			};
-		},
+export const OnSubmit: Story<ITextFieldProps> = (args) => {
+	const [value, setValue] = useState('Enter some text in and hit enter');
 
-		render() {
-			return (
-				<div>
-					<TextField
-						style={{
-							marginBottom: '10px',
-						}}
-						value={this.state.value}
-						onSubmit={(value) => this.setState({ value })}
-					/>
-					<div style={{ marginTop: '10px', marginLeft: '10px' }}>
-						this.state.value: {this.state.value}
-					</div>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<div>
+			<TextField
+				{...args}
+				style={style}
+				value={value}
+				onSubmit={(value) => setValue(value)}
+			/>
+			<div style={{ marginTop: '10px', marginLeft: '10px' }}>
+				state.value: {value}
+			</div>
+		</div>
+	);
 };
 
-/* Debounced */
-export const Debounced = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				value: 'foo',
-			};
-		},
+export const Debounced: Story<ITextFieldProps> = (args) => {
+	const [value, setValue] = useState('foo');
 
-		render() {
-			return (
-				<div>
-					<TextField
-						style={{
-							marginBottom: '10px',
-						}}
-						value={this.state.value}
-						onChangeDebounced={(value) => this.setState({ value })}
-					/>
-
-					<div style={{ marginBottom: '10px', marginLeft: '10px' }}>
-						this.state.value: {this.state.value}
-					</div>
-
-					<Button
-						onClick={() => {
-							this.setState({ value: 'foo' });
-						}}
-					>
-						Set TextField to "foo"
-					</Button>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<div>
+			<TextField
+				{...args}
+				style={style}
+				value={value}
+				onChangeDebounced={(value) => setValue(value)}
+			/>
+			<div style={{ marginBottom: '10px', marginLeft: '10px' }}>
+				state.value: {value}
+			</div>
+			<Button
+				{...Button.defaultProps}
+				onClick={() => {
+					setValue('foo');
+				}}
+			>
+				Set TextField to "foo"
+			</Button>
+		</div>
+	);
 };
 
-/* Multiline */
-export const Multiline = () => {
-	const style = {
-		marginBottom: '10px',
-	};
+export const Multiline: Story<ITextFieldProps> = (args) => {
+	const [value, setValue] = useState('');
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				value: '',
-			};
-		},
-
-		render() {
-			return (
-				<div>
-					<TextField
-						style={style}
-						placeholder='default'
-						value={this.state.value}
-						onChange={(value) => this.setState({ value })}
-					/>
-
-					<TextField
-						isMultiLine
-						placeholder='isMultiLine'
-						style={style}
-						value={this.state.value}
-						onChange={(value) => this.setState({ value })}
-					/>
-
-					<div style={{ marginBottom: '10px', marginLeft: '10px' }}>
-						this.state.value: {this.state.value}
-					</div>
-
-					<Button
-						onClick={() => {
-							this.setState({ value: 'foo' });
-						}}
-					>
-						Set TextField to "foo"
-					</Button>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<div>
+			<TextField
+				{...args}
+				placeholder='default'
+				style={style}
+				value={value}
+				onChange={(value) => setValue(value)}
+			/>
+			<TextField
+				{...args}
+				isMultiLine
+				placeholder='isMultiline'
+				style={style}
+				value={value}
+				onChange={(value) => setValue(value)}
+			/>
+			<div style={{ marginBottom: '10px', marginLeft: '10px' }}>
+				state.value: {value}
+			</div>
+			<Button
+				{...Button.defaultProps}
+				onClick={() => {
+					setValue('foo');
+				}}
+			>
+				Set TextField to "foo"
+			</Button>
+		</div>
+	);
 };
 
-/* Disabled */
-export const Disabled = () => {
-	const style = {
-		marginBottom: '10px',
-	};
+export const Disabled: Story<ITextFieldProps> = (args) => {
+	const [value, setValue] = useState('foo');
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				value: '',
-			};
-		},
-
-		render() {
-			return (
-				<div>
-					<TextField
-						style={style}
-						placeholder='disabled'
-						isDisabled
-						value={this.state.value}
-						onChange={(value) => this.setState({ value })}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<div>
+			<TextField
+				{...args}
+				placeholder='disabled'
+				isDisabled
+				style={style}
+				value={value}
+				onChange={(value) => setValue(value)}
+			/>
+		</div>
+	);
 };

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -92,6 +92,9 @@ export interface ITextFieldProps extends StandardProps {
 		flowing in to the component until the timer has elapsed.  This was
 		heavily inspired by the [lazy-input](https:/docs.npmjs.com/package/lazy-input) component. */
 	lazyLevel?: number;
+
+	/** A reference to the node accessible at the current attribute of the ref. */
+	ref?: any;
 }
 
 export type ITextFieldPropsWithPassThroughs = Overwrite<
@@ -120,6 +123,7 @@ const nonPassThroughs = [
 	'value',
 	'debounceLevel',
 	'lazyLevel',
+	'ref',
 	'initialState',
 	'callbackId',
 	'children',
@@ -213,6 +217,15 @@ class TextField extends React.Component<
 			[lazy-input](https:/docs.npmjs.com/package/lazy-input) component.
 		*/
 		lazyLevel: number,
+
+		/**
+			 When a ref is passed to an element in render, 
+		 	a reference to the node becomes accessible at the current attribute of the ref.
+		 */
+		ref: oneOfType([
+			PropTypes.func,
+			PropTypes.shape({ current: PropTypes.elementType }),
+		]),
 	};
 
 	state = {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -373,7 +373,7 @@ class TextField extends React.Component<
 		const { value } = this.state;
 
 		const finalProps = {
-			..._.omit(passThroughs, nonPassThroughs),
+			...(_.omit(passThroughs, nonPassThroughs) as any),
 			className: cx(
 				'&',
 				{

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	omitProps,
-	StandardProps,
-	Overwrite,
-} from '../../util/component-types';
+import { StandardProps, Overwrite } from '../../util/component-types';
 import reducers from './TextField.reducers';
 import * as KEYCODE from '../../constants/key-code';
 
@@ -107,6 +104,26 @@ export interface ITextFieldState {
 	isHolding: boolean;
 	isMounted: boolean;
 }
+
+/** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
+const nonPassThroughs = [
+	'style',
+	'isMultiLine',
+	'isDisabled',
+	'rows',
+	'className',
+	'onChange',
+	'onBlur',
+	'onChangeDebounced',
+	'onKeyDown',
+	'onSubmit',
+	'value',
+	'debounceLevel',
+	'lazyLevel',
+	'initialState',
+	'callbackId',
+	'children',
+];
 
 class TextField extends React.Component<
 	ITextFieldPropsWithPassThroughs,
@@ -343,10 +360,7 @@ class TextField extends React.Component<
 		const { value } = this.state;
 
 		const finalProps = {
-			...omitProps(passThroughs, undefined, [
-				..._.keys(TextField.propTypes),
-				'children',
-			]),
+			..._.omit(passThroughs, nonPassThroughs),
 			className: cx(
 				'&',
 				{

--- a/src/components/TextField/TextFieldPlain.spec.tsx
+++ b/src/components/TextField/TextFieldPlain.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { shallow } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import TextFieldPlain from './TextFieldPlain';
-import { shallow } from 'enzyme';
 
 describe('TextField', () => {
 	common(TextFieldPlain);

--- a/src/components/TextField/TextFieldPlain.tsx
+++ b/src/components/TextField/TextFieldPlain.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import PropTypes from 'prop-types';
 
@@ -11,6 +12,8 @@ interface TextFieldInputPlain extends InputProps {
 	isDisabled?: boolean;
 	isMultiLine?: boolean;
 	rows?: number;
+	style?: object;
+	placeholder?: string;
 }
 interface TextFieldTextareaPlain extends TextareaProps {
 	isDisabled?: boolean;

--- a/src/components/TextField/__snapshots__/TextField.spec.tsx.snap
+++ b/src/components/TextField/__snapshots__/TextField.spec.tsx.snap
@@ -23,9 +23,9 @@ exports[`TextField [common] example testing should match snapshot(s) for Debounc
     value="foo"
   />
   <div
-    style="margin-bottom:10px;margin-left:10px"
+    style="margin-top:10px;margin-left:10px"
   >
-    this.state.value: foo
+    state.value: foo
   </div>
   <button
     class="lucid-Button"
@@ -49,8 +49,23 @@ exports[`TextField [common] example testing should match snapshot(s) for Disable
     rows="5"
     style="margin-bottom:10px"
     type="text"
-    value=""
+    value="foo"
   />
+  <div
+    style="margin-top:10px;margin-left:10px"
+  >
+    state.value: foo
+  </div>
+  <button
+    class="lucid-Button"
+    type="button"
+  >
+    <span
+      class="lucid-Button-content"
+    >
+      Set TextField to "foo"
+    </span>
+  </button>
 </div>
 `;
 
@@ -58,22 +73,23 @@ exports[`TextField [common] example testing should match snapshot(s) for Multili
 <div>
   <input
     class="lucid-TextField lucid-TextField-is-single-line"
-    placeholder="default"
     rows="5"
     style="margin-bottom:10px"
     type="text"
-    value=""
+    value="foo"
   />
   <textarea
     class="lucid-TextField lucid-TextField-is-multi-line"
-    placeholder="isMultiLine"
+    placeholder="isMultiline"
     rows="5"
     style="margin-bottom:10px"
-  />
-  <div
-    style="margin-bottom:10px;margin-left:10px"
   >
-    this.state.value: 
+    foo
+  </textarea>
+  <div
+    style="margin-top:10px;margin-left:10px"
+  >
+    state.value: foo
   </div>
   <button
     class="lucid-Button"
@@ -100,7 +116,7 @@ exports[`TextField [common] example testing should match snapshot(s) for OnSubmi
   <div
     style="margin-top:10px;margin-left:10px"
   >
-    this.state.value: Enter some text in and hit enter
+    state.value: Enter some text in and hit enter
   </div>
 </div>
 `;

--- a/src/components/TextField/__snapshots__/TextField.spec.tsx.snap
+++ b/src/components/TextField/__snapshots__/TextField.spec.tsx.snap
@@ -108,12 +108,15 @@ exports[`TextField [common] example testing should match snapshot(s) for OnSubmi
 exports[`TextField [common] example testing should match snapshot(s) for Plain 1`] = `
 <div>
   <input
-    class="lucid-TextFieldPlain lucid-TextFieldPlain-is-single-line"
+    class="lucid-TextField lucid-TextField-is-single-line"
     placeholder="Plain Textfield example"
+    rows="5"
     style="margin-bottom:10px"
+    type="text"
+    value=""
   />
   <textarea
-    class="lucid-TextFieldPlain lucid-TextFieldPlain-is-multi-line"
+    class="lucid-TextField lucid-TextField-is-multi-line"
     placeholder="Plain Textfield multiline example"
     rows="5"
     style="margin-bottom:10px"

--- a/src/components/TextField/__snapshots__/TextField.spec.tsx.snap
+++ b/src/components/TextField/__snapshots__/TextField.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`TextField [common] example testing should match snapshot(s) for Debounc
     value="foo"
   />
   <div
-    style="margin-top:10px;margin-left:10px"
+    style="margin-bottom:10px;margin-left:10px"
   >
     state.value: foo
   </div>
@@ -51,21 +51,6 @@ exports[`TextField [common] example testing should match snapshot(s) for Disable
     type="text"
     value="foo"
   />
-  <div
-    style="margin-top:10px;margin-left:10px"
-  >
-    state.value: foo
-  </div>
-  <button
-    class="lucid-Button"
-    type="button"
-  >
-    <span
-      class="lucid-Button-content"
-    >
-      Set TextField to "foo"
-    </span>
-  </button>
 </div>
 `;
 
@@ -73,23 +58,22 @@ exports[`TextField [common] example testing should match snapshot(s) for Multili
 <div>
   <input
     class="lucid-TextField lucid-TextField-is-single-line"
+    placeholder="default"
     rows="5"
     style="margin-bottom:10px"
     type="text"
-    value="foo"
+    value=""
   />
   <textarea
     class="lucid-TextField lucid-TextField-is-multi-line"
     placeholder="isMultiline"
     rows="5"
     style="margin-bottom:10px"
-  >
-    foo
-  </textarea>
+  />
   <div
-    style="margin-top:10px;margin-left:10px"
+    style="margin-bottom:10px;margin-left:10px"
   >
-    state.value: foo
+    state.value: 
   </div>
   <button
     class="lucid-Button"

--- a/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
@@ -1,18 +1,49 @@
 import React from 'react';
+import { shallow } from 'enzyme';
+import assert from 'assert';
+
 import { common } from '../../util/generic-tests';
 import TextFieldValidated from './TextFieldValidated';
 import TextField from '../TextField/TextField';
-import { shallow } from 'enzyme';
-import assert from 'assert';
+
+const defaultProps = TextFieldValidated.defaultProps;
 
 describe('TextFieldValidated', () => {
 	common(TextFieldValidated);
 
 	describe('props', () => {
-		it('should pass through props to TextField', () => {
+		it('should pass through onBlur prop to TextField', () => {
 			const onBlur = () => {};
-			const wrapper = shallow(<TextFieldValidated onBlur={onBlur} />);
+			const wrapper = shallow(
+				<TextFieldValidated {...defaultProps} onBlur={onBlur} />
+			);
 			assert.strictEqual(wrapper.find(TextField).prop('onBlur'), onBlur);
+		});
+
+		it('should not pass through its props to TextField', () => {
+			const nonPassThroughs = [
+				'style',
+				'className',
+				'Error',
+				'Info',
+				'initialState',
+			];
+			const style = { height: 20 };
+			const wrapper = shallow(
+				<TextFieldValidated
+					{...defaultProps}
+					style={style}
+					className='test'
+					Error='Error'
+					Info='Info'
+				/>
+			);
+			nonPassThroughs.forEach((nonPassThrough) => {
+				assert.strictEqual(
+					wrapper.find(TextField).prop(nonPassThrough),
+					undefined
+				);
+			});
 		});
 	});
 });

--- a/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
 import createClass from 'create-react-class';
-import TextFieldValidated from './TextFieldValidated';
+
+import TextFieldValidated, {
+	ITextFieldValidatedProps,
+} from './TextFieldValidated';
 
 export default {
 	title: 'Controls/TextFieldValidated',
@@ -8,88 +12,56 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (TextFieldValidated as any).peek.description,
+				component: TextFieldValidated.peek.description,
 			},
 		},
 	},
+} as Meta;
+
+const style = {
+	marginBottom: '10px',
 };
 
-/* Basic */
-export const Basic = () => {
-	const Component = createClass({
-		render() {
-			return <TextFieldValidated Error='Nope, not even close!' />;
-		},
-	});
-
-	return <Component />;
+export const Basic: Story<ITextFieldValidatedProps> = (args) => {
+	return <TextFieldValidated {...args} Error='Nope, not even close!' />;
 };
 
-/* Debounced */
-export const Debounced = () => {
-	const style = {
-		marginBottom: '10px',
-	};
+export const Debounced: Story<ITextFieldValidatedProps> = (args) => {
+	const [value, setValue] = useState('');
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				value: '',
-			};
-		},
-
-		render() {
-			return (
-				<div>
-					<TextFieldValidated
-						style={style}
-						value={this.state.value}
-						onChangeDebounced={(value) => this.setState({ value })}
-						Error={this.state.value === 'foo' ? null : 'Please enter "foo"'}
-					/>
-					<div style={style}>state.value: {this.state.value}</div>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<div>
+			<TextFieldValidated
+				{...args}
+				style={style}
+				value={value}
+				onChangeDebounced={(value) => setValue(value)}
+				Error={value === 'foo' ? null : 'Please enter "foo"'}
+			/>
+		</div>
+	);
 };
 
-/* Error Types */
-export const ErrorTypes = () => {
-	const style = {
-		marginBottom: '10px',
-	};
+export const ErrorTypes: Story<ITextFieldValidatedProps> = (args) => {
+	const [value, setValue] = useState('');
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				value: '',
-			};
-		},
-
-		render() {
-			return (
-				<div>
-					<TextFieldValidated
-						style={style}
-						value={this.state.value}
-						onChangeDebounced={() => {}}
-						Error={'This is an error'}
-					/>
-					<TextFieldValidated
-						style={style}
-						value={this.state.value}
-						onChangeDebounced={() => {}}
-						Error={null}
-						Info={'This is an info'}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<div>
+			<TextFieldValidated
+				{...args}
+				style={style}
+				value={value}
+				onChangeDebounced={() => {}}
+				Error={'This is an error'}
+			/>
+			<TextFieldValidated
+				{...args}
+				style={style}
+				value={value}
+				onChangeDebounced={() => {}}
+				Error={null}
+				Info={'This is an info'}
+			/>
+		</div>
+	);
 };
-ErrorTypes.storyName = 'ErrorTypes';

--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -8,7 +8,7 @@ import TextField, {
 } from '../TextField/TextField';
 import reducers from '../TextField/TextField.reducers';
 import { lucidClassNames } from '../../util/style-helpers';
-import { findTypes, omitProps } from '../../util/component-types';
+import { findTypes } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-TextFieldValidated');
 
@@ -25,6 +25,9 @@ TextFieldValidatedError.peek = {
 	description: `Content that will be displayed as an error message.`,
 };
 TextFieldValidatedError.propName = 'Error';
+
+/** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
+const nonPassThroughs = ['style', 'className', 'Error', 'Info', 'initialState'];
 
 export interface ITextFieldValidatedProps
 	extends ITextFieldPropsWithPassThroughs {
@@ -104,12 +107,7 @@ class TextFieldValidated extends React.Component<
 				Error={childProps}
 			>
 				<TextField
-					{...omitProps(
-						passThroughs,
-						undefined,
-						_.keys(TextFieldValidated.propTypes),
-						false
-					)}
+					{...(_.omit(passThroughs, nonPassThroughs) as any)}
 					ref={this.textFieldRef}
 				/>
 			</Validation>

--- a/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
+++ b/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
@@ -36,11 +36,6 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
       Please enter "foo"
     </div>
   </div>
-  <div
-    style="margin-bottom:10px"
-  >
-    state.value: 
-  </div>
 </div>
 `;
 


### PR DESCRIPTION
## PR Checklist

For TextField and TextFieldValidated:
Replaces deprecated omitProps method with an explicit list of omitted props.
Adds unit tests for the omitted props
Updates the stories to SB6

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/CXP-2589-TextField-Validated-Fix-Props/?path=/docs/controls-textfield--basic)

TextField:
https://docspot.adnxs.net/projects/lucid/CXP-2589-TextField-Validated-Fix-Props/?path=/docs/controls-textfield--basic

TextFieldValidated:
https://docspot.adnxs.net/projects/lucid/CXP-2589-TextField-Validated-Fix-Props/?path=/docs/controls-textfieldvalidated--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
