### PR TITLE
Remove omitProps from SearchField and add unit tests for the nonPassThroughs

### DIFF
--- a/src/components/SearchField/SearchField.spec.tsx
+++ b/src/components/SearchField/SearchField.spec.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import _ from 'lodash';
+import React, { ReactElement } from 'react';
 import { shallow } from 'enzyme';
 import assert from 'assert';
 
@@ -11,11 +12,14 @@ describe('SearchField', () => {
 	common(SearchField);
 
 	describe('props', () => {
-		const fn = () => {};
+		const fn = _.noop;
+		const defaultProps = SearchField.defaultProps;
 
 		describe('onSubmit', () => {
 			it('should pass onSubmit to the underlying TextField', () => {
-				const wrapper = shallow(<SearchField onSubmit={fn} />);
+				const wrapper = shallow(
+					<SearchField {...defaultProps} onSubmit={fn} />
+				);
 				const textFieldWrapper = wrapper.find(TextField).first();
 				assert.strictEqual(textFieldWrapper.props().onSubmit, fn);
 			});
@@ -23,7 +27,9 @@ describe('SearchField', () => {
 
 		describe('onChange', () => {
 			it('should pass onChange to the underlying TextField', () => {
-				const wrapper = shallow(<SearchField onChange={fn} />);
+				const wrapper = shallow(
+					<SearchField {...defaultProps} onChange={fn} />
+				);
 				const textFieldWrapper = wrapper.find(TextField).first();
 				assert.strictEqual(textFieldWrapper.props().onChange, fn);
 			});
@@ -31,7 +37,9 @@ describe('SearchField', () => {
 
 		describe('onChangeDebounced', () => {
 			it('should pass onChangeDebounced to the underlying TextField', () => {
-				const wrapper = shallow(<SearchField onChangeDebounced={fn} />);
+				const wrapper = shallow(
+					<SearchField {...defaultProps} onChangeDebounced={fn} />
+				);
 				const textFieldWrapper = wrapper.find(TextField).first();
 				assert.strictEqual(textFieldWrapper.props().onChangeDebounced, fn);
 			});
@@ -39,7 +47,9 @@ describe('SearchField', () => {
 
 		describe('debounceLevel', () => {
 			it('should pass the `debounceLevel` prop thru to the underlying TextField', () => {
-				const wrapper = shallow(<SearchField debounceLevel={1000} />);
+				const wrapper = shallow(
+					<SearchField {...defaultProps} debounceLevel={1000} />
+				);
 				const textFieldWrapper = wrapper.find(TextField).first();
 				assert.strictEqual(textFieldWrapper.prop('debounceLevel'), 1000);
 			});
@@ -47,7 +57,9 @@ describe('SearchField', () => {
 
 		describe('isDisabled', () => {
 			it('should pass the `isDisabled` prop thru to the underlying TextField', () => {
-				const wrapper = shallow(<SearchField isDisabled={true} />);
+				const wrapper = shallow(
+					<SearchField {...defaultProps} isDisabled={true} />
+				);
 				const textFieldWrapper = wrapper.find(TextField).first();
 				assert.strictEqual(textFieldWrapper.prop('isDisabled'), true);
 			});
@@ -56,7 +68,9 @@ describe('SearchField', () => {
 		describe('value', () => {
 			it('should pass a string value prop thru to the underlying TextField', () => {
 				const valueText = 'Name/ID';
-				const wrapper = shallow(<SearchField value={valueText} />);
+				const wrapper = shallow(
+					<SearchField {...defaultProps} value={valueText} />
+				);
 				const textFieldWrapper = wrapper.find(TextField).first();
 				assert.strictEqual(textFieldWrapper.prop('value'), valueText);
 			});
@@ -65,7 +79,9 @@ describe('SearchField', () => {
 		describe('placeholder', () => {
 			it('shold pass a placeholder text thru to the underlying TextField', () => {
 				const placeholderText = 'Some placeholder text';
-				const wrapper = shallow(<SearchField placeholder={placeholderText} />);
+				const wrapper = shallow(
+					<SearchField {...defaultProps} placeholder={placeholderText} />
+				);
 				const textFieldWrapper = wrapper.find(TextField).first();
 				assert.strictEqual(
 					textFieldWrapper.prop('placeholder'),
@@ -76,8 +92,9 @@ describe('SearchField', () => {
 
 		describe('isValid', () => {
 			it('should pass the `&-Icon-active` class to the underlying TextField', () => {
-				const wrapper = shallow(<SearchField isValid={true} />);
-				console.warn(wrapper.debug());
+				const wrapper = shallow(
+					<SearchField {...defaultProps} isValid={true} />
+				);
 				const textFieldWrapper = wrapper.find(SearchIcon).first();
 				assert.strictEqual(
 					textFieldWrapper.hasClass('lucid-SearchField-Icon-active'),
@@ -85,13 +102,40 @@ describe('SearchField', () => {
 				);
 			});
 			it('should not pass the `-Icon-active` class to the underlying TextField', () => {
-				const wrapper = shallow(<SearchField isValid={false} />);
-				console.warn(wrapper.debug());
+				const wrapper = shallow(
+					<SearchField {...defaultProps} isValid={false} />
+				);
 				const textFieldWrapper = wrapper.find(SearchIcon).first();
 				assert.strictEqual(
 					textFieldWrapper.hasClass('lucid-SearchField-Icon-active'),
 					false
 				);
+			});
+		});
+
+		describe('nonPassThroughs', () => {
+			it('should filter out specfic props from the SearchField wrapper', () => {
+				const nonPassThroughs = {
+					onChange: fn,
+					onChangeDebounced: fn,
+					debounceLevel: 1000,
+					onSubmit: fn,
+					value: 'search',
+					isValid: true,
+					isDisabled: true,
+					placeholder: 'some placeholder text',
+					className: 'testClassName',
+					Icon: <SearchIcon />,
+					TextField: <></>,
+					initialState: {},
+					callbackId: 1,
+				};
+				const combinedProps = { ...defaultProps, ...nonPassThroughs };
+				const wrapper = shallow(<SearchField {...combinedProps} />);
+				assert.strictEqual(wrapper.prop('callbackId'), undefined);
+				assert.strictEqual(wrapper.prop('initalState'), undefined);
+				assert.strictEqual(wrapper.prop('Icon'), undefined);
+				assert.strictEqual(wrapper.prop('TextField'), undefined);
 			});
 		});
 	});

--- a/src/components/SearchField/SearchField.stories.tsx
+++ b/src/components/SearchField/SearchField.stories.tsx
@@ -20,12 +20,10 @@ export default {
 	},
 } as Meta;
 
-/* Basic */
 export const Basic: Story<ISearchFieldProps> = (args) => {
 	return <SearchField {...args} />;
 };
 
-/* Interactive */
 export const Interactive: Story<ISearchFieldProps> = (args) => {
 	const [state, setState] = useState('');
 
@@ -39,17 +37,14 @@ export const Interactive: Story<ISearchFieldProps> = (args) => {
 	);
 };
 
-/* Placeholder */
 export const Placeholder: Story<ISearchFieldProps> = (args) => {
 	return <SearchField {...args} placeholder='Name/ID' />;
 };
 
-/* Disabled */
 export const Disabled: Story<ISearchFieldProps> = (args) => {
 	return <SearchField {...args} isDisabled />;
 };
 
-/* Custom Icon */
 export const CustomIcon: Story<ISearchFieldProps> = (args) => {
 	return (
 		<SearchField {...args}>
@@ -60,7 +55,6 @@ export const CustomIcon: Story<ISearchFieldProps> = (args) => {
 	);
 };
 
-/* Custom Text Field */
 export const CustomTextField: Story<ISearchFieldProps> = (args) => {
 	const [state, setState] = useState({
 		value: '',
@@ -90,7 +84,6 @@ export const CustomTextField: Story<ISearchFieldProps> = (args) => {
 	);
 };
 
-/* Valid Search */
 export const ValidSearch: Story<ISearchFieldProps> = (args) => {
 	const [state, setState] = useState({
 		value: '',
@@ -110,7 +103,6 @@ export const ValidSearch: Story<ISearchFieldProps> = (args) => {
 	);
 };
 
-/* Props */
 export const Props: Story<ISearchFieldProps> = (args) => {
 	return (
 		<div>
@@ -135,7 +127,6 @@ export const Props: Story<ISearchFieldProps> = (args) => {
 	);
 };
 
-/* Debounced */
 export const Debounced: Story<ISearchFieldProps> = (args) => {
 	const [value, setValue] = useState('foo');
 
@@ -157,6 +148,7 @@ export const Debounced: Story<ISearchFieldProps> = (args) => {
 			</div>
 
 			<Button
+				{...Button.defaultProps}
 				onClick={() => {
 					setValue('foo');
 				}}

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -4,12 +4,7 @@ import React, { createElement } from 'react';
 import PropTypes from 'prop-types';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	StandardProps,
-	getFirst,
-	omitProps,
-	Overwrite,
-} from '../../util/component-types';
+import { StandardProps, getFirst, Overwrite } from '../../util/component-types';
 import { buildModernHybridComponent } from '../../util/state-management';
 import TextField, { ITextFieldProps } from '../TextField/TextField';
 import SearchIcon from '../Icon/SearchIcon/SearchIcon';
@@ -78,6 +73,23 @@ export interface ISearchFieldProps extends StandardProps {
 	/**n placeholder value */
 	placeholder?: string;
 }
+
+/** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
+const nonPassThroughs = [
+	'onChange',
+	'onChangeDebounced',
+	'debounceLevel',
+	'onSubmit',
+	'value',
+	'isValid',
+	'isDisabled',
+	'placeholder',
+	'className',
+	'Icon',
+	'TextField',
+	'initialState',
+	'callbackId',
+];
 
 type ISearchFieldPropsWithPassThroughs = Overwrite<
 	React.DetailedHTMLProps<
@@ -235,7 +247,7 @@ class SearchField extends React.Component<
 
 		return (
 			<div
-				{...omitProps(passThroughs, undefined, _.keys(SearchField.propTypes))}
+				{..._.omit(passThroughs, nonPassThroughs)}
 				className={cx('&', className)}
 			>
 				{textFieldElement}


### PR DESCRIPTION

## PR Checklist

- Replace omitProps with _.omit and explicit list of nonPassThroughs props for SearchField.
- Tidy up the SB6 stories.
- Add a unit test to ensure the props are removed. 

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/CXP-2810-SearchField-Remove-omitProps/?path=/docs/controls-searchfield--basic)

SearchField Story:
https://docspot.adnxs.net/projects/lucid/CXP-2810-SearchField-Remove-omitProps/?path=/docs/controls-searchfield--basic
- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
