### PR TITLE
Cxp 2720 radio group button group props

### DIFF
--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -388,13 +388,13 @@ export const Stateless = () => {
 					suggestions={wordlist}
 					value='ab'
 					onSelect={(index: any) => {
-						console.log(`selected: ${wordlist[index]}`);
+						console.warn(`selected: ${wordlist[index]}`);
 					}}
 					DropMenu={{
 						isExpanded: true,
 						focusedIndex: 2,
 						onCollapse: () => {
-							console.log('onCollapse');
+							console.warn('onCollapse');
 						},
 					}}
 				/>

--- a/src/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -12,88 +12,88 @@ const defaultProps = ButtonGroup.defaultProps;
 describe('ButtonGroup', () => {
 	common(ButtonGroup);
 
-	it('prop children', () => {
-		const wrapper = shallow(
-			<ButtonGroup {...defaultProps}>
-				<ButtonGroup.Button data-test-name='one' />
-				<div className='jim' />
-			</ButtonGroup>
-		);
+	describe('props', () => {
+		it('prop children', () => {
+			const wrapper = shallow(
+				<ButtonGroup {...defaultProps}>
+					<ButtonGroup.Button data-test-name='one' />
+					<div className='jim' />
+				</ButtonGroup>
+			);
 
-		assert(wrapper.contains(<div className='jim' />));
-	});
+			assert(wrapper.contains(<div className='jim' />));
+		});
 
-	it('prop selectedIndices', () => {
-		const wrapper = shallow(
-			<ButtonGroup {...defaultProps} selectedIndices={[1]}>
-				<ButtonGroup.Button data-test-name='zero' />
-				<ButtonGroup.Button data-test-name='one' />
-			</ButtonGroup>
-		);
+		it('prop selectedIndices', () => {
+			const wrapper = shallow(
+				<ButtonGroup {...defaultProps} selectedIndices={[1]}>
+					<ButtonGroup.Button data-test-name='zero' />
+					<ButtonGroup.Button data-test-name='one' />
+				</ButtonGroup>
+			);
 
-		assert.strictEqual(wrapper.children().at(1).prop('isActive'), true);
-	});
-});
+			assert.strictEqual(wrapper.children().at(1).prop('isActive'), true);
+		});
 
-describe('ButtonGroup', () => {
-	it('prop onSelect', () => {
-		const onSelect: any = sinon.spy();
-		const wrapper = mount(
-			<ButtonGroup {...defaultProps} onSelect={onSelect}>
-				<ButtonGroup.Button data-test-name='zero' />
-				<ButtonGroup.Button data-test-name='one' />
-			</ButtonGroup>
-		);
+		it('prop onSelect', () => {
+			const onSelect: any = sinon.spy();
+			const wrapper = mount(
+				<ButtonGroup {...defaultProps} onSelect={onSelect}>
+					<ButtonGroup.Button data-test-name='zero' />
+					<ButtonGroup.Button data-test-name='one' />
+				</ButtonGroup>
+			);
 
-		wrapper.find('button[data-test-name="one"]').simulate('click');
+			wrapper.find('button[data-test-name="one"]').simulate('click');
 
-		assert.strictEqual(onSelect.args[0][0], 1);
-	});
+			assert.strictEqual(onSelect.args[0][0], 1);
+		});
 
-	it('prop onSelect on children', () => {
-		const onClick = sinon.spy();
-		const wrapper = mount(
-			<ButtonGroup {...defaultProps}>
-				<ButtonGroup.Button data-test-name='zero' />
-				<ButtonGroup.Button onClick={onClick} data-test-name='one' />
-			</ButtonGroup>
-		);
+		it('prop onSelect on children', () => {
+			const onClick = sinon.spy();
+			const wrapper = mount(
+				<ButtonGroup {...defaultProps}>
+					<ButtonGroup.Button data-test-name='zero' />
+					<ButtonGroup.Button onClick={onClick} data-test-name='one' />
+				</ButtonGroup>
+			);
 
-		wrapper.find('button[data-test-name="one"]').simulate('click');
+			wrapper.find('button[data-test-name="one"]').simulate('click');
 
-		assert(onClick.called, 'onClick was not called');
-		assert(
-			_.has(onClick.args[0][0], 'event'),
-			'`event` missing from `onClick` callback'
-		);
-		assert(
-			_.has(onClick.args[0][0], 'props'),
-			'`props` missing from `onClick` callback'
-		);
-	});
+			assert(onClick.called, 'onClick was not called');
+			assert(
+				_.has(onClick.args[0][0], 'event'),
+				'`event` missing from `onClick` callback'
+			);
+			assert(
+				_.has(onClick.args[0][0], 'props'),
+				'`props` missing from `onClick` callback'
+			);
+		});
 
-	it('tests onSelect props shape', () => {
-		const onSelect: any = jest.fn();
-		const wrapper = mount(
-			<ButtonGroup {...defaultProps} onSelect={onSelect}>
-				<ButtonGroup.Button data-test-name='zero' />
-				<ButtonGroup.Button data-test-name='one' />
-				<ButtonGroup.Button data-test-name='two' />
-			</ButtonGroup>
-		);
+		it('tests onSelect props have the correct shape', () => {
+			const onSelect: any = jest.fn();
+			const wrapper = mount(
+				<ButtonGroup {...defaultProps} onSelect={onSelect}>
+					<ButtonGroup.Button data-test-name='zero' />
+					<ButtonGroup.Button data-test-name='one' />
+					<ButtonGroup.Button data-test-name='two' />
+				</ButtonGroup>
+			);
 
-		wrapper.find('button[data-test-name="one"]').simulate('click');
+			wrapper.find('button[data-test-name="one"]').simulate('click');
 
-		expect(onSelect).toBeCalledWith(1, {
-			event: expect.anything(),
-			props: {
-				'data-test-name': 'one',
-				hasOnlyIcon: false,
-				isActive: false,
-				isDisabled: false,
-				onClick: expect.anything(),
-				type: 'button',
-			},
+			expect(onSelect).toBeCalledWith(1, {
+				event: expect.anything(),
+				props: {
+					'data-test-name': 'one',
+					hasOnlyIcon: false,
+					isActive: false,
+					isDisabled: false,
+					onClick: expect.anything(),
+					type: 'button',
+				},
+			});
 		});
 	});
 });

--- a/src/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -2,9 +2,9 @@ import _ from 'lodash';
 import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
-import { common } from '../../util/generic-tests';
 import { shallow, mount } from 'enzyme';
 
+import { common } from '../../util/generic-tests';
 import { ButtonGroupDumb as ButtonGroup } from './ButtonGroup';
 
 const defaultProps = ButtonGroup.defaultProps;
@@ -15,7 +15,7 @@ describe('ButtonGroup', () => {
 	it('prop children', () => {
 		const wrapper = shallow(
 			<ButtonGroup {...defaultProps}>
-				<ButtonGroup.Button />
+				<ButtonGroup.Button data-test-name='one' />
 				<div className='jim' />
 			</ButtonGroup>
 		);
@@ -26,8 +26,8 @@ describe('ButtonGroup', () => {
 	it('prop selectedIndices', () => {
 		const wrapper = shallow(
 			<ButtonGroup {...defaultProps} selectedIndices={[1]}>
-				<ButtonGroup.Button />
-				<ButtonGroup.Button />
+				<ButtonGroup.Button data-test-name='zero' />
+				<ButtonGroup.Button data-test-name='one' />
 			</ButtonGroup>
 		);
 
@@ -40,14 +40,36 @@ describe('ButtonGroup', () => {
 		const onSelect: any = sinon.spy();
 		const wrapper = mount(
 			<ButtonGroup {...defaultProps} onSelect={onSelect}>
-				<ButtonGroup.Button />
-				<ButtonGroup.Button />
+				<ButtonGroup.Button data-test-name='zero' />
+				<ButtonGroup.Button data-test-name='one' />
 			</ButtonGroup>
 		);
 
-		wrapper.children().children().at(1).simulate('click'); // second button
+		wrapper.find('button[data-test-name="one"]').simulate('click');
 
 		assert.strictEqual(onSelect.args[0][0], 1);
+	});
+
+	it('prop onSelect on children', () => {
+		const onClick = sinon.spy();
+		const wrapper = mount(
+			<ButtonGroup {...defaultProps}>
+				<ButtonGroup.Button data-test-name='zero' />
+				<ButtonGroup.Button onClick={onClick} data-test-name='one' />
+			</ButtonGroup>
+		);
+
+		wrapper.find('button[data-test-name="one"]').simulate('click');
+
+		assert(onClick.called, 'onClick was not called');
+		assert(
+			_.has(onClick.args[0][0], 'event'),
+			'`event` missing from `onClick` callback'
+		);
+		assert(
+			_.has(onClick.args[0][0], 'props'),
+			'`props` missing from `onClick` callback'
+		);
 	});
 
 	it('tests onSelect props shape', () => {
@@ -73,27 +95,5 @@ describe('ButtonGroup', () => {
 				type: 'button',
 			},
 		});
-	});
-
-	it('prop onSelect on children', () => {
-		const onClick = sinon.spy();
-		const wrapper = mount(
-			<ButtonGroup {...defaultProps}>
-				<ButtonGroup.Button />
-				<ButtonGroup.Button onClick={onClick} />
-			</ButtonGroup>
-		);
-
-		wrapper.children().children().at(1).simulate('click'); // second button
-
-		assert(onClick.called, 'onClick was not called');
-		assert(
-			_.has(onClick.args[0][0], 'event'),
-			'`event` missing from `onClick` callback'
-		);
-		assert(
-			_.has(onClick.args[0][0], 'props'),
-			'`props` missing from `onClick` callback'
-		);
 	});
 });

--- a/src/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -6,6 +6,8 @@ import { shallow, mount } from 'enzyme';
 
 import { common } from '../../util/generic-tests';
 import { ButtonGroupDumb as ButtonGroup } from './ButtonGroup';
+import { Button } from '../..';
+import { array } from 'prop-types';
 
 const defaultProps = ButtonGroup.defaultProps;
 
@@ -71,6 +73,22 @@ describe('ButtonGroup', () => {
 			);
 		});
 
+		it('omits the list of nonPassThroughs, except className and children', () => {
+			const nonPassThroughs = {
+				onSelect: _.noop,
+				className: 'testClassName',
+				children: <ButtonGroup.Button />,
+				selectedIndices: [0, 1],
+			};
+			const combinedProps = { ...defaultProps, ...nonPassThroughs };
+			const wrapper = shallow(<ButtonGroup {...combinedProps} />);
+
+			expect(wrapper.prop('className')).toContain('testClassName');
+			expect(wrapper.prop('onSelect')).toBeUndefined;
+			expect(wrapper.prop('selectedIndices')).toBeUndefined;
+			expect(wrapper.prop('children')).toBeTruthy;
+		});
+
 		it('tests onSelect props have the correct shape', () => {
 			const onSelect: any = jest.fn();
 			const wrapper = mount(
@@ -83,6 +101,7 @@ describe('ButtonGroup', () => {
 
 			wrapper.find('button[data-test-name="one"]').simulate('click');
 
+			expect(onSelect).toBeCalledTimes(1);
 			expect(onSelect).toBeCalledWith(1, {
 				event: expect.anything(),
 				props: {

--- a/src/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -7,12 +7,14 @@ import { shallow, mount } from 'enzyme';
 
 import { ButtonGroupDumb as ButtonGroup } from './ButtonGroup';
 
+const defaultProps = ButtonGroup.defaultProps;
+
 describe('ButtonGroup', () => {
 	common(ButtonGroup);
 
 	it('prop children', () => {
 		const wrapper = shallow(
-			<ButtonGroup>
+			<ButtonGroup {...defaultProps}>
 				<ButtonGroup.Button />
 				<div className='jim' />
 			</ButtonGroup>
@@ -23,7 +25,7 @@ describe('ButtonGroup', () => {
 
 	it('prop selectedIndices', () => {
 		const wrapper = shallow(
-			<ButtonGroup selectedIndices={[1]}>
+			<ButtonGroup {...defaultProps} selectedIndices={[1]}>
 				<ButtonGroup.Button />
 				<ButtonGroup.Button />
 			</ButtonGroup>
@@ -37,7 +39,7 @@ describe('ButtonGroup', () => {
 	it('prop onSelect', () => {
 		const onSelect: any = sinon.spy();
 		const wrapper = mount(
-			<ButtonGroup onSelect={onSelect}>
+			<ButtonGroup {...defaultProps} onSelect={onSelect}>
 				<ButtonGroup.Button />
 				<ButtonGroup.Button />
 			</ButtonGroup>
@@ -48,10 +50,35 @@ describe('ButtonGroup', () => {
 		assert.strictEqual(onSelect.args[0][0], 1);
 	});
 
+	it('tests onSelect props shape', () => {
+		const onSelect: any = jest.fn();
+		const wrapper = mount(
+			<ButtonGroup {...defaultProps} onSelect={onSelect}>
+				<ButtonGroup.Button data-test-name='zero' />
+				<ButtonGroup.Button data-test-name='one' />
+				<ButtonGroup.Button data-test-name='two' />
+			</ButtonGroup>
+		);
+
+		wrapper.find('button[data-test-name="one"]').simulate('click');
+
+		expect(onSelect).toBeCalledWith(1, {
+			event: expect.anything(),
+			props: {
+				'data-test-name': 'one',
+				hasOnlyIcon: false,
+				isActive: false,
+				isDisabled: false,
+				onClick: expect.anything(),
+				type: 'button',
+			},
+		});
+	});
+
 	it('prop onSelect on children', () => {
 		const onClick = sinon.spy();
 		const wrapper = mount(
-			<ButtonGroup>
+			<ButtonGroup {...defaultProps}>
 				<ButtonGroup.Button />
 				<ButtonGroup.Button onClick={onClick} />
 			</ButtonGroup>

--- a/src/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -6,8 +6,6 @@ import { shallow, mount } from 'enzyme';
 
 import { common } from '../../util/generic-tests';
 import { ButtonGroupDumb as ButtonGroup } from './ButtonGroup';
-import { Button } from '../..';
-import { array } from 'prop-types';
 
 const defaultProps = ButtonGroup.defaultProps;
 

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -86,10 +86,10 @@ export const OnClick: Story<IButtonGroupProps> = (args) => {
 
 	return (
 		<ButtonGroup {...args}>
-			<ButtonGroup.Button onClick={() => handleClick('zero')}>
+			<ButtonGroup.Button onClick={() => handleClick('Zero')}>
 				Zero
 			</ButtonGroup.Button>
-			<ButtonGroup.Button onClick={() => handleClick('one')}>
+			<ButtonGroup.Button onClick={() => handleClick('One')}>
 				One
 			</ButtonGroup.Button>
 		</ButtonGroup>

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
+import _ from 'lodash';
 import { Meta, Story } from '@storybook/react';
 
-import ButtonGroup, { ButtonGroupDumb, IButtonGroupProps } from './ButtonGroup';
+import ButtonGroup, { IButtonGroupProps } from './ButtonGroup';
 
 export default {
 	title: 'Controls/ButtonGroup',
-	component: ButtonGroupDumb,
+	component: ButtonGroup,
 	subcomponents: { 'ButtonGroup.Button': ButtonGroup.Button },
+	args: ButtonGroup.defaultProps,
 	parameters: {
 		docs: {
 			inlineStories: false,
@@ -17,7 +19,6 @@ export default {
 	},
 } as Meta;
 
-/** Default */
 export const Basic: Story<IButtonGroupProps> = (args) => {
 	const buttonStyle = { width: '100px' };
 	return (
@@ -29,14 +30,21 @@ export const Basic: Story<IButtonGroupProps> = (args) => {
 	);
 };
 
-/** Stateful */
 export const Stateful: Story<IButtonGroupProps> = (args) => {
-	const handleSelect: any = (idx, evt, props) => {
-		console.warn(idx, evt, props);
+	const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
+
+	const handleSelect = (selectedIndex: number, { event, props }) => {
+		const currentIndices = selectedIndices;
+		// If the item does not exist in the original array add it, if it exists remove it.
+		setSelectedIndices(_.xor(currentIndices, [selectedIndex]));
 	};
 
 	return (
-		<ButtonGroup {...args} onSelect={handleSelect}>
+		<ButtonGroup
+			{...args}
+			selectedIndices={selectedIndices}
+			onSelect={handleSelect}
+		>
 			<ButtonGroup.Button>Zero</ButtonGroup.Button>
 			<ButtonGroup.Button>One</ButtonGroup.Button>
 			<ButtonGroup.Button>Two</ButtonGroup.Button>
@@ -45,7 +53,6 @@ export const Stateful: Story<IButtonGroupProps> = (args) => {
 	);
 };
 
-/** Stateless */
 export const Stateless: Story<IButtonGroupProps> = (args) => {
 	return (
 		<ButtonGroup {...args} selectedIndices={[7, 8]}>
@@ -63,7 +70,6 @@ export const Stateless: Story<IButtonGroupProps> = (args) => {
 	);
 };
 
-/** Disabled */
 export const Disabled: Story<IButtonGroupProps> = (args) => {
 	const buttonStyle = { width: '100px' };
 	return (
@@ -78,10 +84,9 @@ export const Disabled: Story<IButtonGroupProps> = (args) => {
 	);
 };
 
-/** On Click */
 export const OnClick: Story<IButtonGroupProps> = (args) => {
-	const handleClick = (btn) => {
-		alert(btn);
+	const handleClick = (label) => {
+		alert(label);
 	};
 
 	return (

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -32,21 +32,18 @@ export const Basic: Story<IButtonGroupProps> = (args) => {
 /** Stateful */
 export const Stateful: Story<IButtonGroupProps> = (args) => {
 	const handleSelect: any = (idx, evt, props) => {
-		console.log(idx, evt, props);
+		console.warn(idx, evt, props);
 	};
 
 	return (
 		<ButtonGroup {...args} onSelect={handleSelect}>
-			<ButtonGroup.Button>Zero TEST</ButtonGroup.Button>
+			<ButtonGroup.Button>Zero</ButtonGroup.Button>
 			<ButtonGroup.Button>One</ButtonGroup.Button>
 			<ButtonGroup.Button>Two</ButtonGroup.Button>
 			<ButtonGroup.Button>Three</ButtonGroup.Button>
 		</ButtonGroup>
 	);
 };
-// Stateful.args = {
-// 	selectedIndices: [2]
-// }
 
 /** Stateless */
 export const Stateless: Story<IButtonGroupProps> = (args) => {
@@ -83,12 +80,18 @@ export const Disabled: Story<IButtonGroupProps> = (args) => {
 
 /** On Click */
 export const OnClick: Story<IButtonGroupProps> = (args) => {
+	const handleClick = (btn) => {
+		alert(btn);
+	};
+
 	return (
 		<ButtonGroup {...args}>
-			<ButtonGroup.Button onClick={() => alert('zero')}>
+			<ButtonGroup.Button onClick={() => handleClick('zero')}>
 				Zero
 			</ButtonGroup.Button>
-			<ButtonGroup.Button onClick={() => alert('one')}>One</ButtonGroup.Button>
+			<ButtonGroup.Button onClick={() => handleClick('one')}>
+				One
+			</ButtonGroup.Button>
 		</ButtonGroup>
 	);
 };

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -21,7 +21,7 @@ export default {
 export const Basic: Story<IButtonGroupProps> = (args) => {
 	const buttonStyle = { width: '100px' };
 	return (
-		<ButtonGroup {...args} selectedIndices={[1, 2]}>
+		<ButtonGroup {...args}>
 			<ButtonGroup.Button style={buttonStyle}>Smol</ButtonGroup.Button>
 			<ButtonGroup.Button style={buttonStyle}>Lonnnnnnnng</ButtonGroup.Button>
 			<ButtonGroup.Button style={buttonStyle}>Medium</ButtonGroup.Button>
@@ -31,15 +31,22 @@ export const Basic: Story<IButtonGroupProps> = (args) => {
 
 /** Stateful */
 export const Stateful: Story<IButtonGroupProps> = (args) => {
+	const handleSelect: any = (idx, evt, props) => {
+		console.log(idx, evt, props);
+	};
+
 	return (
-		<ButtonGroup {...args}>
-			<ButtonGroup.Button>Zero</ButtonGroup.Button>
+		<ButtonGroup {...args} onSelect={handleSelect}>
+			<ButtonGroup.Button>Zero TEST</ButtonGroup.Button>
 			<ButtonGroup.Button>One</ButtonGroup.Button>
 			<ButtonGroup.Button>Two</ButtonGroup.Button>
 			<ButtonGroup.Button>Three</ButtonGroup.Button>
 		</ButtonGroup>
 	);
 };
+// Stateful.args = {
+// 	selectedIndices: [2]
+// }
 
 /** Stateless */
 export const Stateless: Story<IButtonGroupProps> = (args) => {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -134,7 +134,9 @@ class ButtonGroup extends React.Component<
 							isActive={_.includes(selectedIndices, index)}
 							{...buttonChildProp}
 							key={index}
-							onClick={(event, props) => this.handleSelect(event, props, index)}
+							onClick={({ event, props }) =>
+								this.handleSelect(event, props, index)
+							}
 						/>
 					);
 				})}

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`ButtonGroup [common] example testing should match snapshot(s) for Basic
     </span>
   </button>
   <button
-    class="lucid-Button lucid-Button-is-active"
+    class="lucid-Button"
     style="width:100px"
     type="button"
   >
@@ -27,7 +27,7 @@ exports[`ButtonGroup [common] example testing should match snapshot(s) for Basic
     </span>
   </button>
   <button
-    class="lucid-Button lucid-Button-is-active"
+    class="lucid-Button"
     style="width:100px"
     type="button"
   >
@@ -130,7 +130,7 @@ exports[`ButtonGroup [common] example testing should match snapshot(s) for State
     <span
       class="lucid-Button-content"
     >
-      Zero
+      Zero TEST
     </span>
   </button>
   <button

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -130,7 +130,7 @@ exports[`ButtonGroup [common] example testing should match snapshot(s) for State
     <span
       class="lucid-Button-content"
     >
-      Zero TEST
+      Zero
     </span>
   </button>
   <button

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -36,7 +36,7 @@ export interface IRadioButtonPropsRaw extends StandardProps {
 			event,
 			props,
 		}: {
-			event: React.MouseEvent<HTMLInputElement>;
+			event: React.MouseEvent<HTMLSpanElement>;
 			props: IRadioButtonProps;
 		}
 	) => void;
@@ -80,7 +80,7 @@ export const RadioButton = (props: IRadioButtonProps): React.ReactElement => {
 
 	const nativeElement = React.createRef<HTMLInputElement>();
 
-	function handleClicked(event: React.MouseEvent<HTMLInputElement>): void {
+	function handleClicked(event: React.MouseEvent<HTMLSpanElement>): void {
 		if (!isDisabled && !isSelected) {
 			onSelect(true, { event, props });
 			if (nativeElement.current) {
@@ -89,7 +89,7 @@ export const RadioButton = (props: IRadioButtonProps): React.ReactElement => {
 		}
 	}
 
-	function handleSpanClick(e: React.MouseEvent<HTMLInputElement>): void {
+	function handleSpanClick(e: React.MouseEvent<HTMLSpanElement>): void {
 		e.preventDefault();
 	}
 
@@ -103,7 +103,7 @@ export const RadioButton = (props: IRadioButtonProps): React.ReactElement => {
 				},
 				className
 			)}
-			onClick={handleClicked}
+			onClick={(e) => handleClicked(e)}
 			style={style}
 		>
 			<input

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -14,14 +14,14 @@ export interface IRadioButtonPropsRaw extends StandardProps {
 	 *
 	 * @default false
 	 */
-	isDisabled?: boolean;
+	isDisabled: boolean;
 
 	/** Indicates that the component is in the "selected" state when true and in
 	 * the "unselected" state when false.
 	 *
 	 * @default false
 	 */
-	isSelected?: boolean;
+	isSelected: boolean;
 
 	/** Optional name for the input element */
 	name?: string;

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -14,14 +14,14 @@ export interface IRadioButtonPropsRaw extends StandardProps {
 	 *
 	 * @default false
 	 */
-	isDisabled: boolean;
+	isDisabled?: boolean;
 
 	/** Indicates that the component is in the "selected" state when true and in
 	 * the "unselected" state when false.
 	 *
 	 * @default false
 	 */
-	isSelected: boolean;
+	isSelected?: boolean;
 
 	/** Optional name for the input element */
 	name?: string;

--- a/src/components/RadioGroup/RadioGroup.spec.tsx
+++ b/src/components/RadioGroup/RadioGroup.spec.tsx
@@ -7,8 +7,10 @@ import { common } from '../../util/generic-tests';
 
 import { RadioGroupDumb as RadioGroup } from './RadioGroup';
 import RadioButtonLabeled from '../RadioButtonLabeled/RadioButtonLabeled';
+import RadioButton from '../RadioButton/RadioButton';
 
 const defaultProps = RadioGroup.defaultProps;
+const radioButtonDefaultProps = RadioButton.defaultProps;
 
 describe('RadioGroup', () => {
 	common(RadioGroup);
@@ -19,9 +21,9 @@ describe('RadioGroup', () => {
 				const name = 'radio';
 				const wrapper = shallow(
 					<RadioGroup {...defaultProps} name={name}>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 
@@ -33,9 +35,9 @@ describe('RadioGroup', () => {
 			it('defaults to a string that is passed along to the children.', () => {
 				const wrapper = mount(
 					<RadioGroup {...defaultProps}>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 				const name = wrapper.first().prop('name');
@@ -50,9 +52,9 @@ describe('RadioGroup', () => {
 			it('should set `isDisabled` to true for all child radio buttons', () => {
 				const wrapper = shallow(
 					<RadioGroup {...defaultProps} isDisabled={true}>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 				wrapper.find(RadioButtonLabeled).forEach((node) => {
@@ -63,9 +65,12 @@ describe('RadioGroup', () => {
 			it('should set `isDisabled` to true for all child radio buttons even if the child radio buttons have isDisabled set as false', () => {
 				const wrapper = shallow(
 					<RadioGroup {...defaultProps} isDisabled={true}>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton isDisabled={false} />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton
+							{...radioButtonDefaultProps}
+							isDisabled={false}
+						/>
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 				wrapper.find(RadioButtonLabeled).forEach((node) => {
@@ -76,9 +81,12 @@ describe('RadioGroup', () => {
 			it('should allow specific radio buttons to be disabled', () => {
 				const wrapper = shallow(
 					<RadioGroup {...defaultProps} isDisabled={false}>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton isDisabled={true} />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton
+							{...radioButtonDefaultProps}
+							isDisabled={true}
+						/>
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 
@@ -92,9 +100,9 @@ describe('RadioGroup', () => {
 			it('sets the `isSelected` prop of the child radio button at the matching index to true...', () => {
 				const wrapper = shallow(
 					<RadioGroup {...defaultProps} selectedIndex={2}>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 				const childNodes = wrapper.find(RadioButtonLabeled);
@@ -107,9 +115,15 @@ describe('RadioGroup', () => {
 			it('...except when a child component already has an explicitly defined `isSelected` prop which takes precedence.', () => {
 				const wrapper = shallow(
 					<RadioGroup {...defaultProps} selectedIndex={2}>
-						<RadioGroup.RadioButton isSelected={true} />
-						<RadioGroup.RadioButton isSelected={true} />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton
+							{...radioButtonDefaultProps}
+							isSelected={true}
+						/>
+						<RadioGroup.RadioButton
+							{...radioButtonDefaultProps}
+							isSelected={true}
+						/>
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 				const childNodes = wrapper.find(RadioButtonLabeled);
@@ -122,9 +136,9 @@ describe('RadioGroup', () => {
 			it('defaults to 0.', () => {
 				const wrapper = shallow(
 					<RadioGroup {...defaultProps}>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 				const childNodes = wrapper.find(RadioButtonLabeled);
@@ -142,9 +156,9 @@ describe('RadioGroup', () => {
 						{...defaultProps}
 						{...{ foo: 1, bar: 2, baz: 3, qux: 4, quux: 5 }}
 					>
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
-						<RadioGroup.RadioButton />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 					</RadioGroup>
 				);
 				const rootProps = _.keys(wrapper.first().props());
@@ -162,13 +176,13 @@ describe('RadioGroup', () => {
 		it('passes its children through as the `Label` prop for the corresponding `RadioButtonLabeled`.', () => {
 			const wrapper = shallow(
 				<RadioGroup {...defaultProps}>
-					<RadioGroup.RadioButton>
+					<RadioGroup.RadioButton {...radioButtonDefaultProps}>
 						<RadioGroup.Label>foo</RadioGroup.Label>
 					</RadioGroup.RadioButton>
-					<RadioGroup.RadioButton>
+					<RadioGroup.RadioButton {...radioButtonDefaultProps}>
 						<RadioGroup.Label>bar</RadioGroup.Label>
 					</RadioGroup.RadioButton>
-					<RadioGroup.RadioButton>
+					<RadioGroup.RadioButton {...radioButtonDefaultProps}>
 						<RadioGroup.Label>
 							<span>baz</span>
 							<span>qux</span>
@@ -190,7 +204,7 @@ describe('RadioGroup', () => {
 	it('should handle multiple children', () => {
 		const wrapper = mount(
 			<RadioGroup {...defaultProps}>
-				<RadioGroup.RadioButton>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps}>
 					<RadioGroup.Label>
 						<span id='foo'>foo</span>
 						<span id='bar'>bar</span>
@@ -208,9 +222,9 @@ describe('RadioGroup', () => {
 			const onSelect: any = sinon.spy();
 			const wrapper = mount(
 				<RadioGroup {...defaultProps} onSelect={onSelect}>
-					<RadioGroup.RadioButton />
-					<RadioGroup.RadioButton />
-					<RadioGroup.RadioButton />
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 				</RadioGroup>
 			);
 
@@ -222,9 +236,9 @@ describe('RadioGroup', () => {
 			const onSelect: any = sinon.spy();
 			const wrapper = mount(
 				<RadioGroup {...defaultProps} onSelect={onSelect}>
-					<RadioGroup.RadioButton />
-					<RadioGroup.RadioButton />
-					<RadioGroup.RadioButton />
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 				</RadioGroup>
 			);
 
@@ -238,9 +252,12 @@ describe('RadioGroup', () => {
 			const onSelect: any = sinon.spy();
 			const wrapper = mount(
 				<RadioGroup {...defaultProps} onSelect={onSelect}>
-					<RadioGroup.RadioButton />
-					<RadioGroup.RadioButton onSelect={childOnSelect} />
-					<RadioGroup.RadioButton />
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
+					<RadioGroup.RadioButton
+						{...radioButtonDefaultProps}
+						onSelect={childOnSelect}
+					/>
+					<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 				</RadioGroup>
 			);
 
@@ -248,32 +265,33 @@ describe('RadioGroup', () => {
 			assert(childOnSelect.calledBefore(onSelect));
 		});
 
-		it.only('tests onSelect props shape', () => {
+		it('tests that the correct onSelect is called', () => {
 			const onSelect: any = jest.fn();
 			const wrapper = mount(
 				<RadioGroup {...defaultProps} onSelect={onSelect}>
-					<RadioGroup.RadioButton data-test-name='zero' />
-					<RadioGroup.RadioButton data-test-name='one' />
-					<RadioGroup.RadioButton data-test-name='two' />
+					<RadioGroup.RadioButton
+						{...radioButtonDefaultProps}
+						isDisabled={false}
+						isSelected={false}
+						onSelect={_.noop}
+						data-test-name='zero'
+					/>
+					<RadioGroup.RadioButton
+						data-test-name='one'
+						{...radioButtonDefaultProps}
+					/>
+					<RadioGroup.RadioButton
+						data-test-name='two'
+						{...radioButtonDefaultProps}
+					/>
 				</RadioGroup>
 			);
 
-			console.log(wrapper.debug());
 			wrapper
 				.find('RadioButton[data-test-name="one"] > span')
 				.simulate('click');
 
-			expect(onSelect).toBeCalledWith(1, {
-				event: expect.anything(),
-				props: {
-					'data-test-name': 'one',
-					hasOnlyIcon: false,
-					isActive: false,
-					isDisabled: false,
-					onClick: expect.anything(),
-					type: 'button',
-				},
-			});
+			expect(onSelect).toBeCalledTimes(1);
 		});
 	});
 });

--- a/src/components/RadioGroup/RadioGroup.spec.tsx
+++ b/src/components/RadioGroup/RadioGroup.spec.tsx
@@ -247,5 +247,33 @@ describe('RadioGroup', () => {
 			wrapper.childAt(0).childAt(1).childAt(0).childAt(0).simulate('click');
 			assert(childOnSelect.calledBefore(onSelect));
 		});
+
+		it.only('tests onSelect props shape', () => {
+			const onSelect: any = jest.fn();
+			const wrapper = mount(
+				<RadioGroup {...defaultProps} onSelect={onSelect}>
+					<RadioGroup.RadioButton data-test-name='zero' />
+					<RadioGroup.RadioButton data-test-name='one' />
+					<RadioGroup.RadioButton data-test-name='two' />
+				</RadioGroup>
+			);
+
+			console.log(wrapper.debug());
+			wrapper
+				.find('RadioButton[data-test-name="one"] > span')
+				.simulate('click');
+
+			expect(onSelect).toBeCalledWith(1, {
+				event: expect.anything(),
+				props: {
+					'data-test-name': 'one',
+					hasOnlyIcon: false,
+					isActive: false,
+					isDisabled: false,
+					onClick: expect.anything(),
+					type: 'button',
+				},
+			});
+		});
 	});
 });

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -4,6 +4,7 @@ import { Meta, Story } from '@storybook/react';
 import RadioGroup, { IRadioGroupProps } from './RadioGroup';
 import SingleSelect from '../SingleSelect/SingleSelect';
 import RadioButtonLabeled from '../RadioButtonLabeled/RadioButtonLabeled';
+import RadioButton from '../RadioButton/RadioButton';
 
 export default {
 	title: 'Controls/RadioGroup',
@@ -20,21 +21,24 @@ export default {
 	},
 } as Meta;
 
+const style = {
+	marginRight: '13px',
+};
+
+const radioButtonDefaultProps = RadioButton.defaultProps;
+const singleSelectDefaultProps = SingleSelect.defaultProps;
+
 /* Stateful */
 export const Stateful: Story<IRadioGroupProps> = (args) => {
-	const style = {
-		marginRight: '13px',
-	};
-
 	return (
 		<RadioGroup {...args} isDisabled={false}>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Alvin</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Simon</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Theodore</RadioGroup.Label>
 			</RadioGroup.RadioButton>
 		</RadioGroup>
@@ -43,23 +47,19 @@ export const Stateful: Story<IRadioGroupProps> = (args) => {
 
 /* OnSelect */
 export const OnSelect: Story<IRadioGroupProps> = (args) => {
-	const style = {
-		marginRight: '13px',
-	};
-
 	const handleSelect = (...args) => {
-		console.log({ args });
+		console.warn({ args });
 	};
 
 	return (
 		<RadioGroup {...args} isDisabled={false} onSelect={handleSelect}>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Alvin</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Simon</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Theodore</RadioGroup.Label>
 			</RadioGroup.RadioButton>
 		</RadioGroup>
@@ -68,23 +68,31 @@ export const OnSelect: Story<IRadioGroupProps> = (args) => {
 
 /* OnSelect On Child */
 export const OnSelectOnChild: Story<IRadioGroupProps> = (args) => {
-	const style = {
-		marginRight: '13px',
-	};
-
 	const handleSelect = (...args) => {
-		console.log({ args });
+		console.warn({ args });
 	};
 
 	return (
 		<RadioGroup {...args} isDisabled={false}>
-			<RadioGroup.RadioButton style={style} onSelect={handleSelect}>
+			<RadioGroup.RadioButton
+				{...radioButtonDefaultProps}
+				style={style}
+				onSelect={handleSelect}
+			>
 				<RadioGroup.Label>Alvin</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style} onSelect={handleSelect}>
+			<RadioGroup.RadioButton
+				{...radioButtonDefaultProps}
+				style={style}
+				onSelect={handleSelect}
+			>
 				<RadioGroup.Label>Simon</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style} onSelect={handleSelect}>
+			<RadioGroup.RadioButton
+				{...radioButtonDefaultProps}
+				style={style}
+				onSelect={handleSelect}
+			>
 				<RadioGroup.Label>Theodore</RadioGroup.Label>
 			</RadioGroup.RadioButton>
 		</RadioGroup>
@@ -93,10 +101,6 @@ export const OnSelectOnChild: Story<IRadioGroupProps> = (args) => {
 
 /* Nested Select */
 export const NestedSelect: Story<IRadioGroupProps> = (args) => {
-	const style = {
-		marginRight: '15px',
-	};
-
 	const subSelection = {
 		display: 'block',
 		marginTop: '13px',
@@ -114,10 +118,10 @@ export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 
 	return (
 		<RadioGroup {...args}>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Alvin</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>
 					Simon
 					<RadioButtonLabeled
@@ -134,10 +138,10 @@ export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 					</RadioButtonLabeled>
 				</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>
 					Theodore
-					<SingleSelect style={subSelection}>
+					<SingleSelect {...singleSelectDefaultProps} style={subSelection}>
 						<SingleSelect.Option>Tall Theo</SingleSelect.Option>
 						<SingleSelect.Option>Short Theo</SingleSelect.Option>
 						<SingleSelect.Option>Average height Theo</SingleSelect.Option>
@@ -150,10 +154,6 @@ export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 
 /* Selected Index As Prop */
 export const SelectedIndexAsProp: Story<IRadioGroupProps> = (args) => {
-	const style = {
-		marginRight: '13px',
-	};
-
 	return (
 		<section>
 			<RadioGroup
@@ -190,10 +190,6 @@ export const SelectedIndexAsProp: Story<IRadioGroupProps> = (args) => {
 
 /* Selected Index From Child */
 export const SelectedIndexFromChild: Story<IRadioGroupProps> = (args) => {
-	const style = {
-		marginRight: '13px',
-	};
-
 	return (
 		<RadioGroup
 			{...args}
@@ -225,10 +221,6 @@ export const SelectedIndexFromChild: Story<IRadioGroupProps> = (args) => {
 
 /* Default Props */
 export const DefaultProps: Story<IRadioGroupProps> = (args) => {
-	const style = {
-		marginRight: '13px',
-	};
-
 	return (
 		<RadioGroup {...args}>
 			<RadioGroup.RadioButton style={style}>

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -16,6 +16,7 @@ export default {
 			},
 		},
 	},
+	args: RadioGroup.defaultProps,
 	argTypes: {
 		children: { control: false },
 	},
@@ -28,7 +29,6 @@ const style = {
 const radioButtonDefaultProps = RadioButton.defaultProps;
 const singleSelectDefaultProps = SingleSelect.defaultProps;
 
-/* Stateful */
 export const Stateful: Story<IRadioGroupProps> = (args) => {
 	return (
 		<RadioGroup {...args} isDisabled={false}>
@@ -45,61 +45,64 @@ export const Stateful: Story<IRadioGroupProps> = (args) => {
 	);
 };
 
-/* OnSelect */
 export const OnSelect: Story<IRadioGroupProps> = (args) => {
-	const handleSelect = (...args) => {
-		console.warn({ args });
+	const [selectedIndex, setSelectedIndex] = useState(0);
+
+	const handleSelect = (idx) => {
+		setSelectedIndex(idx);
 	};
 
 	return (
-		<RadioGroup {...args} isDisabled={false} onSelect={handleSelect}>
-			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
-				<RadioGroup.Label>Alvin</RadioGroup.Label>
-			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
-				<RadioGroup.Label>Simon</RadioGroup.Label>
-			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
-				<RadioGroup.Label>Theodore</RadioGroup.Label>
-			</RadioGroup.RadioButton>
-		</RadioGroup>
+		<div>
+			<RadioGroup
+				{...args}
+				isDisabled={false}
+				onSelect={handleSelect}
+				selectedIndex={selectedIndex}
+			>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
+					<RadioGroup.Label>Alvin</RadioGroup.Label>
+				</RadioGroup.RadioButton>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
+					<RadioGroup.Label>Simon</RadioGroup.Label>
+				</RadioGroup.RadioButton>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
+					<RadioGroup.Label>Theodore</RadioGroup.Label>
+				</RadioGroup.RadioButton>
+			</RadioGroup>
+
+			<pre>Selected Index: {selectedIndex}</pre>
+		</div>
 	);
 };
 
-/* OnSelect On Child */
 export const OnSelectOnChild: Story<IRadioGroupProps> = (args) => {
-	const handleSelect = (...args) => {
-		console.warn({ args });
+	const [selectedIndex, setSelectedIndex] = useState(0);
+
+	const handleSelect = (index) => {
+		setSelectedIndex(index);
 	};
 
+	const children = ['Alvin', 'Simon', 'Theodore'];
+
 	return (
-		<RadioGroup {...args} isDisabled={false}>
-			<RadioGroup.RadioButton
-				{...radioButtonDefaultProps}
-				style={style}
-				onSelect={handleSelect}
-			>
-				<RadioGroup.Label>Alvin</RadioGroup.Label>
-			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton
-				{...radioButtonDefaultProps}
-				style={style}
-				onSelect={handleSelect}
-			>
-				<RadioGroup.Label>Simon</RadioGroup.Label>
-			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton
-				{...radioButtonDefaultProps}
-				style={style}
-				onSelect={handleSelect}
-			>
-				<RadioGroup.Label>Theodore</RadioGroup.Label>
-			</RadioGroup.RadioButton>
+		<RadioGroup {...args} isDisabled={false} selectedIndex={selectedIndex}>
+			{children.map((child, idx) => {
+				return (
+					<RadioGroup.RadioButton
+						{...radioButtonDefaultProps}
+						key={idx}
+						style={style}
+						onSelect={() => handleSelect(idx)}
+					>
+						<RadioGroup.Label>{child}</RadioGroup.Label>
+					</RadioGroup.RadioButton>
+				);
+			})}
 		</RadioGroup>
 	);
 };
 
-/* Nested Select */
 export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 	const subSelection = {
 		display: 'block',
@@ -152,7 +155,6 @@ export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 	);
 };
 
-/* Selected Index As Prop */
 export const SelectedIndexAsProp: Story<IRadioGroupProps> = (args) => {
 	return (
 		<section>
@@ -165,22 +167,22 @@ export const SelectedIndexAsProp: Story<IRadioGroupProps> = (args) => {
 					flexDirection: 'column',
 				}}
 			>
-				<RadioGroup.RadioButton style={style}>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 					<RadioGroup.Label>Captain America</RadioGroup.Label>
 				</RadioGroup.RadioButton>
-				<RadioGroup.RadioButton style={style}>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 					<RadioGroup.Label>Iron Man</RadioGroup.Label>
 				</RadioGroup.RadioButton>
-				<RadioGroup.RadioButton style={style}>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 					<RadioGroup.Label>Thor</RadioGroup.Label>
 				</RadioGroup.RadioButton>
-				<RadioGroup.RadioButton style={style}>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 					<RadioGroup.Label>Hulk</RadioGroup.Label>
 				</RadioGroup.RadioButton>
-				<RadioGroup.RadioButton style={style}>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 					<RadioGroup.Label>Black Widow</RadioGroup.Label>
 				</RadioGroup.RadioButton>
-				<RadioGroup.RadioButton style={style}>
+				<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 					<RadioGroup.Label>Hawkeye</RadioGroup.Label>
 				</RadioGroup.RadioButton>
 			</RadioGroup>
@@ -188,7 +190,6 @@ export const SelectedIndexAsProp: Story<IRadioGroupProps> = (args) => {
 	);
 };
 
-/* Selected Index From Child */
 export const SelectedIndexFromChild: Story<IRadioGroupProps> = (args) => {
 	return (
 		<RadioGroup
@@ -200,42 +201,53 @@ export const SelectedIndexFromChild: Story<IRadioGroupProps> = (args) => {
 				flexDirection: 'column',
 			}}
 		>
-			<RadioGroup.RadioButton isSelected={true} style={style}>
+			<RadioGroup.RadioButton
+				{...radioButtonDefaultProps}
+				isSelected={true}
+				style={style}
+			>
 				<RadioGroup.Label>Leonardo</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton isSelected={true} style={style}>
+			<RadioGroup.RadioButton
+				{...radioButtonDefaultProps}
+				isSelected={true}
+				style={style}
+			>
 				<RadioGroup.Label>Raphael</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton isSelected={true} style={style}>
+			<RadioGroup.RadioButton
+				{...radioButtonDefaultProps}
+				isSelected={true}
+				style={style}
+			>
 				<RadioGroup.Label>Donatello</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Michelangelo</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Venus</RadioGroup.Label>
 			</RadioGroup.RadioButton>
 		</RadioGroup>
 	);
 };
 
-/* Default Props */
 export const DefaultProps: Story<IRadioGroupProps> = (args) => {
 	return (
 		<RadioGroup {...args}>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Superman</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Batman</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Wonder Woman</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Aquaman</RadioGroup.Label>
 			</RadioGroup.RadioButton>
-			<RadioGroup.RadioButton style={style}>
+			<RadioGroup.RadioButton {...radioButtonDefaultProps} style={style}>
 				<RadioGroup.Label>Robin</RadioGroup.Label>
 			</RadioGroup.RadioButton>
 		</RadioGroup>

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -41,6 +41,56 @@ export const Stateful: Story<IRadioGroupProps> = (args) => {
 	);
 };
 
+/* OnSelect */
+export const OnSelect: Story<IRadioGroupProps> = (args) => {
+	const style = {
+		marginRight: '13px',
+	};
+
+	const handleSelect = (...args) => {
+		console.log({ args });
+	};
+
+	return (
+		<RadioGroup {...args} isDisabled={false} onSelect={handleSelect}>
+			<RadioGroup.RadioButton style={style}>
+				<RadioGroup.Label>Alvin</RadioGroup.Label>
+			</RadioGroup.RadioButton>
+			<RadioGroup.RadioButton style={style}>
+				<RadioGroup.Label>Simon</RadioGroup.Label>
+			</RadioGroup.RadioButton>
+			<RadioGroup.RadioButton style={style}>
+				<RadioGroup.Label>Theodore</RadioGroup.Label>
+			</RadioGroup.RadioButton>
+		</RadioGroup>
+	);
+};
+
+/* OnSelect On Child */
+export const OnSelectOnChild: Story<IRadioGroupProps> = (args) => {
+	const style = {
+		marginRight: '13px',
+	};
+
+	const handleSelect = (...args) => {
+		console.log({ args });
+	};
+
+	return (
+		<RadioGroup {...args} isDisabled={false}>
+			<RadioGroup.RadioButton style={style} onSelect={handleSelect}>
+				<RadioGroup.Label>Alvin</RadioGroup.Label>
+			</RadioGroup.RadioButton>
+			<RadioGroup.RadioButton style={style} onSelect={handleSelect}>
+				<RadioGroup.Label>Simon</RadioGroup.Label>
+			</RadioGroup.RadioButton>
+			<RadioGroup.RadioButton style={style} onSelect={handleSelect}>
+				<RadioGroup.Label>Theodore</RadioGroup.Label>
+			</RadioGroup.RadioButton>
+		</RadioGroup>
+	);
+};
+
 /* Nested Select */
 export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 	const style = {

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -128,12 +128,14 @@ export const NestedSelect: Story<IRadioGroupProps> = (args) => {
 				<RadioGroup.Label>
 					Simon
 					<RadioButtonLabeled
+						{...radioButtonDefaultProps}
 						isSelected={height === 'Tall Simon'}
 						onSelect={handleSelectedTallSimon}
 					>
 						<RadioButtonLabeled.Label>Tall Simon</RadioButtonLabeled.Label>
 					</RadioButtonLabeled>
 					<RadioButtonLabeled
+						{...radioButtonDefaultProps}
 						isSelected={height === 'Short Simon'}
 						onSelect={handleSelectedShortSimon}
 					>

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -117,12 +117,16 @@ const RadioGroup = (props: IRadioGroupProps) => {
 			);
 			// If the `RadioGroup.RadioButton` child has an `onSelect` prop that is
 			// a function, call that prior to calling the group's `onSelect` prop.
+
 			if (_.isFunction(clickedRadioButtonProps.onSelect)) {
 				clickedRadioButtonProps.onSelect(isSelected, {
 					event,
 					props: childProps,
 				});
 			}
+
+			//console.log('props.onSelect', props.onSelect);
+
 			props.onSelect(selectedIndex, { event, props: childProps });
 		}
 	};
@@ -160,7 +164,7 @@ const RadioGroup = (props: IRadioGroupProps) => {
 						key={index}
 						callbackId={index}
 						name={name}
-						onSelect={(event, props, isSelected) =>
+						onSelect={(isSelected, { event, props }) =>
 							handleSelected(event, props, isSelected, index)
 						}
 						Label={_.get(

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -124,9 +124,6 @@ const RadioGroup = (props: IRadioGroupProps) => {
 					props: childProps,
 				});
 			}
-
-			//console.log('props.onSelect', props.onSelect);
-
 			props.onSelect(selectedIndex, { event, props: childProps });
 		}
 	};

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -21,6 +21,17 @@ const cx = lucidClassNames.bind('&-RadioGroup');
 
 const { func, node, number, string, bool } = PropTypes;
 
+/** RadioGroup Label */
+const RadioGroupLabel = (props: IRadioButtonLabeledLabelProps) => null;
+RadioGroupLabel.peek = {
+	description: `Support radio button labels as \`RadioGroup.Label\` component which can be provided as a child of a \`RadioGroup.RadioButton\` component.`,
+};
+RadioGroupLabel.propTypes = {
+	children: node,
+};
+RadioGroupLabel.displayName = 'RadioGroup.Label';
+
+/** RadioGroup */
 export interface IRadioGroupPropsRaw extends StandardProps {
 	/**
 	 * Passed along to the \`RadioGroup.RadioButton\' children whose \'name\'
@@ -67,15 +78,6 @@ export type IRadioGroupProps = Overwrite<
 	>,
 	IRadioGroupPropsRaw
 >;
-
-const RadioGroupLabel = (props: IRadioButtonLabeledLabelProps) => null;
-RadioGroupLabel.peek = {
-	description: `Support radio button labels as \`RadioGroup.Label\` component which can be provided as a child of a \`RadioGroup.RadioButton\` component.`,
-};
-RadioGroupLabel.propTypes = {
-	children: node,
-};
-RadioGroupLabel.displayName = 'RadioGroup.Label';
 
 const defaultProps = {
 	name: uniqueName(`${cx('&')}-`),
@@ -161,9 +163,9 @@ const RadioGroup = (props: IRadioGroupProps) => {
 						key={index}
 						callbackId={index}
 						name={name}
-						onSelect={(isSelected, { event, props }) =>
-							handleSelected(event, props, isSelected, index)
-						}
+						onSelect={(isSelected, { event, props }) => {
+							handleSelected(event, props, isSelected, index);
+						}}
 						Label={_.get(
 							getFirst(radioButtonChildProp, RadioGroup.Label),
 							'props',

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
@@ -320,92 +320,97 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for Nested
 `;
 
 exports[`RadioGroup [common] example testing should match snapshot(s) for OnSelect 1`] = `
-<span
-  class="lucid-RadioGroup"
->
-  <label
-    class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected"
-    style="margin-right:13px"
+<div>
+  <span
+    class="lucid-RadioGroup"
   >
-    <span
-      class="lucid-RadioButton lucid-RadioButton-is-selected"
+    <label
+      class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected"
+      style="margin-right:13px"
     >
-      <input
-        checked=""
-        class="lucid-RadioButton-native"
-        type="radio"
-      />
       <span
-        class="lucid-RadioButton-visualization-glow"
-      />
-      <span
-        class="lucid-RadioButton-visualization-container"
-      />
-      <span
-        class="lucid-RadioButton-visualization-dot"
-      />
-    </span>
-    <div
-      class="lucid-RadioButtonLabeled-label"
+        class="lucid-RadioButton lucid-RadioButton-is-selected"
+      >
+        <input
+          checked=""
+          class="lucid-RadioButton-native"
+          type="radio"
+        />
+        <span
+          class="lucid-RadioButton-visualization-glow"
+        />
+        <span
+          class="lucid-RadioButton-visualization-container"
+        />
+        <span
+          class="lucid-RadioButton-visualization-dot"
+        />
+      </span>
+      <div
+        class="lucid-RadioButtonLabeled-label"
+      >
+        Alvin
+      </div>
+    </label>
+    <label
+      class="lucid-RadioButtonLabeled"
+      style="margin-right:13px"
     >
-      Alvin
-    </div>
-  </label>
-  <label
-    class="lucid-RadioButtonLabeled"
-    style="margin-right:13px"
-  >
-    <span
-      class="lucid-RadioButton"
+      <span
+        class="lucid-RadioButton"
+      >
+        <input
+          class="lucid-RadioButton-native"
+          type="radio"
+        />
+        <span
+          class="lucid-RadioButton-visualization-glow"
+        />
+        <span
+          class="lucid-RadioButton-visualization-container"
+        />
+        <span
+          class="lucid-RadioButton-visualization-dot"
+        />
+      </span>
+      <div
+        class="lucid-RadioButtonLabeled-label"
+      >
+        Simon
+      </div>
+    </label>
+    <label
+      class="lucid-RadioButtonLabeled"
+      style="margin-right:13px"
     >
-      <input
-        class="lucid-RadioButton-native"
-        type="radio"
-      />
       <span
-        class="lucid-RadioButton-visualization-glow"
-      />
-      <span
-        class="lucid-RadioButton-visualization-container"
-      />
-      <span
-        class="lucid-RadioButton-visualization-dot"
-      />
-    </span>
-    <div
-      class="lucid-RadioButtonLabeled-label"
-    >
-      Simon
-    </div>
-  </label>
-  <label
-    class="lucid-RadioButtonLabeled"
-    style="margin-right:13px"
-  >
-    <span
-      class="lucid-RadioButton"
-    >
-      <input
-        class="lucid-RadioButton-native"
-        type="radio"
-      />
-      <span
-        class="lucid-RadioButton-visualization-glow"
-      />
-      <span
-        class="lucid-RadioButton-visualization-container"
-      />
-      <span
-        class="lucid-RadioButton-visualization-dot"
-      />
-    </span>
-    <div
-      class="lucid-RadioButtonLabeled-label"
-    >
-      Theodore
-    </div>
-  </label>
-</span>
+        class="lucid-RadioButton"
+      >
+        <input
+          class="lucid-RadioButton-native"
+          type="radio"
+        />
+        <span
+          class="lucid-RadioButton-visualization-glow"
+        />
+        <span
+          class="lucid-RadioButton-visualization-container"
+        />
+        <span
+          class="lucid-RadioButton-visualization-dot"
+        />
+      </span>
+      <div
+        class="lucid-RadioButtonLabeled-label"
+      >
+        Theodore
+      </div>
+    </label>
+  </span>
+  <pre>
+    Selected Index: 0
+  </pre>
+</div>
 `;
 
 exports[`RadioGroup [common] example testing should match snapshot(s) for OnSelectOnChild 1`] = `

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
@@ -149,7 +149,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for Nested
 >
   <label
     class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected"
-    style="margin-right:15px"
+    style="margin-right:13px"
   >
     <span
       class="lucid-RadioButton lucid-RadioButton-is-selected"
@@ -177,7 +177,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for Nested
   </label>
   <label
     class="lucid-RadioButtonLabeled"
-    style="margin-right:15px"
+    style="margin-right:13px"
   >
     <span
       class="lucid-RadioButton"
@@ -256,7 +256,7 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for Nested
   </label>
   <label
     class="lucid-RadioButtonLabeled"
-    style="margin-right:15px"
+    style="margin-right:13px"
   >
     <span
       class="lucid-RadioButton"
@@ -314,6 +314,184 @@ exports[`RadioGroup [common] example testing should match snapshot(s) for Nested
           </div>
         </span>
       </div>
+    </div>
+  </label>
+</span>
+`;
+
+exports[`RadioGroup [common] example testing should match snapshot(s) for OnSelect 1`] = `
+<span
+  class="lucid-RadioGroup"
+>
+  <label
+    class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected"
+    style="margin-right:13px"
+  >
+    <span
+      class="lucid-RadioButton lucid-RadioButton-is-selected"
+    >
+      <input
+        checked=""
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      Alvin
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-right:13px"
+  >
+    <span
+      class="lucid-RadioButton"
+    >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      Simon
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-right:13px"
+  >
+    <span
+      class="lucid-RadioButton"
+    >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      Theodore
+    </div>
+  </label>
+</span>
+`;
+
+exports[`RadioGroup [common] example testing should match snapshot(s) for OnSelectOnChild 1`] = `
+<span
+  class="lucid-RadioGroup"
+>
+  <label
+    class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected"
+    style="margin-right:13px"
+  >
+    <span
+      class="lucid-RadioButton lucid-RadioButton-is-selected"
+    >
+      <input
+        checked=""
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      Alvin
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-right:13px"
+  >
+    <span
+      class="lucid-RadioButton"
+    >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      Simon
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-right:13px"
+  >
+    <span
+      class="lucid-RadioButton"
+    >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      Theodore
     </div>
   </label>
 </span>

--- a/src/components/TextField/TextField.spec.tsx
+++ b/src/components/TextField/TextField.spec.tsx
@@ -35,7 +35,6 @@ describe('TextField', () => {
 					value='test'
 				/>
 			);
-			console.warn(wrapper.debug());
 			assert.strictEqual(wrapper.find('input').prop('disabled'), true);
 			assert.strictEqual(wrapper.find('input').prop('style'), style);
 			assert.strictEqual(wrapper.find('input').prop('rows'), 10);


### PR DESCRIPTION
## PR Checklist

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/CXP-2720-RadioGroup-ButtonGroup-Props)

RadioGroup
https://docspot.adnxs.net/projects/lucid/CXP-2720-RadioGroup-ButtonGroup-Props/?path=/docs/controls-radiogroup--stateful

ButtonGroup
https://docspot.adnxs.net/projects/lucid/CXP-2720-RadioGroup-ButtonGroup-Props/?path=/docs/controls-buttongroup--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
- [ ] Two core team engineer approvals
- [ ] One core team UX approval
