### PR TITLE
Cxp 2870 lucid cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 AppNexus Inc.
+Copyright 2022 Xandr Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lucid [![codecov](https://codecov.io/gh/appnexus/lucid/branch/master/graph/badge.svg)](https://codecov.io/gh/appnexus/lucid)
 
-A UI component library from AppNexus.
+A UI component library from Xandr.
 
 ## Install
 
@@ -15,17 +15,15 @@ or yarn
 ```sh
   yarn add lucid-ui
 ```
+
 ## Usage
 
 ```js
-  import React from 'react';
-  import ReactDOM from 'react-dom';
-  import { Button } from 'lucid-ui';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Button } from 'lucid-ui';
 
-  ReactDOM.render(
-    <Button>Hello World</Button>,
-    mountNode
-  );
+ReactDOM.render(<Button>Hello World</Button>, mountNode);
 ```
 
 Lucid uses `less` for its stylesheets. If you use `less`, you can include the
@@ -63,13 +61,13 @@ we support React 15 and 16.
 Example package.json:
 
 ```json
-  {
-    "dependencies": {
-      "lucid-ui": "^5.0.0",
-      "react": "^16.0.0",
-      "react-dom": "^16.0.0",
-    }
-  }
+{
+	"dependencies": {
+		"lucid-ui": "^5.0.0",
+		"react": "^16.0.0",
+		"react-dom": "^16.0.0"
+	}
+}
 ```
 
 To contribute to lucid, please see `CONTRIBUTING.md`.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ Lucid can be installed with npm
   npm install --save lucid-ui
 ```
 
-or yarn
-
-```sh
-  yarn add lucid-ui
-```
-
 ## Usage
 
 ```js

--- a/docs/intro.stories.mdx
+++ b/docs/intro.stories.mdx
@@ -4,7 +4,7 @@ import { Source, Meta } from '@storybook/addon-docs';
 
 # Introduction
 
-Lucid UI is a React component library by AppNexus.
+Lucid UI is a React component library by Xandr.
 
 - Battle-tested in Enterprise Apps
 - Hybrid Component State
@@ -25,7 +25,7 @@ Lucid UI is a React component library by AppNexus.
 
 #### Battle-tested in Enterprise Apps
 
-AppNexus is an internet technology company that uses data and machine learning to power the world’s open digital audience platforms.
+Xandr is an internet technology company that uses data and machine learning to power the world’s open digital audience platforms.
 React is a core part of our front-end architecture and our components have to be able to handle large data sets and complex workflows.
 We take great care in designing components that are easy-to-use and flexible enough to handle unique configurations.
 We continuously create new components and refine existing ones with feedback from our own suite of enterprise React apps and the open source community.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lucid-ui",
 	"version": "8.10.0",
-	"description": "A UI component library from AppNexus.",
+	"description": "A UI component library from Xandr.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "dist/esm/index.d.ts",
@@ -49,7 +49,7 @@
 		"stateful",
 		"stateless"
 	],
-	"author": "AppNexus engineering",
+	"author": "Xandr engineering",
 	"license": "Apache-2.0",
 	"dependencies": {
 		"classnames": "^2.3.1",

--- a/src/components/Accordion/Accordion.spec.tsx
+++ b/src/components/Accordion/Accordion.spec.tsx
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import assert from 'assert';
 import React from 'react';
-import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 
 import { common } from '../../util/generic-tests';
@@ -134,7 +133,7 @@ describe('Accordion', () => {
 
 describe('Accordion', () => {
 	let wrapper: any;
-	const onSelect: any = sinon.spy();
+	const onSelectMock: any = jest.fn();
 	let mountTestDiv: any;
 
 	describe('user picks one of the items', () => {
@@ -142,7 +141,7 @@ describe('Accordion', () => {
 			mountTestDiv = document.createElement('div');
 			document.body.appendChild(mountTestDiv);
 			wrapper = mount(
-				<Accordion onSelect={onSelect}>
+				<Accordion onSelect={onSelectMock}>
 					<Accordion.Item Header='Header One'>One</Accordion.Item>
 					<Accordion.Item Header='Header Two' isDisabled>
 						Two
@@ -155,7 +154,7 @@ describe('Accordion', () => {
 		});
 
 		afterEach(() => {
-			onSelect.reset();
+			onSelectMock.mockClear();
 			wrapper && wrapper.unmount();
 			mountTestDiv && mountTestDiv.parentNode.removeChild(mountTestDiv);
 		});
@@ -166,11 +165,7 @@ describe('Accordion', () => {
 			firstPanel.find('.lucid-ExpanderPanel-header').first().simulate('click');
 			firstPanel.find('.lucid-ExpanderPanel-icon').first().simulate('click');
 
-			assert.strictEqual(
-				onSelect.callCount,
-				2,
-				`onSelect called the wrong number of times, actual: ${onSelect.callCount}, expected: 2`
-			);
+			expect(onSelectMock).toBeCalledTimes(2);
 		});
 
 		it('should not call the function passed in as the `onSelect` prop when Item is disabled', () => {
@@ -179,7 +174,7 @@ describe('Accordion', () => {
 			secondPanel.find('.lucid-ExpanderPanel-header').first().simulate('click');
 			secondPanel.find('.lucid-ExpanderPanel-icon').first().simulate('click');
 
-			expect(onSelect.callCount).toEqual(0);
+			expect(onSelectMock).toBeCalledTimes(0);
 		});
 	});
 });

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -27,8 +27,8 @@ export const Basic: Story<IBadgeProps> = Template.bind({});
 
 export const AllTypes: Story<IBadgeProps> = (args) => (
 	<div>
-		{_.map(kinds, (kind) => (
-			<div key={kind}>
+		{_.map(kinds, (kind, idx) => (
+			<div key={`${kind}-${idx}`}>
 				{_.map(types, (ty) => (
 					<React.Fragment key={`${kind}-${ty}`}>
 						<Badge

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,9 +1,9 @@
-import { Meta, Story } from '@storybook/react';
 import _ from 'lodash';
 import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+
 import { ChatIcon } from '../Icon/ChatIcon/ChatIcon';
 import { Button } from '../Button/Button';
-
 import { Banner, IBannerProps } from './Banner';
 
 export default {
@@ -16,6 +16,7 @@ export default {
 			},
 		},
 	},
+	args: Banner.defaultProps,
 } as Meta;
 
 export const Basic: Story<IBannerProps> = (args) => (
@@ -56,7 +57,7 @@ export const Stateless: Story<IBannerProps> = (args) => {
 	return (
 		<div>
 			{_.map(kinds, ({ label, value }) => (
-				<React.Fragment key={value}>
+				<React.Fragment key={`stateless-${label}`}>
 					<div>
 						<Banner {...args} kind={value as any} style={{ marginBottom: 8 }}>
 							{label}
@@ -111,7 +112,7 @@ export const Stateless: Story<IBannerProps> = (args) => {
 			</div>
 
 			{_.map(kinds, ({ label, value }) => (
-				<React.Fragment key={value}>
+				<React.Fragment key={`stateless-outline-${label}`}>
 					<div>
 						<Banner
 							{...args}
@@ -155,8 +156,8 @@ export const Small: Story<IBannerProps> = (args) => {
 
 	return (
 		<div>
-			{_.map(kinds, ({ label, value }, index) => (
-				<React.Fragment key={index}>
+			{_.map(kinds, ({ label, value }) => (
+				<React.Fragment key={`sm-${label}`}>
 					<div>
 						<Banner
 							{...args}
@@ -180,7 +181,7 @@ export const Small: Story<IBannerProps> = (args) => {
 			))}
 
 			{_.map(kinds, ({ label, value }) => (
-				<React.Fragment key={value}>
+				<React.Fragment key={`sm-outline-${label}`}>
 					<div>
 						<Banner
 							{...args}

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { CSSTransition } from 'react-transition-group';
 import { lucidClassNames } from '../../util/style-helpers';
 import { StandardProps } from '../../util/component-types';

--- a/src/components/Bars/Bars.stories.tsx
+++ b/src/components/Bars/Bars.stories.tsx
@@ -178,9 +178,10 @@ export const LogScale: Story<IBarsProps> = (args) => {
 				<Bars {...args} data={data} xScale={xScale} yScale={yScale} />
 			</g>
 			<g>
-				{_.map(data, (item) => {
+				{_.map(data, (item, idx) => {
 					return (
 						<text
+							key={idx}
 							textAnchor='middle'
 							x={(xScale(item.x as string) as number) + xScale.bandwidth() / 2}
 							y={(yScale(item.y as number) as any) - 10}

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -5,7 +5,6 @@ import { Motion, spring } from 'react-motion';
 import { QUICK_SLIDE_MOTION } from '../../constants/motion-spring';
 import { lucidClassNames } from '../../util/style-helpers';
 import { StandardProps } from '../../util/component-types';
-import InheritedSettingsIconStories from '../Icon/InheritedSettingsIcon/InheritedSettingsIcon.stories';
 
 const cx = lucidClassNames.bind('&-Collapsible');
 

--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -3,12 +3,15 @@ import _ from 'lodash';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import assert from 'assert';
+import { act } from 'react-dom/test-utils';
+
 import { common } from '../../util/generic-tests';
 import DataTable from './DataTable';
 import ScrollTable from '../ScrollTable/ScrollTable';
 import Checkbox from '../Checkbox/Checkbox';
 import EmptyStateWrapper from '../EmptyStateWrapper/EmptyStateWrapper';
 import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
+import { HandleResize } from '../SplitVertical/SplitVertical.stories';
 
 const { Column, ColumnGroup } = DataTable;
 
@@ -148,6 +151,8 @@ describe('DataTable', () => {
 	});
 
 	describe('props', () => {
+		const defaultProps = DataTable.defaultProps;
+
 		describe('data', () => {
 			it('should render 10 empty rows by default if data is an empty array', () => {
 				const wrapper = shallow(<DataTable data={[]} />);
@@ -760,32 +765,17 @@ describe('DataTable', () => {
 		});
 
 		describe('isResize', () => {
-			it('should show a `resizer` if `isResizable equals to true`', () => {
-				const onResize = jest.fn();
+			it('should render a `DragCaptureZone` resizer, if `isResizable` equals true', () => {
 				const wrapper = mount(
-					<DataTable hasFixedHeader onResize={onResize} data={testData}>
-						<Column minWidth={50} field='id' isResizable title='ID' />
+					<DataTable hasFixedHeader data={testData}>
+						<Column field='id' isResizable title='ID' />
 						<Column field='first_name' isResizable title='First' />
 						<Column field='last_name' isResizable title='Last' />
 						<Column field='email' isResizable title='Email' />
-						<Column field='occupation' isResizable title='Occupation' />
+						<Column field='occupation' title='Occupation' />
 					</DataTable>
 				);
-
-				const dragCaptureZoneWrapper = wrapper.find(DragCaptureZone).at(1);
-				const mockEvent = new Event('mouseup');
-				dragCaptureZoneWrapper.prop('onDragEnd')(
-					{
-						dx: 100,
-						dy: 0,
-						pageX: 100,
-						pageY: 0,
-					} as any,
-					{
-						event: mockEvent,
-						props: {},
-					} as any
-				);
+				expect(wrapper.find(DragCaptureZone)).toHaveLength(4);
 			});
 		});
 	});

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -2,13 +2,13 @@
 import _ from 'lodash';
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	findTypes,
 	filterTypes,
 	getFirst,
 	omitProps,
-	StandardProps,
 } from '../../util/component-types';
 
 import Checkbox from '../Checkbox/Checkbox';

--- a/src/components/DraggableLineChart/DraggableLineChart.stories.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from 'react';
 import createClass from 'create-react-class';
 import _ from 'lodash';
+import { Meta, Story } from '@storybook/react';
+
 import { IXAxisRenderProp } from './d3-helpers';
 import { IData, ISelectedChartData } from './DraggableLineChartD3';
 import DraggableLineChart from './DraggableLineChart';
@@ -16,10 +18,9 @@ export default {
 			},
 		},
 	},
-};
+} as Meta;
 
-/* Basic */
-export const Basic = () => {
+export const Basic: Story = () => {
 	const data = [
 		{ x: '12 AM', y: 0 },
 		{ x: '1 AM', y: 0 },

--- a/src/components/DraggableLineChart/DraggableLineChartD3.ts
+++ b/src/components/DraggableLineChart/DraggableLineChartD3.ts
@@ -50,54 +50,70 @@ const getAttributes = function (selection: ISelection, obj: string[]): any {
 export interface IDraggableLineChart extends StandardProps {
 	/** Height of the chart. */
 	height?: number;
+
 	/** Width of the chart. */
 	width?: number;
+
 	/** Margin is an object defining the margins of the chart. These margins will
 	    contain the axis and labels. */
 	margin?: IDraggableLineChartMargin;
+
 	/** Data for the chart.
-			Basic example:
+		Basic example:
 			[
-			 { x: new Date('2015-01-01') , y: 1 } ,
-			 { x: new Date('2015-01-02') , y: 2 } ,
-			 { x: new Date('2015-01-03') , y: 3 } ,
-			 { x: new Date('2015-01-04') , y: 2 } ,
-			 { x: new Date('2015-01-05') , y: 5 } ,
+				{ x: new Date('2015-01-01') , y: 1 } ,
+				{ x: new Date('2015-01-02') , y: 2 } ,
+				{ x: new Date('2015-01-03') , y: 3 } ,
+				{ x: new Date('2015-01-04') , y: 2 } ,
+				{ x: new Date('2015-01-05') , y: 5 } ,
 			]
 
-			If you want to be able to navigate to one of the components, you can use ref as well:
+		If you want to be able to navigate to one of the components, you can use ref as well:
 			[
-			 { x: new Date('2015-01-01') , y: 1, ref: React.createRef() } ,
-			 { x: new Date('2015-01-02') , y: 2, ref: React.createRef() } ,
-			 { x: new Date('2015-01-03') , y: 3, ref: React.createRef() } ,
-			 { x: new Date('2015-01-04') , y: 2, ref: React.createRef() } ,
-			 { x: new Date('2015-01-05') , y: 5, ref: React.createRef() } ,
-			] */
+				{ x: new Date('2015-01-01') , y: 1, ref: React.createRef() } ,
+				{ x: new Date('2015-01-02') , y: 2, ref: React.createRef() } ,
+				{ x: new Date('2015-01-03') , y: 3, ref: React.createRef() } ,
+				{ x: new Date('2015-01-04') , y: 2, ref: React.createRef() } ,
+				{ x: new Date('2015-01-05') , y: 5, ref: React.createRef() } ,
+			] 
+	*/
 	data: IData;
+
 	/** Drag handler function which is a callable function executed at the end of drag.
-			Called when the user stops to dragging an item.
+		Called when the user stops to dragging an item.
 		  Signature: `({ event, props }) => {}` */
 	onDragEnd?: IOnDragEnd;
+
 	/** Drag handler function which is a callable function executed at the end of drag.
-			Called when the user stops to dragging an item.
-		  Signature: `({ event, props }) => {}`
-	    When defined show draggable pane. */
+		Called when the user stops to dragging an item.
+			Signature: `({ event, props }) => {}`
+	    When defined show draggable pane. 
+	*/
 	onPreselect?: IOnPreselect;
+
 	/** Flag for if xAxis tick labels are vertical. */
 	xAxisTicksVertical?: boolean;
+
 	/** Flag for if data is center aligned rather than default left aligned. */
 	dataIsCentered?: boolean;
+
 	/** Flag for yAxis sticking to minimum (not readjusting minimum). */
 	yAxisMin?: number;
+
 	/** Optional react component to render within X-Axis.
-			Note: If you are using input boxes or similar and you want to navigate
-			to the next component on tab, you will might need to provide refs
-			in the data. This react component will always be passed the following props: ({x, y, ref }: { x: string; y: number; ref?: any }) */
+		Note: If you are using input boxes or similar and you want to navigate
+		to the next component on tab, you will might need to provide refs
+		in the data. This react component will always be passed the following props: ({x, y, ref }: { x: string; y: number; ref?: any }) 
+	*/
 	xAxisRenderProp?: IXAxisRenderProp;
-	/**
-	 * Text to show to users when there is no data selection
-	 */
+
+	/** Text to show to users when there is no data selection. */
 	preSelectText?: string;
+
+	/**
+		An optional function used to format your y axis data. If you don't
+		provide anything, we use the default D3 formatter.
+	*/
 	yAxisFormatter?: ((value: string) => string) | null;
 }
 

--- a/src/components/DropMenu/DropMenu.spec.tsx
+++ b/src/components/DropMenu/DropMenu.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import assert from 'assert';
-import sinon from 'sinon';
 import _ from 'lodash';
 import { common } from '../../util/generic-tests';
 
@@ -326,9 +325,9 @@ describe('DropMenu', () => {
 		describe('onExpand', () => {
 			describe('mouse', () => {
 				it('should be called when DropMenu [not expanded, clicked]', () => {
-					const onExpand = sinon.spy();
+					const onExpandMock: any = jest.fn();
 					const wrapper = shallow(
-						<DropMenu isExpanded={false} onExpand={onExpand}>
+						<DropMenu isExpanded={false} onExpand={onExpandMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -338,13 +337,13 @@ describe('DropMenu', () => {
 
 					wrapper.find('.lucid-DropMenu-Control').simulate('click');
 
-					assert(onExpand.called);
+					expect(onExpandMock).toHaveBeenCalledTimes(1);
 				});
 
 				it('should not be called when DropMenu [expanded, clicked]', () => {
-					const onExpand = sinon.spy();
+					const onExpandMock: any = jest.fn();
 					const wrapper = shallow(
-						<DropMenu isExpanded={true} onExpand={onExpand}>
+						<DropMenu isExpanded={true} onExpand={onExpandMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -354,15 +353,15 @@ describe('DropMenu', () => {
 
 					wrapper.find('.lucid-DropMenu-Control').simulate('click');
 
-					assert(onExpand.notCalled);
+					expect(onExpandMock).not.toHaveBeenCalled();
 				});
 			});
 
 			describe('keyboard', () => {
 				it('should be called when DropMenu [not expanded, has focus, Down Arrow key pressed]', () => {
-					const onExpand = sinon.spy();
+					const onExpandMock: any = jest.fn();
 					const wrapper = shallow(
-						<DropMenu isExpanded={false} onExpand={onExpand}>
+						<DropMenu isExpanded={false} onExpand={onExpandMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -375,7 +374,7 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onExpand.called);
+					expect(onExpandMock).toHaveBeenCalledTimes(1);
 				});
 			});
 		});
@@ -383,9 +382,9 @@ describe('DropMenu', () => {
 		describe('onCollapse', () => {
 			describe('mouse', () => {
 				it('should be called when DropMenu [expanded, control clicked]', () => {
-					const onCollapse = sinon.spy();
+					const onCollapseMock: any = jest.fn();
 					const wrapper = shallow(
-						<DropMenu isExpanded={true} onCollapse={onCollapse}>
+						<DropMenu isExpanded={true} onCollapse={onCollapseMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -395,13 +394,13 @@ describe('DropMenu', () => {
 
 					wrapper.find('.lucid-DropMenu-Control').simulate('click');
 
-					assert(onCollapse.called);
+					expect(onCollapseMock).toHaveBeenCalledTimes(1);
 				});
 
 				it('should not be called when DropMenu [not expanded, control clicked]', () => {
-					const onCollapse = sinon.spy();
+					const onCollapseMock: any = jest.fn();
 					const wrapper = shallow(
-						<DropMenu isExpanded={false} onCollapse={onCollapse}>
+						<DropMenu isExpanded={false} onCollapse={onCollapseMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -411,13 +410,13 @@ describe('DropMenu', () => {
 
 					wrapper.find('.lucid-DropMenu-Control').simulate('click');
 
-					assert(onCollapse.notCalled);
+					expect(onCollapseMock).not.toHaveBeenCalled();
 				});
 
 				it('should be called when DropMenu [expanded, ContextMenu onClickOut called]', () => {
-					const onCollapse = sinon.spy();
+					const onCollapseMock: any = jest.fn();
 					const wrapper: any = shallow(
-						<DropMenu isExpanded={true} onCollapse={onCollapse}>
+						<DropMenu isExpanded={true} onCollapse={onCollapseMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -427,15 +426,15 @@ describe('DropMenu', () => {
 
 					wrapper.find('ContextMenu').prop('onClickOut')();
 
-					assert(onCollapse.called);
+					expect(onCollapseMock).toHaveBeenCalledTimes(1);
 				});
 			});
 
 			describe('keyboard', () => {
 				it('should be called when DropMenu [expanded, Escape key pressed]', () => {
-					const onCollapse = sinon.spy();
+					const onCollapseMock: any = jest.fn();
 					const wrapper = shallow(
-						<DropMenu isExpanded={true} onCollapse={onCollapse}>
+						<DropMenu isExpanded={true} onCollapse={onCollapseMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -448,21 +447,21 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onCollapse.called);
+					expect(onCollapseMock).toHaveBeenCalledTimes(1);
 				});
 			});
 		});
 
 		describe('onSelect', () => {
 			describe('mouse', () => {
-				let onSelect: any;
+				let onSelectMock: any;
 				let wrapper: any;
 
 				beforeEach(() => {
-					onSelect = sinon.spy();
+					onSelectMock = jest.fn();
 
 					wrapper = mount(
-						<DropMenu isExpanded={true} onSelect={onSelect}>
+						<DropMenu isExpanded={true} onSelect={onSelectMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -473,7 +472,7 @@ describe('DropMenu', () => {
 
 				afterEach(() => {
 					wrapper.unmount();
-					onSelect.reset();
+					onSelectMock.mockClear();
 				});
 
 				it('should be called when DropMenu [expanded, option clicked]', () => {
@@ -483,16 +482,22 @@ describe('DropMenu', () => {
 
 					optionDOMNodes[2].click();
 
-					assert(onSelect.called);
-					assert(onSelect.calledWith(2));
+					const selectedIndex = onSelectMock.mock.calls[0][0];
+
+					expect(onSelectMock).toHaveBeenCalledTimes(1);
+					expect(selectedIndex).toEqual(2);
 				});
 			});
 
 			describe('keyboard', () => {
 				it('should be called when DropMenu [expanded, option focused, Enter key  pressed]', () => {
-					const onSelect: any = sinon.spy();
+					const onSelectMock: any = jest.fn();
 					const wrapper = shallow(
-						<DropMenu isExpanded={true} focusedIndex={2} onSelect={onSelect}>
+						<DropMenu
+							isExpanded={true}
+							focusedIndex={2}
+							onSelect={onSelectMock}
+						>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -505,8 +510,10 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onSelect.called);
-					assert(onSelect.calledWith(2));
+					const selectedIndex = onSelectMock.mock.calls[0][0];
+
+					expect(onSelectMock).toHaveBeenCalledTimes(1);
+					expect(selectedIndex).toEqual(2);
 				});
 			});
 		});
@@ -514,12 +521,12 @@ describe('DropMenu', () => {
 		describe('onFocusOption', () => {
 			describe('keyboard', () => {
 				it('should be called when DropMenu [expanded, focusedIndex=null, Down Arrow key pressed]', () => {
-					const onFocusOption = sinon.spy();
+					const onFocusOptionMock: any = jest.fn();
 					const wrapper = shallow(
 						<DropMenu
 							isExpanded={true}
 							focusedIndex={null}
-							onFocusOption={onFocusOption}
+							onFocusOption={onFocusOptionMock}
 						>
 							<Control>control</Control>
 							<Option>option a</Option>
@@ -533,16 +540,16 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onFocusOption.called);
+					expect(onFocusOptionMock).toHaveBeenCalledTimes(1);
 				});
 
 				it('should be called when DropMenu [expanded, focusedIndex={not last option}, Down Arrow key pressed]', () => {
-					const onFocusOption = sinon.spy();
+					const onFocusOptionMock: any = jest.fn();
 					const wrapper = shallow(
 						<DropMenu
 							isExpanded={true}
 							focusedIndex={1}
-							onFocusOption={onFocusOption}
+							onFocusOption={onFocusOptionMock}
 						>
 							<Control>control</Control>
 							<Option>option a</Option>
@@ -556,16 +563,16 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onFocusOption.called);
+					expect(onFocusOptionMock).toHaveBeenCalledTimes(1);
 				});
 
 				it('should not be called when DropMenu [expanded, focusedIndex={last option}, Down Arrow key pressed]', () => {
-					const onFocusOption = sinon.spy();
+					const onFocusOptionMock: any = jest.fn();
 					const wrapper = shallow(
 						<DropMenu
 							isExpanded={true}
 							focusedIndex={2}
-							onFocusOption={onFocusOption}
+							onFocusOption={onFocusOptionMock}
 						>
 							<Control>control</Control>
 							<Option>option a</Option>
@@ -579,16 +586,16 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onFocusOption.notCalled);
+					expect(onFocusOptionMock).not.toHaveBeenCalled();
 				});
 
 				it('should be called when DropMenu [expanded, focusedIndex={not first option}, Up Arrow key pressed]', () => {
-					const onFocusOption = sinon.spy();
+					const onFocusOptionMock: any = jest.fn();
 					const wrapper = shallow(
 						<DropMenu
 							isExpanded={true}
 							focusedIndex={2}
-							onFocusOption={onFocusOption}
+							onFocusOption={onFocusOptionMock}
 						>
 							<Control>control</Control>
 							<Option>option a</Option>
@@ -602,16 +609,16 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onFocusOption.called);
+					expect(onFocusOptionMock).toHaveBeenCalledTimes(1);
 				});
 
 				it('should not be called when DropMenu [expanded, focusedIndex={first option}, Up Arrow key pressed]', () => {
-					const onFocusOption = sinon.spy();
+					const onFocusOptionMock: any = jest.fn();
 					const wrapper = shallow(
 						<DropMenu
 							isExpanded={true}
 							focusedIndex={0}
-							onFocusOption={onFocusOption}
+							onFocusOption={onFocusOptionMock}
 						>
 							<Control>control</Control>
 							<Option>option a</Option>
@@ -625,16 +632,16 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onFocusOption.notCalled);
+					expect(onFocusOptionMock).not.toHaveBeenCalled();
 				});
 
 				it('should not be called when DropMenu [expanded, focusedIndex={null}, Up Arrow key pressed]', () => {
-					const onFocusOption = sinon.spy();
+					const onFocusOptionMock: any = jest.fn();
 					const wrapper = shallow(
 						<DropMenu
 							isExpanded={true}
 							focusedIndex={null}
-							onFocusOption={onFocusOption}
+							onFocusOption={onFocusOptionMock}
 						>
 							<Control>control</Control>
 							<Option>option a</Option>
@@ -648,19 +655,19 @@ describe('DropMenu', () => {
 						preventDefault: _.noop,
 					});
 
-					assert(onFocusOption.notCalled);
+					expect(onFocusOptionMock).not.toHaveBeenCalled();
 				});
 			});
 
 			describe('mouse', () => {
-				let onFocusOption: any;
+				let onFocusOptionMock: any;
 				let wrapper: any;
 
 				beforeEach(() => {
-					onFocusOption = sinon.spy();
+					onFocusOptionMock = jest.fn();
 
 					wrapper = mount(
-						<DropMenu isExpanded={true} onFocusOption={onFocusOption}>
+						<DropMenu isExpanded={true} onFocusOption={onFocusOptionMock}>
 							<Control>control</Control>
 							<Option>option a</Option>
 							<Option>option b</Option>
@@ -671,7 +678,7 @@ describe('DropMenu', () => {
 
 				afterEach(() => {
 					wrapper.unmount();
-					onFocusOption.reset();
+					onFocusOptionMock.mockClear();
 				});
 
 				it('should be called when user moves mouse over option', () => {
@@ -698,9 +705,10 @@ describe('DropMenu', () => {
 					);
 					optionDOMNodes[2].dispatchEvent(mouseMoveEvent);
 
-					assert(onFocusOption.called);
-					assert(onFocusOption.calledWith(2));
-					assert(true);
+					const selectedIndex = onFocusOptionMock.mock.calls[0][0];
+
+					expect(onFocusOptionMock).toHaveBeenCalledTimes(1);
+					expect(selectedIndex).toEqual(2);
 				});
 			});
 		});

--- a/src/components/ExampleComponent/ExampleComponent.stories.tsx
+++ b/src/components/ExampleComponent/ExampleComponent.stories.tsx
@@ -20,7 +20,6 @@ export default {
 	},
 } as Meta;
 
-/* Basic */
 export const Basic: Story<IExampleComponentProps> = (args) => {
 	return (
 		<ExampleComponent {...args}>
@@ -30,7 +29,6 @@ export const Basic: Story<IExampleComponentProps> = (args) => {
 	);
 };
 
-/* Prop Example */
 export const PropExample: Story<IExampleComponentProps> = (args) => {
 	return (
 		<ExampleComponent {...args} isX={true}>
@@ -39,4 +37,3 @@ export const PropExample: Story<IExampleComponentProps> = (args) => {
 		</ExampleComponent>
 	);
 };
-PropExample.storyName = 'PropExample';

--- a/src/components/Expander/Expander.stories.tsx
+++ b/src/components/Expander/Expander.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import createClass from 'create-react-class';
+
 import Expander from './Expander';
 import Button from '../Button/Button';
 import EditIcon from '../Icon/EditIcon/EditIcon';
@@ -17,8 +18,7 @@ export default {
 	},
 };
 
-/* Expanded */
-export const Expanded = () => {
+export const Basic = () => {
 	const Component = createClass({
 		render() {
 			return (
@@ -153,7 +153,6 @@ export const InteractiveWithChangingLabels = () => {
 
 	return <Component />;
 };
-InteractiveWithChangingLabels.storyName = 'InteractiveWithChangingLabels';
 
 /* Interactive Without Changing Labels */
 export const InteractiveWithoutChangingLabels = () => {
@@ -249,7 +248,6 @@ export const InteractiveWithoutChangingLabels = () => {
 
 	return <Component />;
 };
-InteractiveWithoutChangingLabels.storyName = 'InteractiveWithoutChangingLabels';
 
 /* Interactive With Changing Labels And Additional Label Content */
 export const InteractiveWithChangingLabelsAndAdditionalLabelContent = () => {
@@ -355,8 +353,6 @@ export const InteractiveWithChangingLabelsAndAdditionalLabelContent = () => {
 
 	return <Component />;
 };
-InteractiveWithChangingLabelsAndAdditionalLabelContent.storyName =
-	'InteractiveWithChangingLabelsAndAdditionalLabelContent';
 
 /* Highlighted */
 export const Highlighted = () => {

--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -43,9 +43,7 @@ const AdditionalLabelContent = (_props: IExpanderAdditionalLabelProps): null =>
 	null;
 AdditionalLabelContent.displayName = 'Expander.AdditionalLabelContent';
 AdditionalLabelContent.peek = {
-	description: `
-						Renders a \`<span>\` to be shown next to the expander label.
-					`,
+	description: `Renders a \`<span>\` to be shown next to the expander label.`,
 };
 AdditionalLabelContent.propName = 'AdditionalLabelContent';
 AdditionalLabelContent.propTypes = {
@@ -161,10 +159,7 @@ class Expander extends React.Component<IExpanderProps, IExpanderState> {
 	static AdditionalLabelContent = AdditionalLabelContent;
 
 	static peek = {
-		description: `
-				This is a container that provides a toggle that controls when the
-				content is shown.
-			`,
+		description: `\`Expander\` is a container that provides a toggle that controls when the content is shown.`,
 		categories: ['layout'],
 		madeFrom: ['ChevronIcon'],
 	};

--- a/src/components/Expander/__snapshots__/Expander.spec.tsx.snap
+++ b/src/components/Expander/__snapshots__/Expander.spec.tsx.snap
@@ -55,61 +55,6 @@ exports[`Expander [common] example testing should match snapshot(s) for Basic 1`
 </div>
 `;
 
-exports[`Expander [common] example testing should match snapshot(s) for Expanded 1`] = `
-<div>
-  <div
-    class="lucid-Expander lucid-Expander-is-expanded"
-  >
-    <header
-      class="lucid-Expander-header"
-    >
-      <div
-        class="lucid-Expander-header-toggle"
-      >
-        <button
-          class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-up"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M.5 4.5l7.5 7 7.5-7"
-              />
-            </svg>
-          </span>
-        </button>
-        <span
-          class="lucid-Expander-text"
-        >
-          Show Less
-        </span>
-      </div>
-    </header>
-    <section
-      class="lucid-Collapsible lucid-Expander-content"
-      style="overflow:hidden;padding:0"
-    >
-      <div
-        class="lucid-Collapsible-content"
-        style="margin:0"
-      >
-        <p>
-          You can't get rid of me. Keep clicking that icon as much as you want, but I'm here to stay!
-        </p>
-      </div>
-    </section>
-  </div>
-</div>
-`;
-
 exports[`Expander [common] example testing should match snapshot(s) for Highlighted 1`] = `
 <div>
   <div

--- a/src/components/Expander/__snapshots__/Expander.spec.tsx.snap
+++ b/src/components/Expander/__snapshots__/Expander.spec.tsx.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Expander [common] example testing should match snapshot(s) for Basic 1`] = `
+<div>
+  <div
+    class="lucid-Expander lucid-Expander-is-expanded"
+  >
+    <header
+      class="lucid-Expander-header"
+    >
+      <div
+        class="lucid-Expander-header-toggle"
+      >
+        <button
+          class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
+          type="button"
+        >
+          <span
+            class="lucid-Button-content"
+          >
+            <svg
+              class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-up"
+              height="16"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M.5 4.5l7.5 7 7.5-7"
+              />
+            </svg>
+          </span>
+        </button>
+        <span
+          class="lucid-Expander-text"
+        >
+          Show Less
+        </span>
+      </div>
+    </header>
+    <section
+      class="lucid-Collapsible lucid-Expander-content"
+      style="overflow:hidden;padding:0"
+    >
+      <div
+        class="lucid-Collapsible-content"
+        style="margin:0"
+      >
+        <p>
+          You can't get rid of me. Keep clicking that icon as much as you want, but I'm here to stay!
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
 exports[`Expander [common] example testing should match snapshot(s) for Expanded 1`] = `
 <div>
   <div

--- a/src/components/IconSelect/IconSelect.spec.tsx
+++ b/src/components/IconSelect/IconSelect.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import assert from 'assert';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import { common } from '../../util/generic-tests';
 import IconSelect from './IconSelect';
@@ -20,7 +20,7 @@ const items = [
 
 describe('IconSelect', () => {
 	common(IconSelect, {
-		defaultProps: { items: [] },
+		getDefaultProps: () => ({ items: [] }),
 	} as any);
 
 	it('prop children', () => {
@@ -33,73 +33,60 @@ describe('IconSelect', () => {
 		assert(wrapper.contains(<div className='jim' />));
 	});
 
-	it.skip('has a selected item', () => {
+	it('has a selected item', () => {
 		const wrapper = shallow(<IconSelect items={items as any} />);
 
-		assert.equal(
-			wrapper.children().at(1).children().at(1).children().prop('isSelected'),
+		assert.strictEqual(
+			wrapper
+				.children()
+				.at(1)
+				.children()
+				.at(0)
+				.children()
+				.at(0)
+				.prop('isSelected'),
 			true
 		);
 	});
 
+	it('has an unselected selected item', () => {
+		const wrapper = shallow(<IconSelect items={items as any} />);
+
+		assert.strictEqual(
+			wrapper
+				.children()
+				.at(0)
+				.children()
+				.at(0)
+				.children()
+				.at(0)
+				.prop('isSelected'),
+			false
+		);
+	});
+
 	describe('IconSelect Events', () => {
-		it.skip('should call the onClick handler when clicked', () => {
-			const onIconSelect = jest.fn();
+		it('should call the onClick handler when clicked', () => {
 			const onIconSelectClick = jest.fn();
-			const mockEvent = {
-				target: {
-					classList: {
-						contains: () => true,
-					},
-					focus: onIconSelect,
-					hasAttribute: () => false,
-					dataset: {
-						id: 'test',
-					},
-				},
-			};
-			const wrapper = shallow(
+			const wrapper = mount(
 				<IconSelect items={items as any} onSelect={onIconSelectClick} />
 			);
-			const onClickEvent: any = wrapper.instance();
-
-			onClickEvent.handleClick(mockEvent);
-
-			expect(onIconSelect).toHaveBeenCalled();
-			expect(onIconSelectClick).toHaveBeenCalledWith(
-				'test',
-				expect.objectContaining({
-					event: expect.anything(),
-					props: expect.anything(),
-				})
-			);
+			wrapper.find('figure[data-id="one"]').simulate('click');
+			expect(onIconSelectClick).toBeCalledTimes(1);
 		});
 
-		it.skip('should not use onClick if disabled', () => {
-			const onIconSelect = jest.fn();
-			const onIconSelectClick = jest.fn();
-			const mockEvent = {
-				target: {
-					focus: onIconSelect,
-					hasAttribute: () => true,
-					dataset: {
-						id: 'test',
-					},
-				},
-			};
-			const wrapper = shallow(
+		it('should not use onClick if disabled', () => {
+			const onIconSelectMock = jest.fn();
+			const wrapper = mount(
 				<IconSelect
 					items={items as any}
-					isDisabled={true}
-					onSelect={onIconSelectClick}
+					onSelect={onIconSelectMock}
+					isDisabled
 				/>
 			);
-			const onClickEvent: any = wrapper.instance();
+			wrapper.find('figure[data-id="one"]').simulate('click');
 
-			onClickEvent.handleClick(mockEvent);
-
-			expect(onIconSelect).not.toHaveBeenCalled();
-			expect(onIconSelectClick).not.toHaveBeenCalled();
+			expect(onIconSelectMock).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/components/IconSelect/IconSelect.stories.tsx
+++ b/src/components/IconSelect/IconSelect.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { Meta } from '@storybook/react';
-import IconSelect from './IconSelect';
+import { Meta, Story } from '@storybook/react';
+
+import IconSelect, { IIconSelectProps } from './IconSelect';
 import ClockIcon from '../Icon/ClockIcon/ClockIcon';
 import StopwatchIcon from '../Icon/StopwatchIcon/StopwatchIcon';
 import SwitchLabeled from '../SwitchLabeled/SwitchLabeled';
@@ -16,10 +17,10 @@ export default {
 			},
 		},
 	},
+	args: IconSelect.defaultProps,
 } as Meta;
 
-//👇 Create a “template” of how args map to rendering
-const Template: any = (args) => {
+export const Basic: Story<IIconSelectProps> = (args) => {
 	const [selectedIcon, setSelectedIcon] = useState<string>('item2');
 
 	const handleSelect = (id: string) => {
@@ -53,16 +54,44 @@ const Template: any = (args) => {
 	);
 };
 
-//👇 Each story then reuses that template
+/** Single: Select One Icon */
+export const Single: Story<IIconSelectProps> = (args) => {
+	const [selectedIcon, setSelectedIcon] = useState<string>('item2');
 
-/** Default: Select One Icon */
-export const Basic = Template.bind({});
-Basic.args = {
-	kind: 'single', // renders as radio buttons
+	const handleSelect = (id: string) => {
+		// when selected, set `selectedIcon`
+		setSelectedIcon(id);
+	};
+
+	return (
+		<section>
+			<IconSelect
+				{...args}
+				onSelect={handleSelect}
+				kind='single'
+				items={
+					[
+						{
+							id: 'item1',
+							icon: <ClockIcon />,
+							isSelected: selectedIcon === 'item1',
+							label: 'Foo Bar',
+						},
+						{
+							id: 'item2',
+							icon: <StopwatchIcon />,
+							isSelected: selectedIcon === 'item2',
+							label: 'Bax Tar',
+						},
+					] as any
+				}
+			/>
+		</section>
+	);
 };
 
 /** Select Multiple Icons */
-export const SelectMultipleIcons = (args) => {
+export const SelectMultipleIcons: Story<IIconSelectProps> = (args) => {
 	const [selectedIcons, setSelectedIcons] = useState<string[]>(['item2']);
 
 	const isSelected = (id: string) => {
@@ -84,6 +113,7 @@ export const SelectMultipleIcons = (args) => {
 			<IconSelect
 				{...args}
 				onSelect={handleSelect}
+				kind='multiple'
 				items={
 					[
 						{
@@ -104,12 +134,9 @@ export const SelectMultipleIcons = (args) => {
 		</section>
 	);
 };
-SelectMultipleIcons.args = {
-	kind: 'multiple', // default value, renders as checkboxes
-};
 
 /** Partially Select Icons */
-export const PartiallySelectIcons = (args) => {
+export const PartiallySelectIcons: Story<IIconSelectProps> = (args) => {
 	const [selectedIcons, setSelectedIcons] = useState<any>([
 		{ id: 'item2', isPartial: true },
 	]);
@@ -178,7 +205,7 @@ export const PartiallySelectIcons = (args) => {
 };
 
 /** Disabled Icon Select */
-export const DisabledIconSelect = (args) => {
+export const DisabledIconSelect: Story<IIconSelectProps> = (args) => {
 	const [selectedIcons, setSelectedIcons] = useState<string[]>(['item2']);
 	const [isDisabled, setIsDisabled] = useState<boolean>(true);
 

--- a/src/components/IconSelect/IconSelect.tsx
+++ b/src/components/IconSelect/IconSelect.tsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import Icon from '../Icon/Icon';
 import RadioButtonLabeled from '../RadioButtonLabeled/RadioButtonLabeled';
 import CheckboxLabeled from '../CheckboxLabeled/CheckboxLabeled';
-
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	StandardProps,
@@ -34,7 +33,7 @@ const getFigureParent = (domNode: HTMLElement): HTMLElement | undefined => {
 interface Item {
 	id: string;
 	icon?: React.ReactElement;
-	label?: React.ReactElement;
+	label?: React.ReactElement | string;
 	isSelected?: boolean;
 	isPartial?: boolean;
 	tabIndex?: number;

--- a/src/components/IconSelect/__snapshots__/IconSelect.spec.tsx.snap
+++ b/src/components/IconSelect/__snapshots__/IconSelect.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`IconSelect [common] example testing should match snapshot(s) for Basic 
     class="lucid-IconSelect"
   >
     <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-single"
+      class="lucid-IconSelect-Item lucid-IconSelect-Item-multi"
       data-id="item1"
     >
       <svg
@@ -29,27 +29,34 @@ exports[`IconSelect [common] example testing should match snapshot(s) for Basic 
         class="lucid-IconSelect-Item-figcaption"
       >
         <label
-          class="lucid-RadioButtonLabeled lucid-IconSelect-Item-radio"
+          class="lucid-CheckboxLabeled lucid-IconSelect-Item-checkbox"
         >
-          <span
-            class="lucid-RadioButton lucid-IconSelect-Item-radio"
+          <div
+            class="lucid-Checkbox lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
           >
             <input
-              class="lucid-RadioButton-native"
-              type="radio"
+              class="lucid-Checkbox-native"
+              type="checkbox"
             />
             <span
-              class="lucid-RadioButton-visualization-glow"
+              class="lucid-Checkbox-visualization-glow"
             />
             <span
-              class="lucid-RadioButton-visualization-container"
+              class="lucid-Checkbox-visualization-container"
             />
             <span
-              class="lucid-RadioButton-visualization-dot"
-            />
-          </span>
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
           <div
-            class="lucid-RadioButtonLabeled-label"
+            class="lucid-CheckboxLabeled-label"
           >
             Foo Bar
           </div>
@@ -57,7 +64,7 @@ exports[`IconSelect [common] example testing should match snapshot(s) for Basic 
       </figcaption>
     </figure>
     <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-single"
+      class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-multi"
       data-id="item2"
     >
       <svg
@@ -81,28 +88,35 @@ exports[`IconSelect [common] example testing should match snapshot(s) for Basic 
         class="lucid-IconSelect-Item-figcaption"
       >
         <label
-          class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected lucid-IconSelect-Item-radio"
+          class="lucid-CheckboxLabeled lucid-CheckboxLabeled-is-selected lucid-IconSelect-Item-checkbox"
         >
-          <span
-            class="lucid-RadioButton lucid-RadioButton-is-selected lucid-IconSelect-Item-radio"
+          <div
+            class="lucid-Checkbox lucid-Checkbox-is-selected lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
           >
             <input
               checked=""
-              class="lucid-RadioButton-native"
-              type="radio"
+              class="lucid-Checkbox-native"
+              type="checkbox"
             />
             <span
-              class="lucid-RadioButton-visualization-glow"
+              class="lucid-Checkbox-visualization-glow"
             />
             <span
-              class="lucid-RadioButton-visualization-container"
+              class="lucid-Checkbox-visualization-container"
             />
             <span
-              class="lucid-RadioButton-visualization-dot"
-            />
-          </span>
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
           <div
-            class="lucid-RadioButtonLabeled-label"
+            class="lucid-CheckboxLabeled-label"
           >
             Bax Tar
           </div>
@@ -507,6 +521,119 @@ exports[`IconSelect [common] example testing should match snapshot(s) for Select
           </div>
           <div
             class="lucid-CheckboxLabeled-label"
+          >
+            Bax Tar
+          </div>
+        </label>
+      </figcaption>
+    </figure>
+  </span>
+</section>
+`;
+
+exports[`IconSelect [common] example testing should match snapshot(s) for Single 1`] = `
+<section>
+  <span
+    class="lucid-IconSelect"
+  >
+    <figure
+      class="lucid-IconSelect-Item lucid-IconSelect-Item-single"
+      data-id="item1"
+    >
+      <svg
+        class="lucid-Icon lucid-Icon-color-primary lucid-ClockIcon"
+        height="16"
+        preserveAspectRatio="xMidYMid meet"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <circle
+          cx="8"
+          cy="8"
+          r="7.5"
+        />
+        <path
+          d="M8 3.5v5l2.75 2.25"
+        />
+      </svg>
+      <figcaption
+        class="lucid-IconSelect-Item-figcaption"
+      >
+        <label
+          class="lucid-RadioButtonLabeled lucid-IconSelect-Item-radio"
+        >
+          <span
+            class="lucid-RadioButton lucid-IconSelect-Item-radio"
+          >
+            <input
+              class="lucid-RadioButton-native"
+              type="radio"
+            />
+            <span
+              class="lucid-RadioButton-visualization-glow"
+            />
+            <span
+              class="lucid-RadioButton-visualization-container"
+            />
+            <span
+              class="lucid-RadioButton-visualization-dot"
+            />
+          </span>
+          <div
+            class="lucid-RadioButtonLabeled-label"
+          >
+            Foo Bar
+          </div>
+        </label>
+      </figcaption>
+    </figure>
+    <figure
+      class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-single"
+      data-id="item2"
+    >
+      <svg
+        class="lucid-Icon lucid-Icon-color-primary lucid-StopwatchIcon"
+        height="16"
+        preserveAspectRatio="xMidYMid meet"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M7.5.5h3M9 .5v1.98M.5 6h5m-5 3h3m-3 3h4"
+        />
+        <path
+          d="M5.5 14.471A6.455 6.455 0 0 0 9 15.5a6.5 6.5 0 1 0 0-13c-1.29 0-2.489.38-3.5 1.029"
+        />
+        <path
+          d="M9 9l2.5-2.5"
+        />
+      </svg>
+      <figcaption
+        class="lucid-IconSelect-Item-figcaption"
+      >
+        <label
+          class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected lucid-IconSelect-Item-radio"
+        >
+          <span
+            class="lucid-RadioButton lucid-RadioButton-is-selected lucid-IconSelect-Item-radio"
+          >
+            <input
+              checked=""
+              class="lucid-RadioButton-native"
+              type="radio"
+            />
+            <span
+              class="lucid-RadioButton-visualization-glow"
+            />
+            <span
+              class="lucid-RadioButton-visualization-container"
+            />
+            <span
+              class="lucid-RadioButton-visualization-dot"
+            />
+          </span>
+          <div
+            class="lucid-RadioButtonLabeled-label"
           >
             Bax Tar
           </div>

--- a/src/components/LineChart/LineChart.spec.tsx
+++ b/src/components/LineChart/LineChart.spec.tsx
@@ -18,6 +18,11 @@ const {
 describe('LineChart', () => {
 	let wrapper: any;
 
+	const defaultData = [
+		{ x: new Date('2015-01-01T00:00:00Z'), y: 1 },
+		{ x: new Date('2015-01-01T00:00:00Z'), y: 2 },
+	];
+
 	afterEach(() => {
 		if (wrapper) {
 			wrapper.unmount();
@@ -35,17 +40,14 @@ describe('LineChart', () => {
 			'y2AxisTooltipDataFormatter',
 		] as any,
 		getDefaultProps: () => ({
-			data: [
-				{ x: new Date('2015-01-01T00:00:00Z'), y: 1 },
-				{ x: new Date('2015-01-01T00:00:00Z'), y: 2 },
-			],
+			data: defaultData,
 		}),
 	});
 
 	describe('props', () => {
 		describe('isLoading', () => {
 			it('should show a `LoadingIndicator` if `isLoading`', () => {
-				wrapper = mount(<LineChart isLoading />);
+				wrapper = mount(<LineChart isLoading data={[]} />);
 
 				const loadingIndicatorWrapper = wrapper
 					.find(EmptyStateWrapper)
@@ -61,7 +63,7 @@ describe('LineChart', () => {
 			it('should render the message title element', () => {
 				const titleText = 'Here is the Title Text';
 				wrapper = mount(
-					<LineChart>
+					<LineChart data={[]}>
 						<EmptyStateWrapper>
 							<Title>{titleText}</Title>
 						</EmptyStateWrapper>
@@ -88,7 +90,7 @@ describe('LineChart', () => {
 					</div>
 				);
 				wrapper = mount(
-					<LineChart>
+					<LineChart data={[]}>
 						<EmptyStateWrapper>
 							<Body>{bodyElement}</Body>
 						</EmptyStateWrapper>

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -1,6 +1,9 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import * as d3Scale from 'd3-scale';
+import * as d3TimeFormat from 'd3-time-format';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	StandardProps,
@@ -14,11 +17,9 @@ import {
 	maxByFieldsStacked,
 	formatDate,
 	nearest,
+	Collection,
 } from '../../util/chart-helpers';
-import * as d3Scale from 'd3-scale';
-import * as d3TimeFormat from 'd3-time-format';
 import * as chartConstants from '../../constants/charts';
-
 import Axis from '../Axis/Axis';
 import AxisLabel from '../AxisLabel/AxisLabel';
 import Legend from '../Legend/Legend';
@@ -70,15 +71,17 @@ export interface ILineChartPropsRaw extends StandardProps {
 
 	/**
 	 * Data for the chart. E.g.
-	 * { x: new Date('2015-01-01') , y: 1 } ,
-	 * { x: new Date('2015-01-02') , y: 2 } ,
-	 * { x: new Date('2015-01-03') , y: 3 } ,
-	 * { x: new Date('2015-01-04') , y: 2 } ,
-	 * { x: new Date('2015-01-05') , y: 5 } ,
-	 * ]
+	 *
+	 * 	[
+	 * 		{ x: new Date('2015-01-01') , y: 1 } ,
+	 * 		{ x: new Date('2015-01-02') , y: 2 } ,
+	 * 		{ x: new Date('2015-01-03') , y: 3 } ,
+	 * 		{ x: new Date('2015-01-04') , y: 2 } ,
+	 * 		{ x: new Date('2015-01-05') , y: 5 } ,
+	 * 	]
 	 */
-	data?: Array<{ [key: string]: Date | number | undefined }>;
-
+	//data?: Array<{ [key: string]: Date | number | undefined }>;
+	data?: Collection;
 	/**
 	 * Legend is an object with human readable names for fields
 	 * that will be used for legends and tooltips. E.g:
@@ -354,7 +357,6 @@ class LineChart extends React.Component<ILineChartProps, ILineChartState, {}> {
 				]
 		*/
 		data: arrayOf(object),
-
 		/**
 			An object with human readable names for fields that will be used for
 			legends and tooltips. E.g:

--- a/src/components/Paginator/Paginator.stories.tsx
+++ b/src/components/Paginator/Paginator.stories.tsx
@@ -6,6 +6,13 @@ import Paginator, { IPaginatorProps } from './Paginator';
 export default {
 	title: 'Navigation/Paginator',
 	component: Paginator,
+	parameters: {
+		docs: {
+			description: {
+				component: Paginator.description,
+			},
+		},
+	},
 };
 
 export const Basic: Story<IPaginatorProps> = (args) => {

--- a/src/components/Paginator/Paginator.tsx
+++ b/src/components/Paginator/Paginator.tsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import React, { FC } from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import { StandardProps } from '../../util/component-types';
 import * as reducers from './Paginator.reducers';

--- a/src/components/RadioButtonLabeled/RadioButtonLabeled.stories.tsx
+++ b/src/components/RadioButtonLabeled/RadioButtonLabeled.stories.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { Meta, Story } from '@storybook/react';
 
-import { IRadioButtonLabeledProps } from './RadioButtonLabeled';
-import RadioButtonLabeled from './RadioButtonLabeled';
+import RadioButtonLabeled, {
+	IRadioButtonLabeledProps,
+} from './RadioButtonLabeled';
 
 export default {
 	title: 'Controls/RadioButtonLabeled',
@@ -14,17 +15,18 @@ export default {
 			},
 		},
 	},
+	args: RadioButtonLabeled.defaultProps,
 } as Meta;
 
-/* Interactive */
-export const Interactive: Story<IRadioButtonLabeledProps> = (args) => {
+/* Basic */
+export const Basic: Story<IRadioButtonLabeledProps> = (args) => {
 	const style = {
 		marginBottom: '3px',
 	};
 
 	const [flavor, setFlavor] = useState('vanilla');
 
-	const handleSelectedFlavor = (flavor) => {
+	const handleSelectedFlavor = (flavor: string) => {
 		setFlavor(flavor);
 	};
 
@@ -116,7 +118,7 @@ export const States: Story<IRadioButtonLabeledProps> = (args) => {
 					style={style}
 				>
 					<RadioButtonLabeled.Label>
-						Disabled & Selected
+						Disabled and Selected
 					</RadioButtonLabeled.Label>
 				</RadioButtonLabeled>
 			</section>
@@ -131,16 +133,14 @@ export const LabelAsChild: Story<IRadioButtonLabeledProps> = (args) => {
 	};
 	return (
 		<section>
-			<section>
-				<RadioButtonLabeled {...args} style={style}>
-					<RadioButtonLabeled.Label>Just text</RadioButtonLabeled.Label>
-				</RadioButtonLabeled>
-				<RadioButtonLabeled {...args} style={style}>
-					<RadioButtonLabeled.Label>
-						<span>HTML element</span>
-					</RadioButtonLabeled.Label>
-				</RadioButtonLabeled>
-			</section>
+			<RadioButtonLabeled {...args} style={style}>
+				<RadioButtonLabeled.Label>Just text</RadioButtonLabeled.Label>
+			</RadioButtonLabeled>
+			<RadioButtonLabeled {...args} style={style}>
+				<RadioButtonLabeled.Label>
+					<span>HTML element</span>
+				</RadioButtonLabeled.Label>
+			</RadioButtonLabeled>
 		</section>
 	);
 };
@@ -153,34 +153,33 @@ export const LabelAsProp: Story<IRadioButtonLabeledProps> = (args) => {
 
 	return (
 		<section>
-			<section>
-				<RadioButtonLabeled {...args} Label='Just text' style={style} />
-				<RadioButtonLabeled Label={<span>HTML element</span>} style={style} />
-				<RadioButtonLabeled
-					{...args}
-					Label={
-						[
-							'Text in an array',
-							'Only the first value in the array is used',
-							'The rest of these should be ignored',
-						] as any
-					}
-					style={style}
-				/>
-				<RadioButtonLabeled
-					{...args}
-					Label={
-						[
-							<span key='1'>HTML element in an array</span>,
-							<span key='2'>
-								Again only the first value in the array is used
-							</span>,
-							<span key='3'>The rest should not be rendered</span>,
-						] as any
-					}
-					style={style}
-				/>
-			</section>
+			<RadioButtonLabeled Label='Just text' style={style}></RadioButtonLabeled>
+			<RadioButtonLabeled
+				Label={<span>HTML element</span>}
+				style={style}
+			></RadioButtonLabeled>
+			<RadioButtonLabeled
+				Label={
+					[
+						'Text in an array',
+						'Only the first value in the array is used',
+						'The rest of these should be ignored',
+					] as any
+				}
+				style={style}
+			></RadioButtonLabeled>
+			<RadioButtonLabeled
+				Label={
+					[
+						<span key='1'>HTML element in an array</span>,
+						<span key='2'>
+							Again only the first value in the array is used
+						</span>,
+						<span key='3'>The rest should not be rendered</span>,
+					] as any
+				}
+				style={style}
+			></RadioButtonLabeled>
 		</section>
 	);
 };

--- a/src/components/RadioButtonLabeled/__snapshots__/RadioButtonLabeled.spec.tsx.snap
+++ b/src/components/RadioButtonLabeled/__snapshots__/RadioButtonLabeled.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RadioButtonLabeled [common] example testing should match snapshot(s) for Interactive 1`] = `
+exports[`RadioButtonLabeled [common] example testing should match snapshot(s) for Basic 1`] = `
 <section>
   <span
     style="display:inline-flex;flex-direction:column;align-items:flex-start"
@@ -147,183 +147,179 @@ exports[`RadioButtonLabeled [common] example testing should match snapshot(s) fo
 
 exports[`RadioButtonLabeled [common] example testing should match snapshot(s) for LabelAsChild 1`] = `
 <section>
-  <section>
-    <label
-      class="lucid-RadioButtonLabeled"
-      style="margin-bottom:3px"
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-bottom:3px"
+  >
+    <span
+      class="lucid-RadioButton"
     >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
       <span
-        class="lucid-RadioButton"
-      >
-        <input
-          class="lucid-RadioButton-native"
-          type="radio"
-        />
-        <span
-          class="lucid-RadioButton-visualization-glow"
-        />
-        <span
-          class="lucid-RadioButton-visualization-container"
-        />
-        <span
-          class="lucid-RadioButton-visualization-dot"
-        />
-      </span>
-      <div
-        class="lucid-RadioButtonLabeled-label"
-      >
-        Just text
-      </div>
-    </label>
-    <label
-      class="lucid-RadioButtonLabeled"
-      style="margin-bottom:3px"
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
     >
+      Just text
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-bottom:3px"
+  >
+    <span
+      class="lucid-RadioButton"
+    >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
       <span
-        class="lucid-RadioButton"
-      >
-        <input
-          class="lucid-RadioButton-native"
-          type="radio"
-        />
-        <span
-          class="lucid-RadioButton-visualization-glow"
-        />
-        <span
-          class="lucid-RadioButton-visualization-container"
-        />
-        <span
-          class="lucid-RadioButton-visualization-dot"
-        />
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      <span>
+        HTML element
       </span>
-      <div
-        class="lucid-RadioButtonLabeled-label"
-      >
-        <span>
-          HTML element
-        </span>
-      </div>
-    </label>
-  </section>
+    </div>
+  </label>
 </section>
 `;
 
 exports[`RadioButtonLabeled [common] example testing should match snapshot(s) for LabelAsProp 1`] = `
 <section>
-  <section>
-    <label
-      class="lucid-RadioButtonLabeled"
-      style="margin-bottom:3px"
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-bottom:3px"
+  >
+    <span
+      class="lucid-RadioButton"
     >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
       <span
-        class="lucid-RadioButton"
-      >
-        <input
-          class="lucid-RadioButton-native"
-          type="radio"
-        />
-        <span
-          class="lucid-RadioButton-visualization-glow"
-        />
-        <span
-          class="lucid-RadioButton-visualization-container"
-        />
-        <span
-          class="lucid-RadioButton-visualization-dot"
-        />
-      </span>
-      <div
-        class="lucid-RadioButtonLabeled-label"
-      >
-        Just text
-      </div>
-    </label>
-    <label
-      class="lucid-RadioButtonLabeled"
-      style="margin-bottom:3px"
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
     >
-      <span
-        class="lucid-RadioButton"
-      >
-        <input
-          class="lucid-RadioButton-native"
-          type="radio"
-        />
-        <span
-          class="lucid-RadioButton-visualization-glow"
-        />
-        <span
-          class="lucid-RadioButton-visualization-container"
-        />
-        <span
-          class="lucid-RadioButton-visualization-dot"
-        />
-      </span>
-      <div
-        class="lucid-RadioButtonLabeled-label"
-      >
-        <span>
-          HTML element
-        </span>
-      </div>
-    </label>
-    <label
-      class="lucid-RadioButtonLabeled"
-      style="margin-bottom:3px"
+      Just text
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-bottom:3px"
+  >
+    <span
+      class="lucid-RadioButton"
     >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
       <span
-        class="lucid-RadioButton"
-      >
-        <input
-          class="lucid-RadioButton-native"
-          type="radio"
-        />
-        <span
-          class="lucid-RadioButton-visualization-glow"
-        />
-        <span
-          class="lucid-RadioButton-visualization-container"
-        />
-        <span
-          class="lucid-RadioButton-visualization-dot"
-        />
-      </span>
-      <div
-        class="lucid-RadioButtonLabeled-label"
-      >
-        Text in an array
-      </div>
-    </label>
-    <label
-      class="lucid-RadioButtonLabeled"
-      style="margin-bottom:3px"
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
     >
-      <span
-        class="lucid-RadioButton"
-      >
-        <input
-          class="lucid-RadioButton-native"
-          type="radio"
-        />
-        <span
-          class="lucid-RadioButton-visualization-glow"
-        />
-        <span
-          class="lucid-RadioButton-visualization-container"
-        />
-        <span
-          class="lucid-RadioButton-visualization-dot"
-        />
+      <span>
+        HTML element
       </span>
-      <div
-        class="lucid-RadioButtonLabeled-label"
-      >
-        <span>
-          HTML element in an array
-        </span>
-      </div>
-    </label>
-  </section>
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-bottom:3px"
+  >
+    <span
+      class="lucid-RadioButton"
+    >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      Text in an array
+    </div>
+  </label>
+  <label
+    class="lucid-RadioButtonLabeled"
+    style="margin-bottom:3px"
+  >
+    <span
+      class="lucid-RadioButton"
+    >
+      <input
+        class="lucid-RadioButton-native"
+        type="radio"
+      />
+      <span
+        class="lucid-RadioButton-visualization-glow"
+      />
+      <span
+        class="lucid-RadioButton-visualization-container"
+      />
+      <span
+        class="lucid-RadioButton-visualization-dot"
+      />
+    </span>
+    <div
+      class="lucid-RadioButtonLabeled-label"
+    >
+      <span>
+        HTML element in an array
+      </span>
+    </div>
+  </label>
 </section>
 `;
 
@@ -441,7 +437,7 @@ exports[`RadioButtonLabeled [common] example testing should match snapshot(s) fo
       <div
         class="lucid-RadioButtonLabeled-label"
       >
-        Disabled & Selected
+        Disabled and Selected
       </div>
     </label>
   </section>

--- a/src/components/RadioGroup/RadioGroup.spec.tsx
+++ b/src/components/RadioGroup/RadioGroup.spec.tsx
@@ -156,7 +156,6 @@ describe('RadioGroup', () => {
 						{...defaultProps}
 						{...{ foo: 1, bar: 2, baz: 3, qux: 4, quux: 5 }}
 						className='testClassName'
-						children={{ foo: '0', bar: 1, baz: 2 }}
 					>
 						<RadioGroup.RadioButton {...radioButtonDefaultProps} />
 						<RadioGroup.RadioButton {...radioButtonDefaultProps} />

--- a/src/components/SplitHorizontal/SplitHorizontal.spec.tsx
+++ b/src/components/SplitHorizontal/SplitHorizontal.spec.tsx
@@ -72,7 +72,7 @@ describe('SplitHorizontal', () => {
 				assert(wrapper.hasClass('lucid-SplitHorizontal-is-expanded'));
 			});
 
-			it.skip('should not apply the &-is-expanded css class when false [mostly stable]', (done) => {
+			it('should not apply the &-is-expanded css class when false [mostly stable]', (done) => {
 				mountWrapper = mount(<SplitHorizontal isExpanded={false} />);
 
 				assert(!mountWrapper.hasClass('lucid-SplitHorizontal-is-expanded'));

--- a/src/components/SplitVertical/SplitVertical.spec.tsx
+++ b/src/components/SplitVertical/SplitVertical.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import assert from 'assert';
 import _ from 'lodash';
+
 import { common } from '../../util/generic-tests';
 import SplitVertical from './SplitVertical';
 import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';

--- a/src/components/SwitchLabeled/SwitchLabeled.stories.tsx
+++ b/src/components/SwitchLabeled/SwitchLabeled.stories.tsx
@@ -147,7 +147,7 @@ export const InteractiveWithChangingLabels: Story<ISwitchLabeledProps> = (
 
 		render() {
 			const spamSwitchLabel = this.state.spam
-				? 'Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.'
+				? 'Yes! I would like to receive updates, special offers, and other information from Xandr and its subsidiaries.'
 				: 'No! Please keep your wicked, dirty spam all to yourselves!';
 
 			return (

--- a/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.tsx.snap
+++ b/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.tsx.snap
@@ -228,7 +228,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for Int
       class="lucid-SwitchLabeled-text"
       style="position:relative"
     >
-      Yes! I would like to receive updates, special offers, and other information from AppNexus and its subsidiaries.
+      Yes! I would like to receive updates, special offers, and other information from Xandr and its subsidiaries.
     </span>
   </label>
 </section>

--- a/src/components/Tabs/Tabs.spec.tsx
+++ b/src/components/Tabs/Tabs.spec.tsx
@@ -1,8 +1,8 @@
 import _ from 'lodash';
-import sinon from 'sinon';
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import { TabsDumb as Tabs } from './Tabs';
 
@@ -132,18 +132,31 @@ describe('Tabs', () => {
 		});
 
 		describe('onSelect', () => {
-			const onSelect: any = sinon.spy();
+			const onSelectMock: any = jest.fn();
 			let clickEvent: any;
 			let wrapper: any;
 			let tabBar: any;
 
 			beforeEach(() => {
-				onSelect.reset();
-				clickEvent = 'event';
+				onSelectMock.mockClear();
+				clickEvent = {
+					event: { index: 1 },
+					props: {
+						index: 1,
+						isLastTab: true,
+						isOpen: true,
+						isProgressive: false,
+						isSelected: false,
+						onSelect: () => {},
+						Title: '',
+						children: 'One',
+					},
+				};
+
 				wrapper = shallow(
-					<Tabs onSelect={onSelect}>
-						<Tabs.Tab isDisabled={true}>One</Tabs.Tab>
-						<Tabs.Tab>Two</Tabs.Tab>
+					<Tabs onSelect={onSelectMock}>
+						<Tabs.Tab isDisabled={true}>Zero</Tabs.Tab>
+						<Tabs.Tab>One</Tabs.Tab>
 					</Tabs>
 				);
 				tabBar = wrapper.find('.lucid-Tabs-bar').shallow();
@@ -151,25 +164,16 @@ describe('Tabs', () => {
 
 			it('should call onSelect with the correct arguments', () => {
 				tabBar.childAt(1).shallow().simulate('click', clickEvent);
-				const selectedIndex = onSelect.args[0][0];
-				const meta = onSelect.args[0][1];
-				assert(onSelect.called);
-				assert.equal(selectedIndex, 1);
-				assert.equal(meta.event, clickEvent);
-				assert.deepEqual(_.omit(meta.props, 'onSelect'), {
-					isLastTab: true,
-					isOpen: true,
-					isProgressive: false,
-					isSelected: false,
-					Title: '',
-					children: 'Two',
-					index: 1,
-				});
+				const selectedIndex = onSelectMock.mock.calls[0][0];
+				const meta = onSelectMock.mock.calls[0][1].event;
+				expect(onSelectMock).toBeCalledTimes(1);
+				expect(selectedIndex).toEqual(1);
+				expect(meta).toEqual(clickEvent);
 			});
 
 			it('should not call onSelect if the `Tab` isDisabled', () => {
 				tabBar.childAt(0).shallow().simulate('click', clickEvent);
-				assert(!onSelect.called);
+				expect(onSelectMock).not.toBeCalled();
 			});
 		});
 

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-//import createClass from 'create-react-class';
 import { Story, Meta } from '@storybook/react';
 
 import HelpIcon from './../Icon/HelpIcon/HelpIcon';
@@ -106,22 +105,21 @@ export const Nested: Story<ITypographyProps> = (args) => {
 				hairy kiss. chevron frontiersman chevron dick van dyke walrus leader of
 				men rugged borat bad guy testosterone trophy groucho-a-like alpha trion
 				hungarian.
-				<br />
-				<br />
-				<Typography {...args} variant='a' style={{ display: 'block' }}>
-					Like!
-				</Typography>
-				<br />
-				<Typography {...args} variant='a' style={{ display: 'block' }}>
-					Subscribe!
-				</Typography>
-				<br />
-				<Typography {...args} variant='h3'>
-					Code Example
-				</Typography>
-				<Typography {...args} variant='code'>
-					npm install all-the-things
-				</Typography>
+			</Typography>
+			<br />
+			<Typography {...args} variant='a' style={{ display: 'block' }}>
+				Like!
+			</Typography>
+			<br />
+			<Typography {...args} variant='a' style={{ display: 'block' }}>
+				Subscribe!
+			</Typography>
+			<br />
+			<Typography {...args} variant='h3'>
+				Code Example
+			</Typography>
+			<Typography {...args} variant='code'>
+				npm install all-the-things
 			</Typography>
 		</section>
 	);

--- a/src/components/Typography/__snapshots__/Typography.spec.tsx.snap
+++ b/src/components/Typography/__snapshots__/Typography.spec.tsx.snap
@@ -16,23 +16,22 @@ exports[`Typography [common] example testing should match snapshot(s) for Nested
     class="lucid-Typography lucid-Typography-p"
   >
     Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pencil mustachioed graeme souness, mustachioed waxy gurn rugged el snort graeme souness burt reynolds educated village people boogie nights pencil man of the year 1986, pencil village people graeme souness rugged boogie nights mouthbrow educated burt reynolds waxy gurn man of the year 1986 des lynam charming villain mustachioed cardinal richelieu el snort. Borat d’artagnan hungarian testosterone trophy frontiersman hairy kiss. beefeater chevron, hairy kiss. cardinal richelieu groucho-a-like testosterone trophy d’artagnan dick van dyke rugged chevron Droopy frontiersman borat beefeater hungarian chevron, cardinal richelieu d’artagnan beefeater el snort Droopy dodgy uncle clive groucho-a-like hairy kiss. chevron frontiersman chevron dick van dyke walrus leader of men rugged borat bad guy testosterone trophy groucho-a-like alpha trion hungarian.
-    <br />
-    <br />
-    <a
-      class="lucid-Typography lucid-Typography-a"
-      style="display:block"
-    >
-      Like!
-    </a>
-    <br />
-    <a
-      class="lucid-Typography lucid-Typography-a"
-      style="display:block"
-    >
-      Subscribe!
-    </a>
-    <br />
   </p>
+  <br />
+  <a
+    class="lucid-Typography lucid-Typography-a"
+    style="display:block"
+  >
+    Like!
+  </a>
+  <br />
+  <a
+    class="lucid-Typography lucid-Typography-a"
+    style="display:block"
+  >
+    Subscribe!
+  </a>
+  <br />
   <h3
     class="lucid-Typography lucid-Typography-h3"
   >
@@ -43,7 +42,6 @@ exports[`Typography [common] example testing should match snapshot(s) for Nested
   >
     npm install all-the-things
   </code>
-  <p />
 </section>
 `;
 

--- a/src/components/VerticalTabs/VerticalTabs.spec.tsx
+++ b/src/components/VerticalTabs/VerticalTabs.spec.tsx
@@ -1,9 +1,8 @@
-import sinon from 'sinon';
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
-import { common } from '../../util/generic-tests';
 
+import { common } from '../../util/generic-tests';
 import { VerticalTabsDumb as VerticalTabs } from './VerticalTabs';
 import { VerticalListMenuDumb as VerticalListMenu } from '../VerticalListMenu/VerticalListMenu';
 
@@ -155,13 +154,13 @@ describe('VerticalTabs', () => {
 		});
 
 		describe('onSelect', () => {
-			const onSelect: any = sinon.spy();
+			const onSelectMock: any = jest.fn();
 			let wrapper: any;
 
 			beforeEach(() => {
-				onSelect.reset();
+				onSelectMock.mockClear();
 				wrapper = shallow(
-					<VerticalTabs onSelect={onSelect}>
+					<VerticalTabs onSelect={onSelectMock}>
 						<VerticalTabs.Tab>One</VerticalTabs.Tab>
 						<VerticalTabs.Tab>Two</VerticalTabs.Tab>
 					</VerticalTabs>
@@ -170,8 +169,8 @@ describe('VerticalTabs', () => {
 
 			it('should pass props onto `VerticalListMenu`', () => {
 				wrapper.find(VerticalListMenu).props().onSelect('stuff');
-				assert(onSelect.called);
-				assert.equal(onSelect.args[0], 'stuff');
+				expect(onSelectMock).toBeCalledTimes(1);
+				expect(onSelectMock.mock.calls[0][0]).toEqual('stuff');
 			});
 		});
 	});

--- a/src/styles/master.less
+++ b/src/styles/master.less
@@ -21,10 +21,10 @@ body {
 	color: @color-neutral-9;
 
 	// repeating triangle Xandr pattern
-	background: url('https://acdn.adnxs.com/cxp/1y/bg-pattern.226a6795ab64d5cdd0bdd4a853719227.svg'),
-		@color-neutral-2;
-	background-position: top right;
-	background-repeat: repeat-y;
+	// background: url('https://acdn.adnxs.com/cxp/1y/bg-pattern.226a6795ab64d5cdd0bdd4a853719227.svg'),
+	// 	@color-neutral-2;
+	// background-position: top right;
+	// background-repeat: repeat-y;
 }
 
 h1,

--- a/src/util/generic-tests.tsx
+++ b/src/util/generic-tests.tsx
@@ -247,7 +247,7 @@ export function controls(
 		it('should callback with `event` and `props`', () => {
 			const expectedSpecialProp = 32;
 			const props = {
-				specialProp: expectedSpecialProp,
+				specialprop: expectedSpecialProp,
 				[callbackName]: sinon.spy(),
 				...additionalProps,
 			};
@@ -257,13 +257,13 @@ export function controls(
 
 			// Last argument should be an object with `uniqueId` and `event`
 			const {
-				props: { specialProp },
+				props: { specialprop },
 				event,
 			}: any = _.last(props[callbackName].args[0]);
 
 			assert(event, 'missing event');
 			assert.equal(
-				specialProp,
+				specialprop,
 				expectedSpecialProp,
 				'incorrect or missing specialProp'
 			);


### PR DESCRIPTION
## PR Checklist

Description of changes:

- cleanup the unit test warnings
- fix some broken unit test (take out .skip and .only)
- fix the console warnings for stories
- fix missing or misformatted story descriptions
- remove sinon where deprecated
- replace visible reference to appnexus with xandr

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2870-Lucid-cleanup/?path=/docs/documentation-intro--page

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
