### PR TITLE
Replace omitProps with _.omit, add unit tests and update Stories

### DIFF
--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -1204,8 +1204,7 @@ describe('DataTable', () => {
 						wrapper.find('[data-testid="columnGroup-column"]').first().props()
 					);
 
-					//console.log('tableThProps', columnGroupColumnProps);
-					// A ColumnGroup Column Table Table Row
+					// A ColumnGroup Column Table Table Rows
 					// should not contain any of the excluded (the unused) Column propTypes and the 'initialState' prop:
 					// 'field', 'title', 'initialState',
 
@@ -1213,7 +1212,7 @@ describe('DataTable', () => {
 						expect(_.includes(columnGroupColumnProps, prop)).toBe(false);
 					});
 
-					// The ColumnGroup Column Table Table Row should include:
+					// A ColumnGroup Column Table Table Row should include:
 					// 'onClick', 'style', 'align', 'isResizable', 'isSorted', 'sortDirection', 'rowSpan', 'children',
 
 					_.forEach(includedColumnProps, (prop) => {

--- a/src/components/DataTable/DataTable.spec.tsx
+++ b/src/components/DataTable/DataTable.spec.tsx
@@ -3,15 +3,14 @@ import _ from 'lodash';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import assert from 'assert';
-import { act } from 'react-dom/test-utils';
 
 import { common } from '../../util/generic-tests';
 import DataTable from './DataTable';
 import ScrollTable from '../ScrollTable/ScrollTable';
+import Table from '../Table/Table';
 import Checkbox from '../Checkbox/Checkbox';
 import EmptyStateWrapper from '../EmptyStateWrapper/EmptyStateWrapper';
 import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
-import { HandleResize } from '../SplitVertical/SplitVertical.stories';
 
 const { Column, ColumnGroup } = DataTable;
 
@@ -764,7 +763,7 @@ describe('DataTable', () => {
 			});
 		});
 
-		describe('isResize', () => {
+		describe('isResizeable', () => {
 			it('should render a `DragCaptureZone` resizer, if `isResizable` equals true', () => {
 				const wrapper = mount(
 					<DataTable hasFixedHeader data={testData}>
@@ -776,6 +775,194 @@ describe('DataTable', () => {
 					</DataTable>
 				);
 				expect(wrapper.find(DragCaptureZone)).toHaveLength(4);
+			});
+		});
+
+		describe('hasFixedHeader', () => {
+			it('should render a `Table` -- not a `ScrollTable` -- if true', () => {
+				const wrapper = shallow(
+					<DataTable hasFixedHeader={true} data={testData}></DataTable>
+				);
+				expect(wrapper.find('.lucid-DataTable-fixed')).toHaveLength(1);
+				expect(wrapper.find('.lucid-DataTable-fixed-header')).toHaveLength(1);
+				expect(
+					wrapper.find('.lucid-DataTable-fixed-header-fixed-columns')
+				).toHaveLength(1);
+				expect(wrapper.find(ScrollTable)).toHaveLength(0);
+			});
+			it('should render a `ScrollTable`, if false', () => {
+				const wrapper = shallow(
+					<DataTable hasFixedHeader={false} data={testData}></DataTable>
+				);
+				expect(wrapper.find('.lucid-DataTable-fixed')).toHaveLength(0);
+				expect(wrapper.find('.lucid-DataTable-fixed-header')).toHaveLength(0);
+				expect(
+					wrapper.find('.lucid-DataTable-fixed-header-fixed-columns')
+				).toHaveLength(0);
+				expect(wrapper.find(ScrollTable)).toHaveLength(1);
+			});
+		});
+
+		describe('passThroughs', () => {
+			const props = {
+				data: [],
+				emptyCellText: '--test',
+				isActionable: true,
+				isFullWidth: true,
+				isLoading: false,
+				isSelectable: true,
+				anchorMessage: true,
+				style: {},
+				minRows: 5,
+				hasFixedHeader: true,
+				fixedColumnCount: 2,
+				fixedRowHeight: 1,
+				truncateContent: false,
+				initialState: {},
+				onRowClick: _.noop,
+				onSelect: _.noop,
+				onSelectAll: _.noop,
+				onSort: _.noop,
+				onResize: _.noop,
+				Column: [
+					<Column field='id' title='ID' />,
+					<Column field='email' title='Email' />,
+					<Column field='occupation' title='Occupation' />,
+				],
+				ColumnGroup: [
+					<ColumnGroup title='Name'>
+						<Column field='first_name' title='First' />
+						<Column field='last_name' title='Last' />
+					</ColumnGroup>,
+				],
+			};
+
+			const excludedProps = [
+				'emptyCellText',
+				'isActionable',
+				'isFullWidth',
+				'isSelectable',
+				'minRows',
+				'fixedRowHeight',
+				'truncateContent',
+				'initialState',
+				'Column',
+				'ColumnGroup',
+				'onRowClick',
+				'onSelect',
+				'onSelectAll',
+				'onSort',
+				'onResize',
+			];
+
+			const includedProps = [
+				'style',
+				'className',
+				'children',
+				'density',
+				'hasBorder',
+				'hasWordWrap',
+				'hasLightHeader',
+				'hasHover',
+			];
+
+			it('omits all unused DataTable props types and the "initialState" props from the root Table component', () => {
+				const wrapper = shallow(<DataTable {...props}></DataTable>);
+
+				const headerFixedColumnProps = _.keys(
+					wrapper
+						.find('Table.lucid-DataTable-fixed-header-fixed-columns-Table')
+						.props()
+				);
+
+				const headerUnfixedColumnProps = _.keys(
+					wrapper
+						.find('Table.lucid-DataTable-fixed-header-unfixed-columns-Table')
+						.props()
+				);
+
+				const bodyFixedColumnProps = _.keys(
+					wrapper
+						.find('Table.lucid-DataTable-fixed-body-fixed-columns-Table')
+						.props()
+				);
+
+				const bodyUnfixedColumnProps = _.keys(
+					wrapper
+						.find('Table.lucid-DataTable-fixed-body-unfixed-columns-Table')
+						.props()
+				);
+
+				// The root Table header and body elements should not contain any of
+				// the excluded (the unused) DataTable propTypes and 'initialState':
+				// 'emptyCellText', 'isActionable', 'isFullWidth', 'isSelectable', 'minRows',
+				// 'fixedRowHeight', 'truncateContent', 'initialState', 'Column', 'ColumnHeader'
+				// 'onRowClick', 'onSelect', 'onSelectAll', 'onSort', 'onResize';
+
+				_.forEach(excludedProps, (prop) => {
+					expect(_.includes(headerFixedColumnProps, prop)).toBe(false);
+				});
+
+				_.forEach(excludedProps, (prop) => {
+					expect(_.includes(headerUnfixedColumnProps, prop)).toBe(false);
+				});
+
+				_.forEach(excludedProps, (prop) => {
+					expect(_.includes(bodyFixedColumnProps, prop)).toBe(false);
+				});
+
+				_.forEach(excludedProps, (prop) => {
+					expect(_.includes(bodyUnfixedColumnProps, prop)).toBe(false);
+				});
+
+				// The root Table header and body elements should include
+				// 'style', 'className', 'children', 'density', 'hasBorder', 'hasWordWrap', 'hasLightHeader', 'hasHover'
+
+				_.forEach(includedProps, (prop) => {
+					expect(_.includes(headerFixedColumnProps, prop)).toBe(true);
+				});
+
+				_.forEach(includedProps, (prop) => {
+					expect(_.includes(headerUnfixedColumnProps, prop)).toBe(true);
+				});
+
+				_.forEach(includedProps, (prop) => {
+					expect(_.includes(bodyFixedColumnProps, prop)).toBe(true);
+				});
+
+				_.forEach(includedProps, (prop) => {
+					expect(_.includes(bodyUnfixedColumnProps, prop)).toBe(true);
+				});
+			});
+
+			it('omits all unused DataTable props types and the "initialState" props from the root ScrollTable', () => {
+				const includedScrollTableProps = _.omit(includedProps, [
+					'hasLightHeader',
+					'density',
+				]);
+
+				const wrapper = shallow(
+					<DataTable {...props} hasFixedHeader={false}></DataTable>
+				);
+
+				const scrollTableProps = _.keys(wrapper.find(ScrollTable).props());
+
+				// The root ScrollTable header and body elements should not contain any of
+				// the excluded (the unused) DataTable propTypes and 'initialState':
+				// 'emptyCellText', 'isActionable', 'isFullWidth', 'isSelectable', 'minRows',
+				// 'fixedRowHeight', 'truncateContent', 'initialState', 'Column', 'ColumnHeader'
+				// 'onRowClick', 'onSelect', 'onSelectAll', 'onSort', 'onResize';
+
+				_.forEach(excludedProps, (prop) => {
+					expect(_.includes(scrollTableProps, prop)).toBe(false);
+				});
+
+				// The root ScrollTable header and body elements should include
+				// 'style', 'className', 'children', 'hasBorder', 'hasWordWrap', 'hasHover'
+
+				_.forEach(includedScrollTableProps, (prop) => {
+					expect(_.includes(includedScrollTableProps, prop)).toBe(true);
+				});
 			});
 		});
 	});
@@ -983,6 +1170,56 @@ describe('DataTable', () => {
 					.shallow();
 
 				assert(thWrapper.hasClass('lucid-Table-align-right'), 'must be true');
+			});
+
+			describe('props.columnProps in a grouped column', () => {
+				const omittedColumnProps = ['field', 'title', 'initialState'];
+
+				const includedColumnProps = [
+					'onClick',
+					'style',
+					'align',
+					'isResizable',
+					'isSorted',
+					'sortDirection',
+					'rowSpan',
+					'children',
+				];
+
+				it('omits all unused Column props from the root Table Header element', () => {
+					const wrapper = shallow(
+						<DataTable data={[]}>
+							<ColumnGroup title='Name'>
+								<Column
+									field='first_name'
+									title='First'
+									data-testid='columnGroup-column'
+								/>
+								<Column field='last_name' title='Last' />
+							</ColumnGroup>
+						</DataTable>
+					);
+
+					const columnGroupColumnProps = _.keys(
+						wrapper.find('[data-testid="columnGroup-column"]').first().props()
+					);
+
+					//console.log('tableThProps', columnGroupColumnProps);
+					// A ColumnGroup Column Table Table Row
+					// should not contain any of the excluded (the unused) Column propTypes and the 'initialState' prop:
+					// 'field', 'title', 'initialState',
+
+					_.forEach(omittedColumnProps, (prop) => {
+						expect(_.includes(columnGroupColumnProps, prop)).toBe(false);
+					});
+
+					// The ColumnGroup Column Table Table Row should include:
+					// 'onClick', 'style', 'align', 'isResizable', 'isSorted', 'sortDirection', 'rowSpan', 'children',
+
+					_.forEach(includedColumnProps, (prop) => {
+						expect(_.includes(columnGroupColumnProps, prop)).toBe(true);
+					});
+				});
 			});
 		});
 

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -1,11 +1,11 @@
 import { every, map, reverse, sortBy } from 'lodash';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { Meta } from '@storybook/react';
+import { Meta, Story } from '@storybook/react';
 
 import { createClass } from '../../util/component-types';
 import SuccessIcon from '../Icon/SuccessIcon/SuccessIcon';
-import DataTable from './DataTable';
+import DataTable, { IDataTableProps } from './DataTable';
 import TextField from '../TextField/TextField';
 import CheckboxLabeled from '../CheckboxLabeled/CheckboxLabeled';
 
@@ -19,13 +19,14 @@ export default {
 			},
 		},
 	},
+	args: DataTable.defaultProps,
 } as Meta;
 
 function addKeys(children) {
 	return map(children, (child, index) => ({ ...child, key: index }));
 }
 
-const Template: any = (args) => <DataTable {...args} />;
+const Template: Story<IDataTableProps> = (args) => <DataTable {...args} />;
 
 const defaultColumns = addKeys([
 	<DataTable.Column field='id' align='left' key={1}>
@@ -149,13 +150,13 @@ const defaultData = [
 	},
 ];
 
-export const Basic = Template.bind({});
+export const Basic: Story<IDataTableProps> = Template.bind({});
 Basic.args = {
 	children: defaultColumns,
 	data: defaultData,
 };
 
-export const ColumnGroups = Template.bind({});
+export const ColumnGroups: Story<IDataTableProps> = Template.bind({});
 ColumnGroups.args = {
 	density: 'extended',
 	children: addKeys([
@@ -203,7 +204,9 @@ ColumnGroups.args = {
 	data: defaultData,
 };
 
-export const SelectableAndNavigableRows = Template.bind({});
+export const SelectableAndNavigableRows: Story<IDataTableProps> = Template.bind(
+	{}
+);
 SelectableAndNavigableRows.args = {
 	density: 'extended',
 	isSelectable: true,
@@ -252,7 +255,7 @@ SelectableAndNavigableRows.args = {
 	data: defaultData,
 };
 
-export const DisabledRows = Template.bind({});
+export const DisabledRows: Story<IDataTableProps> = Template.bind({});
 DisabledRows.args = {
 	children: defaultColumns,
 	data: map(defaultData, (row, index) => ({
@@ -261,7 +264,7 @@ DisabledRows.args = {
 	})),
 };
 
-export const Empty = Template.bind({});
+export const Empty: Story<IDataTableProps> = Template.bind({});
 Empty.args = {
 	isFullWidth: true,
 	density: 'extended',
@@ -288,7 +291,7 @@ Empty.args = {
 };
 
 /* Interactive Table */
-export const InteractiveTable = () => {
+export const InteractiveTable: Story<IDataTableProps> = (args) => {
 	const Component = createReactClass({
 		getInitialState() {
 			return {
@@ -470,6 +473,7 @@ export const InteractiveTable = () => {
 						}
 					</style>
 					<DataTable
+						{...args}
 						data={map(data, (row, index) =>
 							index === activeIndex ? { ...row, isActive: true } : row
 						)}
@@ -570,10 +574,9 @@ export const InteractiveTable = () => {
 
 	return <Component />;
 };
-InteractiveTable.storyName = 'InteractiveTable';
 
 /* Empty With Custom Title And Body */
-export const EmptyWithCustomTitleAndBody = () => {
+export const EmptyWithCustomTitleAndBody: Story<IDataTableProps> = (args) => {
 	const {
 		EmptyStateWrapper,
 		EmptyStateWrapper: { Title, Body },
@@ -590,7 +593,13 @@ export const EmptyWithCustomTitleAndBody = () => {
 			const { data } = this.state;
 
 			return (
-				<DataTable data={data} density='extended' isFullWidth minRows={15}>
+				<DataTable
+					{...args}
+					data={data}
+					density='extended'
+					isFullWidth
+					minRows={15}
+				>
 					<EmptyStateWrapper>
 						<Title>Something went wrong.</Title>
 						<Body style={{ fontSize: '12px' }}>
@@ -628,10 +637,9 @@ export const EmptyWithCustomTitleAndBody = () => {
 
 	return <Component />;
 };
-EmptyWithCustomTitleAndBody.storyName = 'EmptyWithCustomTitleAndBody';
 
 /* Empty With Image */
-export const EmptyWithImage = () => {
+export const EmptyWithImage: Story<IDataTableProps> = (args) => {
 	const {
 		EmptyStateWrapper,
 		EmptyStateWrapper: { Title, Body },
@@ -648,7 +656,7 @@ export const EmptyWithImage = () => {
 			const { data } = this.state;
 
 			return (
-				<DataTable data={data} density='extended' isFullWidth>
+				<DataTable {...args} data={data} density='extended' isFullWidth>
 					<EmptyStateWrapper>
 						<Title>No items found.</Title>
 						<Body>
@@ -697,10 +705,9 @@ export const EmptyWithImage = () => {
 
 	return <Component />;
 };
-EmptyWithImage.storyName = 'EmptyWithImage';
 
 /* Empty With Anchored Message */
-export const EmptyWithAnchoredMessage = () => {
+export const EmptyWithAnchoredMessage: Story<IDataTableProps> = (args) => {
 	const Component = createClass({
 		getInitialState() {
 			return {
@@ -714,6 +721,7 @@ export const EmptyWithAnchoredMessage = () => {
 
 			return (
 				<DataTable
+					{...args}
 					data={map(data, (row, index) =>
 						index === activeIndex ? { ...row, isActive: true } : row
 					)}
@@ -746,14 +754,20 @@ export const EmptyWithAnchoredMessage = () => {
 
 	return <Component />;
 };
-EmptyWithAnchoredMessage.storyName = 'EmptyWithAnchoredMessage';
 
 /* Loading */
-export const Loading = () => {
+export const Loading: Story<IDataTableProps> = (args) => {
 	const Component = createClass({
 		render() {
 			return (
-				<DataTable minRows={50} anchorMessage isFullWidth isLoading data={[]}>
+				<DataTable
+					{...args}
+					minRows={50}
+					anchorMessage
+					isFullWidth
+					isLoading
+					data={[]}
+				>
 					<DataTable.Column field='id'>ID</DataTable.Column>
 
 					<DataTable.Column field='first_name' width={100}>
@@ -780,11 +794,18 @@ export const Loading = () => {
 };
 
 /* Loading With Anchored Message */
-export const LoadingWithAnchoredMessage = () => {
+export const LoadingWithAnchoredMessage: Story<IDataTableProps> = (args) => {
 	const Component = createClass({
 		render() {
 			return (
-				<DataTable minRows={15} anchorMessage isFullWidth isLoading data={[]}>
+				<DataTable
+					{...args}
+					minRows={15}
+					anchorMessage
+					isFullWidth
+					isLoading
+					data={[]}
+				>
 					<DataTable.Column field='id'>ID</DataTable.Column>
 
 					<DataTable.Column field='first_name' width={100}>
@@ -809,10 +830,9 @@ export const LoadingWithAnchoredMessage = () => {
 
 	return <Component />;
 };
-LoadingWithAnchoredMessage.storyName = 'LoadingWithAnchoredMessage';
 
 /* Min Rows */
-export const MinRows = () => {
+export const MinRows: Story<IDataTableProps> = (args) => {
 	const data = [
 		{
 			id: 1,
@@ -865,6 +885,7 @@ export const MinRows = () => {
 
 			return (
 				<DataTable
+					{...args}
 					data={map(data, (row, index) =>
 						index === activeIndex ? { ...row, isActive: true } : row
 					)}
@@ -906,10 +927,9 @@ export const MinRows = () => {
 
 	return <Component />;
 };
-MinRows.storyName = 'MinRows';
 
 /* Fixed Headers */
-export const FixedHeaders = () => {
+export const FixedHeaders: Story<IDataTableProps> = () => {
 	const data = [
 		{
 			id: 1,
@@ -1109,10 +1129,9 @@ export const FixedHeaders = () => {
 
 	return <Component />;
 };
-FixedHeaders.storyName = 'FixedHeaders';
 
 /* Resizable Fixed Headers Table */
-export const ResizableFixedHeadersTable = () => {
+export const ResizableFixedHeadersTable: Story<IDataTableProps> = () => {
 	const data = [
 		{
 			id: 1,
@@ -1341,10 +1360,9 @@ export const ResizableFixedHeadersTable = () => {
 
 	return <Component />;
 };
-ResizableFixedHeadersTable.storyName = 'ResizableFixedHeadersTable';
 
 /* Truncate Content */
-export const TruncateContent = () => {
+export const TruncateContent: Story<IDataTableProps> = () => {
 	const data = [
 		{
 			id: 1,
@@ -1475,4 +1493,3 @@ export const TruncateContent = () => {
 
 	return <Component />;
 };
-TruncateContent.storyName = 'TruncateContent';

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -179,8 +179,41 @@ export interface IDataTableProps
 	 */
 	ColumnGroup?: any;
 
+	/*
+	 * If \`isResizable\` is true,
+	 * it is called when the user resizes the a header cell in the table.
+	 */
 	onResize?: any;
 }
+
+/** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
+const nonPassThroughs = [
+	'className',
+	'data',
+	'emptyCellText',
+	'isActionable',
+	'isFullWidth',
+	'isLoading',
+	'isSelectable',
+	'anchorMessage',
+	'style',
+	'minRows',
+	'hasFixedHeader',
+	'fixedColumnCount',
+	'fixedRowHeight',
+	'truncateContent',
+	'initialState',
+	'onRowClick',
+	'onSelect',
+	'onSelectAll',
+	'onSort',
+	'Column',
+	'ColumnGroup',
+	'onResize',
+];
+
+/** TODO: Remove the nonColumnProps when the component is converted to a functional component */
+const omittedColumnProps = ['field', 'title', 'initialState'];
 
 const defaultProps = {
 	emptyCellText: '--',
@@ -336,12 +369,7 @@ export const DataTable = (props: IDataTableProps) => {
 										? []
 										: [
 												<Th
-													{...omitProps(
-														columnProps,
-														undefined,
-														_.keys(DataTable.Column.propTypes),
-														false
-													)}
+													{..._.omit(columnProps, omittedColumnProps)}
 													onClick={
 														DataTable.shouldColumnHandleSort(columnProps)
 															? (_.partial(
@@ -575,12 +603,7 @@ export const DataTable = (props: IDataTableProps) => {
 						<div className={cx('&-fixed-header-fixed-columns')}>
 							{fixedColumnCount > 0 ? (
 								<Table
-									{...omitProps(
-										passThroughs,
-										undefined,
-										_.keys(DataTable.propTypes),
-										false
-									)}
+									{..._.omit(passThroughs, nonPassThroughs)}
 									style={style}
 									className={cx('&-fixed-header-fixed-columns-Table')}
 								>
@@ -598,12 +621,7 @@ export const DataTable = (props: IDataTableProps) => {
 							ref={(ref) => (fixedHeaderUnfixedColumnsRef = ref)}
 						>
 							<Table
-								{...omitProps(
-									passThroughs,
-									undefined,
-									_.keys(DataTable.propTypes),
-									false
-								)}
+								{..._.omit(passThroughs, nonPassThroughs)}
 								style={style}
 								className={cx('&-fixed-header-unfixed-columns-Table')}
 							>
@@ -623,12 +641,7 @@ export const DataTable = (props: IDataTableProps) => {
 						>
 							{fixedColumnCount > 0 ? (
 								<Table
-									{...omitProps(
-										passThroughs,
-										undefined,
-										_.keys(DataTable.propTypes),
-										false
-									)}
+									{..._.omit(passThroughs, nonPassThroughs)}
 									style={style}
 									className={cx('&-fixed-body-fixed-columns-Table')}
 									hasWordWrap={
@@ -645,12 +658,7 @@ export const DataTable = (props: IDataTableProps) => {
 						>
 							<span className={cx('&-fixed-body-unfixed-columns-shadow')} />
 							<Table
-								{...omitProps(
-									passThroughs,
-									undefined,
-									_.keys(DataTable.propTypes),
-									false
-								)}
+								{..._.omit(passThroughs, nonPassThroughs)}
 								style={style}
 								className={cx('&-fixed-body-unfixed-columns-Table')}
 								hasWordWrap={
@@ -666,12 +674,7 @@ export const DataTable = (props: IDataTableProps) => {
 				<ScrollTable
 					style={style}
 					tableWidth={isFullWidth ? '100%' : undefined}
-					{...omitProps(
-						passThroughs,
-						undefined,
-						_.keys(DataTable.propTypes),
-						false
-					)}
+					{..._.omit(passThroughs, nonPassThroughs)}
 					className={cx(
 						'&',
 						{
@@ -835,6 +838,12 @@ DataTable.propTypes = {
 
 		- the optional prop \`title\`
 	*/,
+
+	/**
+		 If \`isResizable\` is true,
+		it is called when the user resizes the a header cell in the table.
+	 */
+	onResize: func,
 };
 
 DataTable.defaultProps = defaultProps;


### PR DESCRIPTION
## PR Checklist

Description of changes:

- Replace omitProps with _.omit for DataTable (in five places)
- add unit tests to ensure the correct props are being omitted and being passed through
- update Stories to Storybook 6 format

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2560-DataTable-Replace-OmitProps/?path=/docs/table-datatable--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
