### PR TITLE
Replace omitProps in Dialog and update unit test and Storybook

### DIFF
--- a/src/components/Dialog/Dialog.spec.tsx
+++ b/src/components/Dialog/Dialog.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { common, functionalComponents } from '../../util/generic-tests';
 import assert from 'assert';
+import _, { keys, forEach, includes, noop } from 'lodash';
 
 import Dialog from './Dialog';
 import Overlay from '../Overlay/Overlay';
@@ -17,12 +18,6 @@ describe('Dialog', () => {
 
 	functionalComponents(Dialog);
 
-	it('should pass `isModal` to underlying Overlay', () => {
-		const wrapper = shallow(<Dialog isModal={false} />);
-
-		assert.equal(wrapper.find(Overlay).prop('isModal'), false);
-	});
-
 	it('should render a Header', () => {
 		const wrapper = shallow(
 			<Dialog isShown={true}>
@@ -30,10 +25,9 @@ describe('Dialog', () => {
 			</Dialog>
 		);
 
-		assert.equal(
-			wrapper.find('.lucid-Dialog-header').text().startsWith('Mobius'),
-			true
-		);
+		expect(
+			wrapper.find('.lucid-Dialog-header').text().startsWith('Mobius')
+		).toBe(true);
 	});
 
 	it('should render a Footer', () => {
@@ -43,13 +37,13 @@ describe('Dialog', () => {
 			</Dialog>
 		);
 
-		assert.equal(wrapper.find('.lucid-Dialog-footer').text(), 'Groober');
+		expect(wrapper.find('.lucid-Dialog-footer').text()).toBe('Groober');
 	});
 
 	it('should not render a Footer', () => {
 		const wrapper = shallow(<Dialog isShown={true} />);
 
-		assert(!wrapper.contains('.lucid-Dialog-footer'));
+		expect(wrapper.contains('.lucid-Dialog-footer')).toBe(false);
 	});
 
 	it('should render body content', () => {
@@ -58,45 +52,126 @@ describe('Dialog', () => {
 		assert.equal(wrapper.find('.lucid-Dialog-body').text(), 'Flux Capacitor');
 	});
 
-	it('should respect size = "small"', () => {
-		const wrapper = shallow(<Dialog isShown={true} size='small' />);
+	describe('props', () => {
+		it('should respect size = "small"', () => {
+			const wrapper = shallow(<Dialog isShown={true} size='small' />);
 
-		assert.equal(wrapper.find('.lucid-Dialog-window-is-small').length, 1);
-	});
+			assert.equal(wrapper.find('.lucid-Dialog-window-is-small').length, 1);
+		});
 
-	it('should respect size = "medium"', () => {
-		const wrapper = shallow(<Dialog isShown={true} size='medium' />);
+		it('should respect size = "medium"', () => {
+			const wrapper = shallow(<Dialog isShown={true} size='medium' />);
 
-		assert.equal(wrapper.find('.lucid-Dialog-window-is-medium').length, 1);
-	});
+			assert.equal(wrapper.find('.lucid-Dialog-window-is-medium').length, 1);
+		});
 
-	it('should respect size = "large"', () => {
-		const wrapper = shallow(<Dialog isShown={true} size='large' />);
+		it('should respect size = "large"', () => {
+			const wrapper = shallow(<Dialog isShown={true} size='large' />);
 
-		assert.equal(wrapper.find('.lucid-Dialog-window-is-large').length, 1);
-	});
-});
+			assert.equal(wrapper.find('.lucid-Dialog-window-is-large').length, 1);
+		});
 
-describe('Dialog', () => {
-	it('should render when isShown', () => {
-		const wrapper = mount(
-			<Dialog isShown={true}>
-				<div id='holler'>bro</div>
-			</Dialog>
-		);
+		it('should pass `isModal` to underlying Overlay', () => {
+			const wrapper = shallow(<Dialog isModal={false} />);
 
-		assert.equal(document.querySelectorAll('#holler').length, 1);
-		wrapper.unmount();
-	});
+			assert.equal(wrapper.find(Overlay).prop('isModal'), false);
+		});
 
-	it('should not render when not isShown', () => {
-		const wrapper = mount(
-			<Dialog isShown={false}>
-				<div id='flux'>Flux Capacitor</div>
-			</Dialog>
-		);
+		it('should render when `isShown` is true', () => {
+			const wrapper = mount(
+				<Dialog isShown={true}>
+					<div id='holler'>bro</div>
+				</Dialog>
+			);
 
-		assert.equal(document.querySelectorAll('#flux').length, 0);
-		wrapper.unmount();
+			assert.equal(document.querySelectorAll('#holler').length, 1);
+			wrapper.unmount();
+		});
+
+		it('should not render when `isShown` is false', () => {
+			const wrapper = mount(
+				<Dialog isShown={false}>
+					<div id='flux'>Flux Capacitor</div>
+				</Dialog>
+			);
+
+			assert.equal(document.querySelectorAll('#flux').length, 0);
+			wrapper.unmount();
+		});
+
+		describe('pass throughs', () => {
+			let wrapper: any;
+			const defaultProps = Dialog.defaultProps;
+
+			describe('passthroughs', () => {
+				beforeEach(() => {
+					const props = {
+						...defaultProps,
+						handleClose: noop,
+						Header: <i>Rich Header</i>,
+						Footer: <span>Rich Footer</span>,
+						initialState: { testData: true },
+						callbackId: 1,
+						'data-testid': 10,
+					};
+
+					wrapper = shallow(<Dialog {...props} />);
+				});
+
+				afterEach(() => {
+					wrapper.unmount();
+				});
+
+				it('passes through some select props to the root section element', () => {
+					const rootProps = keys(wrapper.first().props());
+
+					// The root Overlay element should contain 'className', 'children', and 'callbackId'
+					forEach(
+						['className', 'children', 'callbackId', 'data-testid'],
+						(prop) => {
+							expect(includes(rootProps, prop)).toBe(true);
+						}
+					);
+
+					// it should also pick any Overlay props, including the defaults
+					// and pass them through to the root element
+					forEach(
+						[
+							'isAnimated',
+							'isShown',
+							'isModal',
+							'onEscape',
+							'onBackgroundClick',
+						],
+						(prop) => {
+							expect(includes(rootProps, prop)).toBe(true);
+						}
+					);
+				});
+
+				it('omits some props from the root section element', () => {
+					const rootProps = keys(wrapper.first().props());
+
+					// It should not pass 'initialState' or
+					// any of the DateSelect prop types to the root element
+					// Note that className and isShown are omitted as a pass through,
+					// but are also directly applied to the Overlay root element, so still should appear
+					forEach(
+						[
+							'initialState',
+							'size',
+							'handleClose',
+							'isComplex',
+							'hasGutters',
+							'Header',
+							'Footer',
+						],
+						(prop) => {
+							expect(includes(rootProps, prop)).toBe(false);
+						}
+					);
+				});
+			});
+		});
 	});
 });

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -1,7 +1,9 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { useState } from 'react';
 import createClass from 'create-react-class';
-import Dialog from './Dialog';
+import { Meta, Story } from '@storybook/react';
+
+import { Dialog, IDialogProps } from './Dialog';
 import Button from '../Button/Button';
 import SearchableMultiSelect from '../SearchableMultiSelect/SearchableMultiSelect';
 import SingleSelect from '../SingleSelect/SingleSelect';
@@ -14,13 +16,65 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (Dialog as any).peek.description,
+				component: Dialog.peek.description,
 			},
 		},
+		layout: 'centered',
 	},
-};
+	args: Dialog.defaultProps,
+	decorators: [
+		(Story) => (
+			<div style={{ margin: '3em' }}>
+				<Story />
+			</div>
+		),
+	],
+} as Meta;
 
-/* Small */
+export const Basic: Story<IDialogProps> = (args) => {
+	const [isShown, setIsShown] = useState(false);
+
+	const handleShow = (isShown: boolean) => {
+		setIsShown(isShown);
+	};
+
+	return (
+		<div>
+			<Button size='large' onClick={_.partial(handleShow, !isShown)}>
+				Toggle
+			</Button>
+
+			<Dialog
+				{...args}
+				isShown={isShown}
+				handleClose={_.partial(handleShow, !isShown)}
+				Header='Header'
+			>
+				<div key={'info'}>
+					For better UX, we recommend NOT handling onEscape and
+					onBackgroundClick when isModal is true. The term "modal" implies that
+					the user needs to interact with one of the buttons in the footer to
+					exit the dialog.
+				</div>
+				{_.times(10).map((i) => {
+					return <div key={i}>Body</div>;
+				})}
+				<Dialog.Footer>
+					<Button
+						kind='invisible'
+						onClick={_.partial(handleShow, false)}
+						style={{ marginRight: '9px' }}
+					>
+						Cancel
+					</Button>
+					<Button kind='primary'>Save</Button>
+				</Dialog.Footer>
+			</Dialog>
+		</div>
+	);
+};
+Basic.decorators = [(Story) => <div style={{ margin: '3em' }}>{Story()}</div>];
+
 export const Small = () => {
 	const Component = createClass({
 		getInitialState() {
@@ -36,7 +90,10 @@ export const Small = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -44,7 +101,6 @@ export const Small = () => {
 						isShown={this.state.isShown}
 						handleClose={_.partial(this.handleShow, !this.state.isShown)}
 						Header='Header'
-						size='small'
 					>
 						<div key={'info'}>
 							For better UX, we recommend NOT handling onEscape and
@@ -90,7 +146,10 @@ export const Medium = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -144,7 +203,10 @@ export const LargeWithRichHeader = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -183,7 +245,6 @@ export const LargeWithRichHeader = () => {
 
 	return <Component />;
 };
-LargeWithRichHeader.storyName = 'LargeWithRichHeader';
 
 /* Complex */
 export const Complex = () => {
@@ -226,7 +287,10 @@ export const Complex = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -314,7 +378,10 @@ export const NoModal = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -348,7 +415,6 @@ export const NoModal = () => {
 
 	return <Component />;
 };
-NoModal.storyName = 'NoModal';
 
 /* No Footer */
 export const NoFooter = () => {
@@ -366,7 +432,10 @@ export const NoFooter = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -387,7 +456,6 @@ export const NoFooter = () => {
 
 	return <Component />;
 };
-NoFooter.storyName = 'NoFooter';
 
 /* No Gutters */
 export const NoGutters = () => {
@@ -405,7 +473,10 @@ export const NoGutters = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -427,7 +498,6 @@ export const NoGutters = () => {
 
 	return <Component />;
 };
-NoGutters.storyName = 'NoGutters';
 
 /* No Close Button */
 export const NoCloseButton = () => {
@@ -445,7 +515,10 @@ export const NoCloseButton = () => {
 		render() {
 			return (
 				<div>
-					<Button onClick={_.partial(this.handleShow, !this.state.isShown)}>
+					<Button
+						size='large'
+						onClick={_.partial(this.handleShow, !this.state.isShown)}
+					>
 						Toggle
 					</Button>
 
@@ -477,4 +550,3 @@ export const NoCloseButton = () => {
 
 	return <Component />;
 };
-NoCloseButton.storyName = 'NoCloseButton';

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,9 +1,10 @@
-import _ from 'lodash';
+import _, { omit, pick } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import Overlay, { IOverlayProps } from '../Overlay/Overlay';
+
+import Overlay, { IOverlayProps, overlayPropTypes } from '../Overlay/Overlay';
 import { lucidClassNames } from '../../util/style-helpers';
-import { StandardProps, getFirst, omitProps } from '../../util/component-types';
+import { StandardProps, getFirst } from '../../util/component-types';
 import Button, { IButtonProps } from '../Button/Button';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
 
@@ -18,29 +19,38 @@ export enum EnumSize {
 }
 type Size = keyof typeof EnumSize;
 
+/** Dialog Header */
 export interface IDialogHeaderProps extends StandardProps {
 	description?: string;
 }
 const DialogHeader = (_props: IDialogHeaderProps): null => null;
 DialogHeader.displayName = 'Dialog.Header';
 DialogHeader.peek = {
-	description: `
-		Renders a \`<div>\`.
-	`,
+	description: `Renders a \`<div>\`.`,
 };
 DialogHeader.propName = 'Header';
 
+/** Dialog Footer */
 export interface IDialogFooterProps extends StandardProps {
 	description?: string;
 }
 const DialogFooter = (_props: IDialogFooterProps): null => null;
 DialogFooter.displayName = 'Dialog.Footer';
 DialogFooter.peek = {
-	description: `
-		Renders a \`<footer>\`.
-	`,
+	description: `Renders a \`<footer>\`.`,
 };
 DialogFooter.propName = 'Footer';
+
+/** Dialog */
+const nonPassThroughs = [
+	'size',
+	'isComplex',
+	'hasGutters',
+	'handleClose',
+	'Header',
+	'Footer',
+	'initialState',
+];
 
 const defaultProps = {
 	...Overlay.defaultProps,
@@ -95,8 +105,8 @@ export const Dialog = (props: IDialogProps): React.ReactElement => {
 
 	return (
 		<Overlay
-			{...omitProps(passThroughs, undefined, _.keys(Dialog.propTypes), false)}
-			{..._.pick<any>(passThroughs, _.keys(Overlay.propTypes))}
+			{...omit(passThroughs, nonPassThroughs)}
+			{...pick<any>(passThroughs, overlayPropTypes)}
 			isShown={isShown}
 			className={cx('&', className)}
 		>

--- a/src/components/Dialog/__snapshots__/Dialog.spec.tsx.snap
+++ b/src/components/Dialog/__snapshots__/Dialog.spec.tsx.snap
@@ -1,9 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Dialog [common] example testing should match snapshot(s) for Basic 1`] = `
+<div>
+  <button
+    class="lucid-Button lucid-Button-large"
+    type="button"
+  >
+    <span
+      class="lucid-Button-content"
+    >
+      Toggle
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Dialog [common] example testing should match snapshot(s) for Complex 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span
@@ -18,7 +33,7 @@ exports[`Dialog [common] example testing should match snapshot(s) for Complex 1`
 exports[`Dialog [common] example testing should match snapshot(s) for LargeWithRichHeader 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span
@@ -33,7 +48,7 @@ exports[`Dialog [common] example testing should match snapshot(s) for LargeWithR
 exports[`Dialog [common] example testing should match snapshot(s) for Medium 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span
@@ -48,7 +63,7 @@ exports[`Dialog [common] example testing should match snapshot(s) for Medium 1`]
 exports[`Dialog [common] example testing should match snapshot(s) for NoCloseButton 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span
@@ -63,7 +78,7 @@ exports[`Dialog [common] example testing should match snapshot(s) for NoCloseBut
 exports[`Dialog [common] example testing should match snapshot(s) for NoFooter 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span
@@ -78,7 +93,7 @@ exports[`Dialog [common] example testing should match snapshot(s) for NoFooter 1
 exports[`Dialog [common] example testing should match snapshot(s) for NoGutters 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span
@@ -93,7 +108,7 @@ exports[`Dialog [common] example testing should match snapshot(s) for NoGutters 
 exports[`Dialog [common] example testing should match snapshot(s) for NoModal 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span
@@ -108,7 +123,7 @@ exports[`Dialog [common] example testing should match snapshot(s) for NoModal 1`
 exports[`Dialog [common] example testing should match snapshot(s) for Small 1`] = `
 <div>
   <button
-    class="lucid-Button"
+    class="lucid-Button lucid-Button-large"
     type="button"
   >
     <span

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Portal from '../Portal/Portal';
 import { CSSTransition } from 'react-transition-group';
 import { lucidClassNames, uniqueName } from '../../util/style-helpers';
-import { omitProps, StandardProps } from '../../util/component-types';
+import { StandardProps } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-Overlay');
 
@@ -46,29 +46,29 @@ export interface IOverlayProps extends StandardProps {
 	}) => void;
 }
 
-const nonPassThroughs = [
-	'className',
+export const overlayPropTypes = [
 	'children',
+	'className',
 	'isShown',
 	'isAnimated',
 	'isModal',
 	'portalId',
 	'onEscape',
 	'onBackgroundClick',
-	'initialState',
-	'callbackId',
 ];
+
+const nonPassThroughs = [...overlayPropTypes, 'initialState', 'callbackId'];
 
 interface IOverlayState {
 	portalId: string;
 }
 
 export const defaultProps = {
-	isShown: false,
-	isModal: true,
-	onEscape: _.noop,
-	onBackgroundClick: _.noop,
 	isAnimated: true,
+	isModal: true,
+	isShown: false,
+	onBackgroundClick: _.noop,
+	onEscape: _.noop,
 };
 
 class Overlay extends React.Component<IOverlayProps, IOverlayState, {}> {
@@ -97,6 +97,9 @@ class Overlay extends React.Component<IOverlayProps, IOverlayState, {}> {
 		*/
 		isShown: bool,
 
+		/**
+			Enables animated transitions during expansion and collapse.
+		 */
 		isAnimated: bool,
 
 		/**


### PR DESCRIPTION
## PR Checklist

Description of changes:
For `Dialog` component:
Replace omitProps with omit and explicit list of props
Update Storybook basic story to SB6
Add a unit test to check for omitted and included props

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2562-Replace-omitProps-Dialog/?path=/docs/layout-dialog--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
