### PR TITLE
DragCaptureZone: Replace omitProps with list of props, add unit test and update Storyb…

### DIFF
--- a/src/components/DragCaptureZone/DragCaptureZone.spec.tsx
+++ b/src/components/DragCaptureZone/DragCaptureZone.spec.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { forEach, has } from 'lodash';
 import assert from 'assert';
 import React from 'react';
 import sinon from 'sinon';
@@ -45,15 +45,55 @@ describe('DragCaptureZone', () => {
 		});
 
 		describe('pass throughs', () => {
-			it('passes through all props to the root element.', () => {
-				const wrapper = mount(
-					<DragCaptureZone {...{ foo: 1, bar: 2, baz: 3 }} />
-				);
+			let wrapper: any;
+			const defaultProps = DragCaptureZone.defaultProps;
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					onDrag: () => {},
+					onDragEnd: () => {},
+					onDragStart: () => {},
+					onDragCancel: () => {},
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<DragCaptureZone {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through select props to the root div element.', () => {
 				const rootProps = wrapper.find('div').props();
 
-				_.forEach(['foo', 'bar', 'baz'], (prop) => {
-					assert(_.has(rootProps, prop));
-				});
+				// 'className' is plucked from the pass through this.props object
+				// but still appears becuase it is also directly passed to the root element as a prop
+				forEach(
+					['className', 'onMouseDown', 'onTouchStart', 'data-testid'],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits the component props, "initialState" and "callbackId" from the root div element', () => {
+				const rootProps = wrapper.find('div').props();
+
+				forEach(
+					[
+						'onDrag',
+						'onDragEnd',
+						'onDragStart',
+						'onDragCancel',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
 			});
 		});
 	});

--- a/src/components/DragCaptureZone/DragCaptureZone.stories.tsx
+++ b/src/components/DragCaptureZone/DragCaptureZone.stories.tsx
@@ -1,7 +1,8 @@
-import _ from 'lodash';
-import React from 'react';
-import createClass from 'create-react-class';
-import DragCaptureZone from './DragCaptureZone';
+import _, { concat, slice, reverse, map } from 'lodash';
+import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+
+import DragCaptureZone, { IDragCaptureZoneProps } from './DragCaptureZone';
 
 export default {
 	title: 'Utility/DragCaptureZone',
@@ -13,114 +14,96 @@ export default {
 			},
 		},
 	},
-};
+	args: DragCaptureZone.defaultProps,
+	decorators: [
+		(Story) => (
+			<div style={{ margin: '2em' }}>
+				<Story />
+			</div>
+		),
+	],
+} as Meta;
 
 /* Interactive */
-export const Interactive = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				events: [],
-			};
-		},
+export const Interactive: Story<IDragCaptureZoneProps> = (args) => {
+	const [events, setEvents] = useState<Array<{ type; coordinates }>>([]);
 
-		render() {
-			const { events } = this.state;
+	const handleDragEnded = (coordinates: any) => {
+		const newEndEvents = concat(events, { type: 'end', coordinates });
+		setEvents([...newEndEvents]);
+	};
 
-			return (
-				<section
+	const handleDragStarted = (coordinates: any) => {
+		const newStartEvents = concat(events, { type: 'start', coordinates });
+		setEvents([...newStartEvents]);
+	};
+
+	const handleDragged = (coordinates: any) => {
+		const lastEvent: any = _.last(events);
+		const alreadyDragging = lastEvent.type === 'start';
+
+		const newDraggedEvents = concat(
+			alreadyDragging ? events : slice(events, 0, -1),
+			{ type: 'drag', coordinates }
+		);
+		setEvents([...newDraggedEvents]);
+	};
+
+	return (
+		<section
+			style={{
+				alignItems: 'center',
+				display: 'flex',
+			}}
+		>
+			<DragCaptureZone
+				onDrag={handleDragged}
+				onDragEnd={handleDragEnded}
+				onDragStart={handleDragStarted}
+			>
+				<div
 					style={{
 						alignItems: 'center',
+						backgroundColor: '#b7b7b7',
 						display: 'flex',
+						fontFamily: 'Helvetica, sans-serif',
+						fontSize: '24px',
+						fontWeight: 300,
+						height: 300,
+						justifyContent: 'center',
+						textTransform: 'uppercase',
+						width: 400,
 					}}
 				>
-					<DragCaptureZone
-						onDrag={this.handleDragged}
-						onDragEnd={this.handleDragEnded}
-						onDragStart={this.handleDragStarted}
-					>
-						<div
-							style={{
-								alignItems: 'center',
-								backgroundColor: '#b7b7b7',
-								display: 'flex',
-								fontFamily: 'Helvetica, sans-serif',
-								fontSize: '24px',
-								fontWeight: 300,
-								height: 300,
-								justifyContent: 'center',
-								textTransform: 'uppercase',
-								width: 400,
-							}}
-						>
-							Go wild!
-						</div>
-					</DragCaptureZone>
-					<div
-						style={{
-							height: 300,
-							marginLeft: 50,
-							overflow: 'auto',
-							width: 600,
-						}}
-					>
-						{_.reverse(
-							_.map(events, ({ coordinates, type }, index) => (
-								<div key={index}>
-									<div
-										style={{
-											fontWeight: 'bold',
-										}}
-									>
-										{type}
-									</div>
-									<div>
-										{`dx: ${coordinates.dX}, dy: ${coordinates.dY},
+					Go wild!
+				</div>
+			</DragCaptureZone>
+			<div
+				style={{
+					height: 300,
+					marginLeft: 50,
+					overflow: 'auto',
+					width: 600,
+				}}
+			>
+				{reverse(
+					map(events, ({ type, coordinates }, index) => (
+						<div key={index}>
+							<div
+								style={{
+									fontWeight: 'bold',
+								}}
+							>
+								{type}
+							</div>
+							<div>
+								{`dx: ${coordinates.dX}, dy: ${coordinates.dY},
 									px: ${coordinates.pageX}, py: ${coordinates.pageY}`}
-									</div>
-								</div>
-							))
-						)}
-					</div>
-				</section>
-			);
-		},
-
-		handleDragEnded(coordinates: any) {
-			this.setState({
-				events: _.concat(this.state.events, {
-					type: 'end',
-					coordinates,
-				}),
-			});
-		},
-
-		handleDragStarted(coordinates: any) {
-			this.setState({
-				events: _.concat(this.state.events, {
-					type: 'start',
-					coordinates,
-				}),
-			});
-		},
-
-		handleDragged(coordinates: any) {
-			const lastEvent: any = _.last(this.state.events);
-			const alreadyDragging = lastEvent.type === 'start';
-
-			this.setState({
-				events: _.concat(
-					alreadyDragging
-						? this.state.events
-						: _.slice(this.state.events, 0, -1),
-					{
-						type: 'drag',
-						coordinates,
-					}
-				),
-			});
-		},
-	});
-
-	return <Component />;
+							</div>
+						</div>
+					))
+				)}
+			</div>
+		</section>
+	);
 };

--- a/src/components/DragCaptureZone/DragCaptureZone.tsx
+++ b/src/components/DragCaptureZone/DragCaptureZone.tsx
@@ -1,12 +1,9 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	omitProps,
-	StandardProps,
-	Overwrite,
-} from '../../util/component-types';
+import { StandardProps, Overwrite } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-DragCaptureZone');
 const { func, string } = PropTypes;
@@ -90,6 +87,17 @@ export interface IDragCaptureZonePropsRaw extends StandardProps {
 		props: IDragCaptureZoneProps;
 	}) => void;
 }
+
+/** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
+const nonPassThroughs = [
+	'className',
+	'onDrag',
+	'onDragEnd',
+	'onDragStart',
+	'onDragCancel',
+	'initialState',
+	'callbackId',
+];
 
 export type IDragCaptureZoneProps = Overwrite<
 	React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
@@ -325,7 +333,7 @@ class DragCaptureZone extends React.Component<
 	render(): React.ReactNode {
 		return (
 			<div
-				{...omitProps(this.props, undefined, _.keys(DragCaptureZone.propTypes))}
+				{...(omit(this.props, nonPassThroughs) as any)}
 				className={cx('&', this.props.className)}
 				key='DragCaptureZone'
 				onMouseDown={this.handleMouseDragStart}


### PR DESCRIPTION
For DragCaptureZone:

- Replace omitProps with list of props, 
- Add unit test 
- Update Storybook 

## PR Checklist

Description of changes:

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2563-DragCaptureZone-Replace-omitProps/?path=/docs/utility-dragcapturezone--interactive

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
