### PR TITLE
Add unit test for DropMenu props

### DIFF
--- a/src/components/DropMenu/DropMenu.spec.tsx
+++ b/src/components/DropMenu/DropMenu.spec.tsx
@@ -58,7 +58,7 @@ describe('DropMenu', () => {
 					expect(has(rootProps, prop)).toBe(true);
 				});
 			});
-			it.only('omits the component props, "initialState" and "callbackId" from the root div element', () => {
+			it('omits the component props, "initialState" and "callbackId" from the root div element', () => {
 				const rootProps = wrapper.find('div.lucid-DropMenu').props();
 
 				forEach(

--- a/src/components/DropMenu/DropMenu.spec.tsx
+++ b/src/components/DropMenu/DropMenu.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import assert from 'assert';
-import _ from 'lodash';
+import _, { forEach, has } from 'lodash';
 import { common } from '../../util/generic-tests';
 
 import { DropMenuDumb as DropMenu } from './DropMenu';
@@ -28,6 +28,73 @@ describe('DropMenu', () => {
 	});
 
 	describe('props', () => {
+		describe('pass throughs', () => {
+			let wrapper: any;
+			const defaultProps = DropMenu.defaultProps;
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<DropMenu {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through select props to the root div element.', () => {
+				const rootProps = wrapper.find('div.lucid-DropMenu').props();
+				const dataTestId = wrapper.first().prop(['data-testid']);
+
+				expect(dataTestId).toBe(10);
+
+				// 'className' and 'style' are plucked from the pass through object
+				// but still appear becuase they are also directly passed to the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it.only('omits the component props, "initialState" and "callbackId" from the root div element', () => {
+				const rootProps = wrapper.find('div.lucid-DropMenu').props();
+
+				forEach(
+					[
+						'isDisabled',
+						'isExpanded',
+						'direction',
+						'alignment',
+						'selectedIndices',
+						'focusedIndex',
+						'portalId',
+						'flyOutStyle',
+						'optionContainerStyle',
+						'onExpand',
+						'onCollapse',
+						'onSelect',
+						'onFocusNext',
+						'onFocusPrev',
+						'onFocusOption',
+						'Control',
+						'Option',
+						'OptionGroup',
+						'NullOption',
+						'Header',
+						'ContextMenu',
+						'FixedOption',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
+			});
+		});
+
 		describe('children', () => {
 			it('should not render any direct child elements which are not DropMenu-specific', () => {
 				const wrapper = shallow(

--- a/src/components/DropMenu/DropMenu.stories.tsx
+++ b/src/components/DropMenu/DropMenu.stories.tsx
@@ -16,6 +16,7 @@ export default {
 				component: DropMenu.peek.description,
 			},
 		},
+		layout: 'centered',
 	},
 	argTypes: {
 		children: { control: false },

--- a/src/components/DropMenu/DropMenu.tsx
+++ b/src/components/DropMenu/DropMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+
 import { lucidClassNames, uniqueName } from '../../util/style-helpers';
 import {
 	StandardProps,


### PR DESCRIPTION
## PR Checklist

Description of changes:
Add unit test for DropMenu props

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2564-DropMenu-Replace-omitProps/?path=/docs/helpers-dropmenu--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
