### PR TITLE
Cxp 2565 Expander ExpanderPanel replace omit props

### DIFF
--- a/src/components/Expander/Expander.spec.tsx
+++ b/src/components/Expander/Expander.spec.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { forEach, has } from 'lodash';
 import assert from 'assert';
 import React from 'react';
 import sinon from 'sinon';
@@ -139,23 +139,61 @@ describe('Expander', () => {
 		});
 
 		describe('pass throughs', () => {
-			it('passes through all props not defined in `propTypes` to the root element.', () => {
-				const wrapper = shallow(
-					<Expander
-						className='wut'
-						isExpanded={true}
-						onToggle={_.noop}
-						style={{ marginRight: 10 }}
-						{...{
-							foo: 1,
-							bar: 2,
-						}}
-					/>
-				);
+			let wrapper: any;
+			const defaultProps = Expander.defaultProps;
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					className: 'wut',
+					isExpanded: true,
+					onToggle: _.noop,
+					Label: <div>Label</div>,
+					AdditionalLabelContent: <div>Additional Label Content</div>,
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<Expander {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
 				const rootProps = wrapper.find('.lucid-Expander').props();
 
-				assert(_.has(rootProps, 'foo'));
-				assert(_.has(rootProps, 'bar'));
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' and 'style' are plucked from the pass through object
+				// but still appear becuase they are also directly passed to the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits all the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) to the root element', () => {
+				const rootProps = wrapper.find('.lucid-Expander').props();
+
+				forEach(
+					[
+						'isExpanded',
+						'onToggle',
+						'Label',
+						'AdditionalLabelContent',
+						'kind',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
 			});
 		});
 	});

--- a/src/components/Expander/Expander.stories.tsx
+++ b/src/components/Expander/Expander.stories.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import createClass from 'create-react-class';
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
 
-import Expander from './Expander';
+import Expander, { IExpanderProps } from './Expander';
 import Button from '../Button/Button';
 import EditIcon from '../Icon/EditIcon/EditIcon';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
@@ -12,365 +12,306 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (Expander as any).peek.description,
+				component: Expander.peek.description,
 			},
 		},
 	},
+	args: Expander.defaultProps,
+} as Meta;
+
+/* Basic */
+export const Basic: Story<IExpanderProps> = (args) => {
+	return (
+		<Expander>
+			<Expander.Label>Show Stuff</Expander.Label>
+			<p>
+				Tacos craft beer humblebrag meditation. Cold-pressed next level man bun
+				readymade beard, wayfarers fanny pack keytar helvetica knausgaard
+				biodiesel lumbersexual. Knausgaard echo park whatever four loko
+				messenger bag hella. Cardigan church-key brooklyn letterpress artisan
+				venmo, gastropub hella. Single-origin coffee selfies four loko,
+				biodiesel health goth truffaut migas sustainable kale chips disrupt
+				locavore meggings mustache actually retro. Mlkshk poutine flexitarian
+				scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn
+				quinoa marfa. Literally before they sold out gochujang pork belly
+				franzen.
+			</p>
+			<p>
+				Sriracha put a bird on it chia, locavore wolf affogato tote bag neutra
+				umami food truck austin keytar cronut man bun. Kitsch man braid occupy
+				art party, tousled waistcoat tilde YOLO keytar street art selvage.
+				Salvia pour-over keytar intelligentsia. Marfa yr stumptown, before they
+				sold out lo-fi literally art party williamsburg blue bottle slow-carb
+				brooklyn. Gochujang post-ironic aesthetic kickstarter, dreamcatcher four
+				dollar toast whatever tattooed quinoa. Single-origin coffee blog lomo,
+				freegan next level ramps small batch put a bird on it listicle
+				stumptown. Stumptown mumblecore vinyl, mustache street art wayfarers
+				lumbersexual everyday carry irony pitchfork gochujang pug DIY gentrify.
+			</p>
+			<p>
+				Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth
+				migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
+				asymmetrical meggings kombucha banh mi meh skateboard artisan man braid.
+				Ugh semiotics intelligentsia sustainable, craft beer next level meggings
+				before they sold out heirloom iPhone try-hard. Listicle blog literally
+				marfa plaid brooklyn humblebrag retro, VHS thundercats man braid
+				waistcoat ennui. Church-key knausgaard austin organic farm-to-table
+				neutra franzen bespoke, mlkshk narwhal DIY raw denim retro. Mlkshk
+				locavore try-hard roof party flexitarian. Letterpress beard fixie, umami
+				waistcoat salvia ennui four loko seitan lomo franzen pickled shoreditch
+				master cleanse.
+			</p>
+			<p>
+				Tacos craft beer humblebrag meditation. Cold-pressed next level man bun
+				readymade beard, wayfarers fanny pack keytar helvetica knausgaard
+				biodiesel lumbersexual. Knausgaard echo park whatever four loko
+				messenger bag hella. Cardigan church-key brooklyn letterpress artisan
+				venmo, gastropub hella. Single-origin coffee selfies four loko,
+				biodiesel health goth truffaut migas sustainable kale chips disrupt
+				locavore meggings mustache actually retro. Mlkshk poutine flexitarian
+				scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn
+				quinoa marfa. Literally before they sold out gochujang pork belly
+				franzen.
+			</p>
+			<p>
+				Sriracha put a bird on it chia, locavore wolf affogato tote bag neutra
+				umami food truck austin keytar cronut man bun. Kitsch man braid occupy
+				art party, tousled waistcoat tilde YOLO keytar street art selvage.
+				Salvia pour-over keytar intelligentsia. Marfa yr stumptown, before they
+				sold out lo-fi literally art party williamsburg blue bottle slow-carb
+				brooklyn. Gochujang post-ironic aesthetic kickstarter, dreamcatcher four
+				dollar toast whatever tattooed quinoa. Single-origin coffee blog lomo,
+				freegan next level ramps small batch put a bird on it listicle
+				stumptown. Stumptown mumblecore vinyl, mustache street art wayfarers
+				lumbersexual everyday carry irony pitchfork gochujang pug DIY gentrify.
+			</p>
+			<p>
+				Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth
+				migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
+				asymmetrical meggings kombucha banh mi meh skateboard artisan man braid.
+				Ugh semiotics intelligentsia sustainable, craft beer next level meggings
+				before they sold out heirloom iPhone try-hard. Listicle blog literally
+				marfa plaid brooklyn humblebrag retro, VHS thundercats man braid
+				waistcoat ennui. Church-key knausgaard austin organic farm-to-table
+				neutra franzen bespoke, mlkshk narwhal DIY raw denim retro. Mlkshk
+				locavore try-hard roof party flexitarian. Letterpress beard fixie, umami
+				waistcoat salvia ennui four loko seitan lomo franzen pickled shoreditch
+				master cleanse.
+			</p>
+		</Expander>
+	);
+};
+Basic.args = {
+	...Expander.defaultProps,
 };
 
-export const Basic = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<Expander isExpanded={true}>
-						<Expander.Label>Show Less</Expander.Label>
-						<p>
-							You can't get rid of me. Keep clicking that icon as much as you
-							want, but I'm here to stay!
-						</p>
-					</Expander>
-				</div>
-			);
-		},
-	});
+export const InteractiveWithChangingLabels: Story<IExpanderProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(false);
 
-	return <Component />;
-};
+	const handleExpanded = (isExpanded: any) => {
+		setIsExpanded(isExpanded);
+	};
 
-/* Interactive With Changing Labels */
-export const InteractiveWithChangingLabels = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				isExpanded: false,
-			};
-		},
-
-		render() {
-			return (
-				<div>
-					<Expander
-						isExpanded={this.state.isExpanded}
-						onToggle={this.handleExpanded}
-					>
-						<Expander.Label>
-							{this.state.isExpanded ? 'Show Less' : 'Show More'}
-						</Expander.Label>
-						<p>
-							Artisan helvetica quinoa kogi fingerstache, biodiesel church-key
-							blue bottle everyday carry schlitz seitan locavore. Retro +1
-							tilde, normcore post-ironic chillwave PBR&B umami. Mlkshk
-							mumblecore meh, kitsch pickled wolf helvetica man bun cronut
-							keffiyeh meggings ramps. Banh mi stumptown cronut wayfarers. Banh
-							mi venmo street art chicharrones, put a bird on it yuccie cornhole
-							poutine knausgaard echo park tilde retro. Occupy XOXO etsy meh
-							pabst blue bottle. Photo booth four loko biodiesel, cornhole
-							chicharrones echo park actually pork belly gochujang DIY
-							gluten-free plaid microdosing salvia pinterest.
-						</p>
-						<p>
-							Cred lumbersexual organic, echo park hashtag roof party pinterest
-							shabby chic green juice salvia scenester hella ramps. Schlitz
-							knausgaard church-key disrupt, four loko XOXO bicycle rights
-							post-ironic four dollar toast fixie butcher mustache tousled
-							humblebrag. Bushwick 8-bit swag, wolf intelligentsia kickstarter
-							roof party cred meh semiotics flannel. Typewriter umami narwhal
-							irony, slow-carb VHS street art cold-pressed wayfarers sriracha
-							everyday carry church-key wolf humblebrag. Skateboard polaroid man
-							braid organic, chambray mustache mixtape freegan humblebrag brunch
-							ugh. Wayfarers VHS brooklyn, fashion axe green juice next level
-							kombucha cray shabby chic lo-fi. Lumbersexual pug farm-to-table,
-							authentic chartreuse street art church-key.
-						</p>
-						<p>
-							3 wolf moon pickled messenger bag knausgaard venmo, retro aliquip
-							portland asymmetrical cliche non pabst pinterest culpa. Laboris
-							beard intelligentsia, pickled viral brooklyn YOLO tempor do cliche
-							fugiat. Messenger bag fanny pack reprehenderit bicycle rights
-							tilde, tumblr neutra do intelligentsia godard street art. Gentrify
-							consectetur laboris, pug venmo literally you probably haven't
-							heard of them actually locavore distillery commodo occupy franzen
-							umami. Slow-carb bespoke pariatur four dollar toast, selfies tofu
-							salvia artisan tousled meggings kinfolk chambray marfa direct
-							trade single-origin coffee. Exercitation fap umami mollit deep v
-							wolf, sint lomo sunt four dollar toast elit selvage vegan
-							truffaut. Cillum pickled sartorial flexitarian chartreuse
-							brooklyn.
-						</p>
-						<p>
-							Artisan helvetica quinoa kogi fingerstache, biodiesel church-key
-							blue bottle everyday carry schlitz seitan locavore. Retro +1
-							tilde, normcore post-ironic chillwave PBR&B umami. Mlkshk
-							mumblecore meh, kitsch pickled wolf helvetica man bun cronut
-							keffiyeh meggings ramps. Banh mi stumptown cronut wayfarers. Banh
-							mi venmo street art chicharrones, put a bird on it yuccie cornhole
-							poutine knausgaard echo park tilde retro. Occupy XOXO etsy meh
-							pabst blue bottle. Photo booth four loko biodiesel, cornhole
-							chicharrones echo park actually pork belly gochujang DIY
-							gluten-free plaid microdosing salvia pinterest.
-						</p>
-						<p>
-							Cred lumbersexual organic, echo park hashtag roof party pinterest
-							shabby chic green juice salvia scenester hella ramps. Schlitz
-							knausgaard church-key disrupt, four loko XOXO bicycle rights
-							post-ironic four dollar toast fixie butcher mustache tousled
-							humblebrag. Bushwick 8-bit swag, wolf intelligentsia kickstarter
-							roof party cred meh semiotics flannel. Typewriter umami narwhal
-							irony, slow-carb VHS street art cold-pressed wayfarers sriracha
-							everyday carry church-key wolf humblebrag. Skateboard polaroid man
-							braid organic, chambray mustache mixtape freegan humblebrag brunch
-							ugh. Wayfarers VHS brooklyn, fashion axe green juice next level
-							kombucha cray shabby chic lo-fi. Lumbersexual pug farm-to-table,
-							authentic chartreuse street art church-key.
-						</p>
-						<p>
-							3 wolf moon pickled messenger bag knausgaard venmo, retro aliquip
-							portland asymmetrical cliche non pabst pinterest culpa. Laboris
-							beard intelligentsia, pickled viral brooklyn YOLO tempor do cliche
-							fugiat. Messenger bag fanny pack reprehenderit bicycle rights
-							tilde, tumblr neutra do intelligentsia godard street art. Gentrify
-							consectetur laboris, pug venmo literally you probably haven't
-							heard of them actually locavore distillery commodo occupy franzen
-							umami. Slow-carb bespoke pariatur four dollar toast, selfies tofu
-							salvia artisan tousled meggings kinfolk chambray marfa direct
-							trade single-origin coffee. Exercitation fap umami mollit deep v
-							wolf, sint lomo sunt four dollar toast elit selvage vegan
-							truffaut. Cillum pickled sartorial flexitarian chartreuse
-							brooklyn.
-						</p>
-					</Expander>
-				</div>
-			);
-		},
-
-		handleExpanded(isExpanded: any) {
-			this.setState({
-				isExpanded,
-			});
-		},
-	});
-
-	return <Component />;
-};
-
-/* Interactive Without Changing Labels */
-export const InteractiveWithoutChangingLabels = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<Expander>
-						<Expander.Label>Show Stuff</Expander.Label>
-						<p>
-							Tacos craft beer humblebrag meditation. Cold-pressed next level
-							man bun readymade beard, wayfarers fanny pack keytar helvetica
-							knausgaard biodiesel lumbersexual. Knausgaard echo park whatever
-							four loko messenger bag hella. Cardigan church-key brooklyn
-							letterpress artisan venmo, gastropub hella. Single-origin coffee
-							selfies four loko, biodiesel health goth truffaut migas
-							sustainable kale chips disrupt locavore meggings mustache actually
-							retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice
-							kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally
-							before they sold out gochujang pork belly franzen.
-						</p>
-						<p>
-							Sriracha put a bird on it chia, locavore wolf affogato tote bag
-							neutra umami food truck austin keytar cronut man bun. Kitsch man
-							braid occupy art party, tousled waistcoat tilde YOLO keytar street
-							art selvage. Salvia pour-over keytar intelligentsia. Marfa yr
-							stumptown, before they sold out lo-fi literally art party
-							williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic
-							aesthetic kickstarter, dreamcatcher four dollar toast whatever
-							tattooed quinoa. Single-origin coffee blog lomo, freegan next
-							level ramps small batch put a bird on it listicle stumptown.
-							Stumptown mumblecore vinyl, mustache street art wayfarers
-							lumbersexual everyday carry irony pitchfork gochujang pug DIY
-							gentrify.
-						</p>
-						<p>
-							Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo
-							booth migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
-							asymmetrical meggings kombucha banh mi meh skateboard artisan man
-							braid. Ugh semiotics intelligentsia sustainable, craft beer next
-							level meggings before they sold out heirloom iPhone try-hard.
-							Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS
-							thundercats man braid waistcoat ennui. Church-key knausgaard
-							austin organic farm-to-table neutra franzen bespoke, mlkshk
-							narwhal DIY raw denim retro. Mlkshk locavore try-hard roof party
-							flexitarian. Letterpress beard fixie, umami waistcoat salvia ennui
-							four loko seitan lomo franzen pickled shoreditch master cleanse.
-						</p>
-						<p>
-							Tacos craft beer humblebrag meditation. Cold-pressed next level
-							man bun readymade beard, wayfarers fanny pack keytar helvetica
-							knausgaard biodiesel lumbersexual. Knausgaard echo park whatever
-							four loko messenger bag hella. Cardigan church-key brooklyn
-							letterpress artisan venmo, gastropub hella. Single-origin coffee
-							selfies four loko, biodiesel health goth truffaut migas
-							sustainable kale chips disrupt locavore meggings mustache actually
-							retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice
-							kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally
-							before they sold out gochujang pork belly franzen.
-						</p>
-						<p>
-							Sriracha put a bird on it chia, locavore wolf affogato tote bag
-							neutra umami food truck austin keytar cronut man bun. Kitsch man
-							braid occupy art party, tousled waistcoat tilde YOLO keytar street
-							art selvage. Salvia pour-over keytar intelligentsia. Marfa yr
-							stumptown, before they sold out lo-fi literally art party
-							williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic
-							aesthetic kickstarter, dreamcatcher four dollar toast whatever
-							tattooed quinoa. Single-origin coffee blog lomo, freegan next
-							level ramps small batch put a bird on it listicle stumptown.
-							Stumptown mumblecore vinyl, mustache street art wayfarers
-							lumbersexual everyday carry irony pitchfork gochujang pug DIY
-							gentrify.
-						</p>
-						<p>
-							Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo
-							booth migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
-							asymmetrical meggings kombucha banh mi meh skateboard artisan man
-							braid. Ugh semiotics intelligentsia sustainable, craft beer next
-							level meggings before they sold out heirloom iPhone try-hard.
-							Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS
-							thundercats man braid waistcoat ennui. Church-key knausgaard
-							austin organic farm-to-table neutra franzen bespoke, mlkshk
-							narwhal DIY raw denim retro. Mlkshk locavore try-hard roof party
-							flexitarian. Letterpress beard fixie, umami waistcoat salvia ennui
-							four loko seitan lomo franzen pickled shoreditch master cleanse.
-						</p>
-					</Expander>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<Expander isExpanded={isExpanded} onToggle={handleExpanded}>
+			<Expander.Label>{isExpanded ? 'Show Less' : 'Show More'}</Expander.Label>
+			<p>
+				Artisan helvetica quinoa kogi fingerstache, biodiesel church-key blue
+				bottle everyday carry schlitz seitan locavore. Retro +1 tilde, normcore
+				post-ironic chillwave PBR&B umami. Mlkshk mumblecore meh, kitsch pickled
+				wolf helvetica man bun cronut keffiyeh meggings ramps. Banh mi stumptown
+				cronut wayfarers. Banh mi venmo street art chicharrones, put a bird on
+				it yuccie cornhole poutine knausgaard echo park tilde retro. Occupy XOXO
+				etsy meh pabst blue bottle. Photo booth four loko biodiesel, cornhole
+				chicharrones echo park actually pork belly gochujang DIY gluten-free
+				plaid microdosing salvia pinterest.
+			</p>
+			<p>
+				Cred lumbersexual organic, echo park hashtag roof party pinterest shabby
+				chic green juice salvia scenester hella ramps. Schlitz knausgaard
+				church-key disrupt, four loko XOXO bicycle rights post-ironic four
+				dollar toast fixie butcher mustache tousled humblebrag. Bushwick 8-bit
+				swag, wolf intelligentsia kickstarter roof party cred meh semiotics
+				flannel. Typewriter umami narwhal irony, slow-carb VHS street art
+				cold-pressed wayfarers sriracha everyday carry church-key wolf
+				humblebrag. Skateboard polaroid man braid organic, chambray mustache
+				mixtape freegan humblebrag brunch ugh. Wayfarers VHS brooklyn, fashion
+				axe green juice next level kombucha cray shabby chic lo-fi. Lumbersexual
+				pug farm-to-table, authentic chartreuse street art church-key.
+			</p>
+			<p>
+				3 wolf moon pickled messenger bag knausgaard venmo, retro aliquip
+				portland asymmetrical cliche non pabst pinterest culpa. Laboris beard
+				intelligentsia, pickled viral brooklyn YOLO tempor do cliche fugiat.
+				Messenger bag fanny pack reprehenderit bicycle rights tilde, tumblr
+				neutra do intelligentsia godard street art. Gentrify consectetur
+				laboris, pug venmo literally you probably haven't heard of them actually
+				locavore distillery commodo occupy franzen umami. Slow-carb bespoke
+				pariatur four dollar toast, selfies tofu salvia artisan tousled meggings
+				kinfolk chambray marfa direct trade single-origin coffee. Exercitation
+				fap umami mollit deep v wolf, sint lomo sunt four dollar toast elit
+				selvage vegan truffaut. Cillum pickled sartorial flexitarian chartreuse
+				brooklyn.
+			</p>
+			<p>
+				Artisan helvetica quinoa kogi fingerstache, biodiesel church-key blue
+				bottle everyday carry schlitz seitan locavore. Retro +1 tilde, normcore
+				post-ironic chillwave PBR&B umami. Mlkshk mumblecore meh, kitsch pickled
+				wolf helvetica man bun cronut keffiyeh meggings ramps. Banh mi stumptown
+				cronut wayfarers. Banh mi venmo street art chicharrones, put a bird on
+				it yuccie cornhole poutine knausgaard echo park tilde retro. Occupy XOXO
+				etsy meh pabst blue bottle. Photo booth four loko biodiesel, cornhole
+				chicharrones echo park actually pork belly gochujang DIY gluten-free
+				plaid microdosing salvia pinterest.
+			</p>
+			<p>
+				Cred lumbersexual organic, echo park hashtag roof party pinterest shabby
+				chic green juice salvia scenester hella ramps. Schlitz knausgaard
+				church-key disrupt, four loko XOXO bicycle rights post-ironic four
+				dollar toast fixie butcher mustache tousled humblebrag. Bushwick 8-bit
+				swag, wolf intelligentsia kickstarter roof party cred meh semiotics
+				flannel. Typewriter umami narwhal irony, slow-carb VHS street art
+				cold-pressed wayfarers sriracha everyday carry church-key wolf
+				humblebrag. Skateboard polaroid man braid organic, chambray mustache
+				mixtape freegan humblebrag brunch ugh. Wayfarers VHS brooklyn, fashion
+				axe green juice next level kombucha cray shabby chic lo-fi. Lumbersexual
+				pug farm-to-table, authentic chartreuse street art church-key.
+			</p>
+			<p>
+				3 wolf moon pickled messenger bag knausgaard venmo, retro aliquip
+				portland asymmetrical cliche non pabst pinterest culpa. Laboris beard
+				intelligentsia, pickled viral brooklyn YOLO tempor do cliche fugiat.
+				Messenger bag fanny pack reprehenderit bicycle rights tilde, tumblr
+				neutra do intelligentsia godard street art. Gentrify consectetur
+				laboris, pug venmo literally you probably haven't heard of them actually
+				locavore distillery commodo occupy franzen umami. Slow-carb bespoke
+				pariatur four dollar toast, selfies tofu salvia artisan tousled meggings
+				kinfolk chambray marfa direct trade single-origin coffee. Exercitation
+				fap umami mollit deep v wolf, sint lomo sunt four dollar toast elit
+				selvage vegan truffaut. Cillum pickled sartorial flexitarian chartreuse
+				brooklyn.
+			</p>
+		</Expander>
+	);
 };
 
 /* Interactive With Changing Labels And Additional Label Content */
-export const InteractiveWithChangingLabelsAndAdditionalLabelContent = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<Expander>
-						<Expander.Label>Show Stuff</Expander.Label>
-						<Expander.AdditionalLabelContent>
-							<Button kind='invisible'>
-								<EditIcon />
-								Edit
-							</Button>
-							<Button kind='invisible'>
-								<CloseIcon />
-								Clear All
-							</Button>
-						</Expander.AdditionalLabelContent>
-						<p>
-							Tacos craft beer humblebrag meditation. Cold-pressed next level
-							man bun readymade beard, wayfarers fanny pack keytar helvetica
-							knausgaard biodiesel lumbersexual. Knausgaard echo park whatever
-							four loko messenger bag hella. Cardigan church-key brooklyn
-							letterpress artisan venmo, gastropub hella. Single-origin coffee
-							selfies four loko, biodiesel health goth truffaut migas
-							sustainable kale chips disrupt locavore meggings mustache actually
-							retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice
-							kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally
-							before they sold out gochujang pork belly franzen.
-						</p>
-						<p>
-							Sriracha put a bird on it chia, locavore wolf affogato tote bag
-							neutra umami food truck austin keytar cronut man bun. Kitsch man
-							braid occupy art party, tousled waistcoat tilde YOLO keytar street
-							art selvage. Salvia pour-over keytar intelligentsia. Marfa yr
-							stumptown, before they sold out lo-fi literally art party
-							williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic
-							aesthetic kickstarter, dreamcatcher four dollar toast whatever
-							tattooed quinoa. Single-origin coffee blog lomo, freegan next
-							level ramps small batch put a bird on it listicle stumptown.
-							Stumptown mumblecore vinyl, mustache street art wayfarers
-							lumbersexual everyday carry irony pitchfork gochujang pug DIY
-							gentrify.
-						</p>
-						<p>
-							Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo
-							booth migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
-							asymmetrical meggings kombucha banh mi meh skateboard artisan man
-							braid. Ugh semiotics intelligentsia sustainable, craft beer next
-							level meggings before they sold out heirloom iPhone try-hard.
-							Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS
-							thundercats man braid waistcoat ennui. Church-key knausgaard
-							austin organic farm-to-table neutra franzen bespoke, mlkshk
-							narwhal DIY raw denim retro. Mlkshk locavore try-hard roof party
-							flexitarian. Letterpress beard fixie, umami waistcoat salvia ennui
-							four loko seitan lomo franzen pickled shoreditch master cleanse.
-						</p>
-						<p>
-							Tacos craft beer humblebrag meditation. Cold-pressed next level
-							man bun readymade beard, wayfarers fanny pack keytar helvetica
-							knausgaard biodiesel lumbersexual. Knausgaard echo park whatever
-							four loko messenger bag hella. Cardigan church-key brooklyn
-							letterpress artisan venmo, gastropub hella. Single-origin coffee
-							selfies four loko, biodiesel health goth truffaut migas
-							sustainable kale chips disrupt locavore meggings mustache actually
-							retro. Mlkshk poutine flexitarian scenester 3 wolf moon, vice
-							kinfolk chia blog ennui bitters brooklyn quinoa marfa. Literally
-							before they sold out gochujang pork belly franzen.
-						</p>
-						<p>
-							Sriracha put a bird on it chia, locavore wolf affogato tote bag
-							neutra umami food truck austin keytar cronut man bun. Kitsch man
-							braid occupy art party, tousled waistcoat tilde YOLO keytar street
-							art selvage. Salvia pour-over keytar intelligentsia. Marfa yr
-							stumptown, before they sold out lo-fi literally art party
-							williamsburg blue bottle slow-carb brooklyn. Gochujang post-ironic
-							aesthetic kickstarter, dreamcatcher four dollar toast whatever
-							tattooed quinoa. Single-origin coffee blog lomo, freegan next
-							level ramps small batch put a bird on it listicle stumptown.
-							Stumptown mumblecore vinyl, mustache street art wayfarers
-							lumbersexual everyday carry irony pitchfork gochujang pug DIY
-							gentrify.
-						</p>
-						<p>
-							Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo
-							booth migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
-							asymmetrical meggings kombucha banh mi meh skateboard artisan man
-							braid. Ugh semiotics intelligentsia sustainable, craft beer next
-							level meggings before they sold out heirloom iPhone try-hard.
-							Listicle blog literally marfa plaid brooklyn humblebrag retro, VHS
-							thundercats man braid waistcoat ennui. Church-key knausgaard
-							austin organic farm-to-table neutra franzen bespoke, mlkshk
-							narwhal DIY raw denim retro. Mlkshk locavore try-hard roof party
-							flexitarian. Letterpress beard fixie, umami waistcoat salvia ennui
-							four loko seitan lomo franzen pickled shoreditch master cleanse.
-						</p>
-					</Expander>
-				</div>
-			);
-		},
-	});
+export const InteractiveWithChangingLabelsAndAdditionalLabelContent: Story<
+	IExpanderProps
+> = (args) => {
+	return (
+		<Expander>
+			<Expander.Label>Show Stuff</Expander.Label>
+			<Expander.AdditionalLabelContent>
+				<Button kind='invisible'>
+					<EditIcon />
+					Edit
+				</Button>
+				<Button kind='invisible'>
+					<CloseIcon />
+					Clear All
+				</Button>
+			</Expander.AdditionalLabelContent>
+			<p>
+				Tacos craft beer humblebrag meditation. Cold-pressed next level man bun
+				readymade beard, wayfarers fanny pack keytar helvetica knausgaard
+				biodiesel lumbersexual. Knausgaard echo park whatever four loko
+				messenger bag hella. Cardigan church-key brooklyn letterpress artisan
+				venmo, gastropub hella. Single-origin coffee selfies four loko,
+				biodiesel health goth truffaut migas sustainable kale chips disrupt
+				locavore meggings mustache actually retro. Mlkshk poutine flexitarian
+				scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn
+				quinoa marfa. Literally before they sold out gochujang pork belly
+				franzen.
+			</p>
+			<p>
+				Sriracha put a bird on it chia, locavore wolf affogato tote bag neutra
+				umami food truck austin keytar cronut man bun. Kitsch man braid occupy
+				art party, tousled waistcoat tilde YOLO keytar street art selvage.
+				Salvia pour-over keytar intelligentsia. Marfa yr stumptown, before they
+				sold out lo-fi literally art party williamsburg blue bottle slow-carb
+				brooklyn. Gochujang post-ironic aesthetic kickstarter, dreamcatcher four
+				dollar toast whatever tattooed quinoa. Single-origin coffee blog lomo,
+				freegan next level ramps small batch put a bird on it listicle
+				stumptown. Stumptown mumblecore vinyl, mustache street art wayfarers
+				lumbersexual everyday carry irony pitchfork gochujang pug DIY gentrify.
+			</p>
+			<p>
+				Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth
+				migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
+				asymmetrical meggings kombucha banh mi meh skateboard artisan man braid.
+				Ugh semiotics intelligentsia sustainable, craft beer next level meggings
+				before they sold out heirloom iPhone try-hard. Listicle blog literally
+				marfa plaid brooklyn humblebrag retro, VHS thundercats man braid
+				waistcoat ennui. Church-key knausgaard austin organic farm-to-table
+				neutra franzen bespoke, mlkshk narwhal DIY raw denim retro. Mlkshk
+				locavore try-hard roof party flexitarian. Letterpress beard fixie, umami
+				waistcoat salvia ennui four loko seitan lomo franzen pickled shoreditch
+				master cleanse.
+			</p>
+			<p>
+				Tacos craft beer humblebrag meditation. Cold-pressed next level man bun
+				readymade beard, wayfarers fanny pack keytar helvetica knausgaard
+				biodiesel lumbersexual. Knausgaard echo park whatever four loko
+				messenger bag hella. Cardigan church-key brooklyn letterpress artisan
+				venmo, gastropub hella. Single-origin coffee selfies four loko,
+				biodiesel health goth truffaut migas sustainable kale chips disrupt
+				locavore meggings mustache actually retro. Mlkshk poutine flexitarian
+				scenester 3 wolf moon, vice kinfolk chia blog ennui bitters brooklyn
+				quinoa marfa. Literally before they sold out gochujang pork belly
+				franzen.
+			</p>
+			<p>
+				Sriracha put a bird on it chia, locavore wolf affogato tote bag neutra
+				umami food truck austin keytar cronut man bun. Kitsch man braid occupy
+				art party, tousled waistcoat tilde YOLO keytar street art selvage.
+				Salvia pour-over keytar intelligentsia. Marfa yr stumptown, before they
+				sold out lo-fi literally art party williamsburg blue bottle slow-carb
+				brooklyn. Gochujang post-ironic aesthetic kickstarter, dreamcatcher four
+				dollar toast whatever tattooed quinoa. Single-origin coffee blog lomo,
+				freegan next level ramps small batch put a bird on it listicle
+				stumptown. Stumptown mumblecore vinyl, mustache street art wayfarers
+				lumbersexual everyday carry irony pitchfork gochujang pug DIY gentrify.
+			</p>
+			<p>
+				Kale chips pug jean shorts cardigan, ramps plaid mlkshk photo booth
+				migas whatever. Ramps affogato bespoke, crucifix ennui PBR&B
+				asymmetrical meggings kombucha banh mi meh skateboard artisan man braid.
+				Ugh semiotics intelligentsia sustainable, craft beer next level meggings
+				before they sold out heirloom iPhone try-hard. Listicle blog literally
+				marfa plaid brooklyn humblebrag retro, VHS thundercats man braid
+				waistcoat ennui. Church-key knausgaard austin organic farm-to-table
+				neutra franzen bespoke, mlkshk narwhal DIY raw denim retro. Mlkshk
+				locavore try-hard roof party flexitarian. Letterpress beard fixie, umami
+				waistcoat salvia ennui four loko seitan lomo franzen pickled shoreditch
+				master cleanse.
+			</p>
+		</Expander>
+	);
+};
 
-	return <Component />;
+/** IsExpanded */
+export const IsExpanded: Story<IExpanderProps> = (args) => {
+	return (
+		<Expander isExpanded={true}>
+			<Expander.Label>Show Less</Expander.Label>
+			<p>
+				You can't get rid of me. Keep clicking that icon as much as you want,
+				but I'm here to stay!
+			</p>
+		</Expander>
+	);
 };
 
 /* Highlighted */
-export const Highlighted = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<Expander kind='highlighted'>
-						<Expander.Label>Show Less</Expander.Label>
-						<p>
-							You can't get rid of me. Keep clicking that icon as much as you
-							want, but I'm here to stay!
-						</p>
-					</Expander>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+export const Highlighted: Story<IExpanderProps> = (args) => {
+	return (
+		<Expander kind='highlighted'>
+			<Expander.Label>Show Less</Expander.Label>
+			<p>
+				You can't get rid of me. Keep clicking that icon as much as you want,
+				but I'm here to stay!
+			</p>
+		</Expander>
+	);
 };

--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -1,6 +1,7 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	findTypes,
@@ -17,11 +18,8 @@ const cx = lucidClassNames.bind('&-Expander');
 
 const { any, bool, func, node, object, oneOf, string } = PropTypes;
 
+/** Expander Label */
 export interface IExpanderLabelProps extends StandardProps {
-	description?: string;
-}
-
-export interface IExpanderAdditionalLabelProps extends StandardProps {
 	description?: string;
 }
 
@@ -33,12 +31,16 @@ Label.peek = {
 Label.propName = 'Label';
 Label.propTypes = {
 	/**
-					Used to identify the purpose of this switch to the user -- can be any
-					renderable content.
-				*/
+		Used to identify the purpose of this switch to the user -- can be any
+		renderable content.
+	*/
 	children: node,
 };
 
+/** Additional Label */
+export interface IExpanderAdditionalLabelProps extends StandardProps {
+	description?: string;
+}
 const AdditionalLabelContent = (_props: IExpanderAdditionalLabelProps): null =>
 	null;
 AdditionalLabelContent.displayName = 'Expander.AdditionalLabelContent';
@@ -48,11 +50,12 @@ AdditionalLabelContent.peek = {
 AdditionalLabelContent.propName = 'AdditionalLabelContent';
 AdditionalLabelContent.propTypes = {
 	/**
-					Used to display additional information or/and actions next to expander label.
-				*/
+		Used to display additional information or/and actions next to expander label.
+	*/
 	children: node,
 };
 
+/** Expander */
 export interface IExpanderProps
 	extends StandardProps,
 		React.DetailedHTMLProps<
@@ -91,6 +94,17 @@ export interface IExpanderProps
 	 * */
 	kind: 'simple' | 'highlighted';
 }
+
+const nonPassThroughs = [
+	'isExpanded',
+	'onToggle',
+	'style',
+	'Label',
+	'AdditionalLabelContent',
+	'kind',
+	'initialState',
+	'callbackId',
+];
 
 const defaultProps = {
 	isExpanded: false,
@@ -159,7 +173,7 @@ class Expander extends React.Component<IExpanderProps, IExpanderState> {
 	static AdditionalLabelContent = AdditionalLabelContent;
 
 	static peek = {
-		description: `\`Expander\` is a container that provides a toggle that controls when the content is shown.`,
+		description: `\`Expander\` is a container that provides a toggle that controls when the \`Panel\` content is shown.`,
 		categories: ['layout'],
 		madeFrom: ['ChevronIcon'],
 	};
@@ -185,7 +199,7 @@ class Expander extends React.Component<IExpanderProps, IExpanderState> {
 
 		return (
 			<div
-				{...omitProps(passThroughs, undefined, _.keys(Expander.propTypes))}
+				{...omit(passThroughs, nonPassThroughs)}
 				className={cx(
 					'&',
 					{

--- a/src/components/Expander/__snapshots__/Expander.spec.tsx.snap
+++ b/src/components/Expander/__snapshots__/Expander.spec.tsx.snap
@@ -1,306 +1,296 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Expander [common] example testing should match snapshot(s) for Basic 1`] = `
-<div>
-  <div
-    class="lucid-Expander lucid-Expander-is-expanded"
+<div
+  class="lucid-Expander"
+>
+  <header
+    class="lucid-Expander-header"
   >
-    <header
-      class="lucid-Expander-header"
+    <div
+      class="lucid-Expander-header-toggle"
     >
-      <div
-        class="lucid-Expander-header-toggle"
+      <button
+        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
+        type="button"
       >
-        <button
-          class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-up"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M.5 4.5l7.5 7 7.5-7"
-              />
-            </svg>
-          </span>
-        </button>
         <span
-          class="lucid-Expander-text"
+          class="lucid-Button-content"
         >
-          Show Less
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M.5 4.5l7.5 7 7.5-7"
+            />
+          </svg>
         </span>
-      </div>
-    </header>
-    <section
-      class="lucid-Collapsible lucid-Expander-content"
-      style="overflow:hidden;padding:0"
-    >
-      <div
-        class="lucid-Collapsible-content"
-        style="margin:0"
+      </button>
+      <span
+        class="lucid-Expander-text"
       >
-        <p>
-          You can't get rid of me. Keep clicking that icon as much as you want, but I'm here to stay!
-        </p>
-      </div>
-    </section>
-  </div>
+        Show Stuff
+      </span>
+    </div>
+  </header>
+  <section
+    class="lucid-Collapsible lucid-Expander-content"
+    style="overflow:hidden;padding:0"
+  >
+    <div
+      class="lucid-Collapsible-content"
+      style="margin:0"
+    />
+  </section>
 </div>
 `;
 
 exports[`Expander [common] example testing should match snapshot(s) for Highlighted 1`] = `
-<div>
-  <div
-    class="lucid-Expander lucid-Expander-kind-highlighted"
+<div
+  class="lucid-Expander lucid-Expander-kind-highlighted"
+>
+  <header
+    class="lucid-Expander-header"
   >
-    <header
-      class="lucid-Expander-header"
+    <div
+      class="lucid-Expander-header-toggle"
     >
-      <div
-        class="lucid-Expander-header-toggle"
+      <button
+        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
+        type="button"
       >
-        <button
-          class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M.5 4.5l7.5 7 7.5-7"
-              />
-            </svg>
-          </span>
-        </button>
         <span
-          class="lucid-Expander-text"
+          class="lucid-Button-content"
         >
-          Show Less
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M.5 4.5l7.5 7 7.5-7"
+            />
+          </svg>
         </span>
-      </div>
-    </header>
-    <section
-      class="lucid-Collapsible lucid-Expander-content"
-      style="overflow:hidden;padding:0"
-    >
-      <div
-        class="lucid-Collapsible-content"
-        style="margin:0"
-      />
-    </section>
-  </div>
+      </button>
+      <span
+        class="lucid-Expander-text"
+      >
+        Show Less
+      </span>
+    </div>
+  </header>
+  <section
+    class="lucid-Collapsible lucid-Expander-content"
+    style="overflow:hidden;padding:0"
+  >
+    <div
+      class="lucid-Collapsible-content"
+      style="margin:0"
+    />
+  </section>
 </div>
 `;
 
 exports[`Expander [common] example testing should match snapshot(s) for InteractiveWithChangingLabels 1`] = `
-<div>
-  <div
-    class="lucid-Expander"
+<div
+  class="lucid-Expander"
+>
+  <header
+    class="lucid-Expander-header"
   >
-    <header
-      class="lucid-Expander-header"
+    <div
+      class="lucid-Expander-header-toggle"
     >
-      <div
-        class="lucid-Expander-header-toggle"
+      <button
+        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
+        type="button"
       >
-        <button
-          class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M.5 4.5l7.5 7 7.5-7"
-              />
-            </svg>
-          </span>
-        </button>
         <span
-          class="lucid-Expander-text"
+          class="lucid-Button-content"
         >
-          Show More
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M.5 4.5l7.5 7 7.5-7"
+            />
+          </svg>
         </span>
-      </div>
-    </header>
-    <section
-      class="lucid-Collapsible lucid-Expander-content"
-      style="overflow:hidden;padding:0"
-    >
-      <div
-        class="lucid-Collapsible-content"
-        style="margin:0"
-      />
-    </section>
-  </div>
+      </button>
+      <span
+        class="lucid-Expander-text"
+      >
+        Show More
+      </span>
+    </div>
+  </header>
+  <section
+    class="lucid-Collapsible lucid-Expander-content"
+    style="overflow:hidden;padding:0"
+  >
+    <div
+      class="lucid-Collapsible-content"
+      style="margin:0"
+    />
+  </section>
 </div>
 `;
 
 exports[`Expander [common] example testing should match snapshot(s) for InteractiveWithChangingLabelsAndAdditionalLabelContent 1`] = `
-<div>
-  <div
-    class="lucid-Expander"
+<div
+  class="lucid-Expander"
+>
+  <header
+    class="lucid-Expander-header"
   >
-    <header
-      class="lucid-Expander-header"
+    <div
+      class="lucid-Expander-header-toggle"
     >
-      <div
-        class="lucid-Expander-header-toggle"
+      <button
+        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
+        type="button"
       >
-        <button
-          class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M.5 4.5l7.5 7 7.5-7"
-              />
-            </svg>
-          </span>
-        </button>
         <span
-          class="lucid-Expander-text"
+          class="lucid-Button-content"
         >
-          Show Stuff
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M.5 4.5l7.5 7 7.5-7"
+            />
+          </svg>
         </span>
-      </div>
-      <div
-        class="lucid-Expander-additional-content"
+      </button>
+      <span
+        class="lucid-Expander-text"
       >
-        <button
-          class="lucid-Button lucid-Button-invisible"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-EditIcon"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M4.541 14.522L.548 15.547l.974-4.006L12.452.472l3.019 2.981zm5.924-12.038l3.019 2.981M2.5 10.5l3 3"
-              />
-            </svg>
-            Edit
-          </span>
-        </button>
-        <button
-          class="lucid-Button lucid-Button-invisible"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-CloseIcon"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M.5.5l15 15m0-15l-15 15"
-              />
-            </svg>
-            Clear All
-          </span>
-        </button>
-      </div>
-    </header>
-    <section
-      class="lucid-Collapsible lucid-Expander-content"
-      style="overflow:hidden;padding:0"
+        Show Stuff
+      </span>
+    </div>
+    <div
+      class="lucid-Expander-additional-content"
     >
-      <div
-        class="lucid-Collapsible-content"
-        style="margin:0"
-      />
-    </section>
-  </div>
+      <button
+        class="lucid-Button lucid-Button-invisible"
+        type="button"
+      >
+        <span
+          class="lucid-Button-content"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-EditIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M4.541 14.522L.548 15.547l.974-4.006L12.452.472l3.019 2.981zm5.924-12.038l3.019 2.981M2.5 10.5l3 3"
+            />
+          </svg>
+          Edit
+        </span>
+      </button>
+      <button
+        class="lucid-Button lucid-Button-invisible"
+        type="button"
+      >
+        <span
+          class="lucid-Button-content"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-CloseIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M.5.5l15 15m0-15l-15 15"
+            />
+          </svg>
+          Clear All
+        </span>
+      </button>
+    </div>
+  </header>
+  <section
+    class="lucid-Collapsible lucid-Expander-content"
+    style="overflow:hidden;padding:0"
+  >
+    <div
+      class="lucid-Collapsible-content"
+      style="margin:0"
+    />
+  </section>
 </div>
 `;
 
-exports[`Expander [common] example testing should match snapshot(s) for InteractiveWithoutChangingLabels 1`] = `
-<div>
-  <div
-    class="lucid-Expander"
+exports[`Expander [common] example testing should match snapshot(s) for IsExpanded 1`] = `
+<div
+  class="lucid-Expander lucid-Expander-is-expanded"
+>
+  <header
+    class="lucid-Expander-header"
   >
-    <header
-      class="lucid-Expander-header"
+    <div
+      class="lucid-Expander-header-toggle"
     >
-      <div
-        class="lucid-Expander-header-toggle"
+      <button
+        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
+        type="button"
       >
-        <button
-          class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Expander-icon"
-          type="button"
-        >
-          <span
-            class="lucid-Button-content"
-          >
-            <svg
-              class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-              height="16"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 16 16"
-              width="16"
-            >
-              <path
-                d="M.5 4.5l7.5 7 7.5-7"
-              />
-            </svg>
-          </span>
-        </button>
         <span
-          class="lucid-Expander-text"
+          class="lucid-Button-content"
         >
-          Show Stuff
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-up"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M.5 4.5l7.5 7 7.5-7"
+            />
+          </svg>
         </span>
-      </div>
-    </header>
-    <section
-      class="lucid-Collapsible lucid-Expander-content"
-      style="overflow:hidden;padding:0"
+      </button>
+      <span
+        class="lucid-Expander-text"
+      >
+        Show Less
+      </span>
+    </div>
+  </header>
+  <section
+    class="lucid-Collapsible lucid-Expander-content"
+    style="overflow:hidden;padding:0"
+  >
+    <div
+      class="lucid-Collapsible-content"
+      style="margin:0"
     >
-      <div
-        class="lucid-Collapsible-content"
-        style="margin:0"
-      />
-    </section>
-  </div>
+      <p>
+        You can't get rid of me. Keep clicking that icon as much as you want, but I'm here to stay!
+      </p>
+    </div>
+  </section>
 </div>
 `;

--- a/src/components/ExpanderPanel/ExpanderPanel.spec.tsx
+++ b/src/components/ExpanderPanel/ExpanderPanel.spec.tsx
@@ -88,6 +88,7 @@ describe('ExpanderPanel', () => {
 					onToggle: _.noop,
 					onRest: _.noop,
 					onRestAppliedOnCollapse: true,
+					Header: <div>ExpanderPanel Header Prop</div>,
 					hasPadding: false,
 					isDisabled: true,
 					className: 'wut',
@@ -133,6 +134,7 @@ describe('ExpanderPanel', () => {
 						'isDisabled',
 						'hasPadding',
 						'initialState',
+						'Header',
 					],
 					(prop) => {
 						expect(has(rootProps, prop)).toBe(false);

--- a/src/components/ExpanderPanel/ExpanderPanel.stories.tsx
+++ b/src/components/ExpanderPanel/ExpanderPanel.stories.tsx
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import React from 'react';
-import createClass from 'create-react-class';
-import ExpanderPanel from './ExpanderPanel';
+import { Story, Meta } from '@storybook/react';
+
+import ExpanderPanel, { IExpanderPanelProps } from './ExpanderPanel';
 
 export default {
 	title: 'Layout/ExpanderPanel',
@@ -9,74 +10,49 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (ExpanderPanel as any).peek.description,
+				component: ExpanderPanel.peek.description,
 			},
 		},
 	},
-};
+	args: ExpanderPanel.defaultProps,
+} as Meta;
 
 /* Basic */
-export const Basic = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<ExpanderPanel>
-						<ExpanderPanel.Header>Show More</ExpanderPanel.Header>
-						{_.times(100, (n) => (
-							<div key={n}>{_.repeat('-', 75 * Math.sin(n / 5))}</div>
-						))}
-					</ExpanderPanel>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+export const Basic: Story<IExpanderPanelProps> = (args) => {
+	return (
+		<ExpanderPanel {...args}>
+			<ExpanderPanel.Header>Show More</ExpanderPanel.Header>
+			{_.times(100, (n) => (
+				<div key={n}>{_.repeat('-', 75 * Math.sin(n / 5))}</div>
+			))}
+		</ExpanderPanel>
+	);
 };
 
 /* No Padding */
-export const NoPadding = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<ExpanderPanel hasPadding={false}>
-						<ExpanderPanel.Header>Show More</ExpanderPanel.Header>
-						{_.times(100, (n) => (
-							<div key={n}>{_.repeat('-', 75 * Math.sin(n / 5))}</div>
-						))}
-					</ExpanderPanel>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+export const NoPadding: Story<IExpanderPanelProps> = (args) => {
+	return (
+		<ExpanderPanel {...args} hasPadding={false}>
+			<ExpanderPanel.Header>Show More</ExpanderPanel.Header>
+			{_.times(100, (n) => (
+				<div key={n}>{_.repeat('-', 75 * Math.sin(n / 5))}</div>
+			))}
+		</ExpanderPanel>
+	);
 };
-NoPadding.storyName = 'NoPadding';
 
 /* Basic With On Rest Callback */
-export const BasicWithOnRestCallback = () => {
+export const BasicWithOnRestCallback: Story<IExpanderPanelProps> = (args) => {
 	const onRest = () => {
 		alert('A big ball of wibbly wobbly, timey wimey stuff');
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<ExpanderPanel onRest={onRest}>
-						<ExpanderPanel.Header>Show More</ExpanderPanel.Header>
-						{_.times(100, (n) => (
-							<div key={n}>{_.repeat('-', 75 * Math.sin(n / 5))}</div>
-						))}
-					</ExpanderPanel>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<ExpanderPanel {...args} onRest={onRest}>
+			<ExpanderPanel.Header>Show More</ExpanderPanel.Header>
+			{_.times(100, (n) => (
+				<div key={n}>{_.repeat('-', 75 * Math.sin(n / 5))}</div>
+			))}
+		</ExpanderPanel>
+	);
 };
-BasicWithOnRestCallback.storyName = 'BasicWithOnRestCallback';

--- a/src/components/ExpanderPanel/ExpanderPanel.tsx
+++ b/src/components/ExpanderPanel/ExpanderPanel.tsx
@@ -79,6 +79,7 @@ const nonPassThroughs = [
 	'onToggle',
 	'onRest',
 	'onRestAppliedOnCollapse',
+	'Header',
 	'isDisabled',
 	'hasPadding',
 	'initialState',

--- a/src/components/ExpanderPanel/ExpanderPanel.tsx
+++ b/src/components/ExpanderPanel/ExpanderPanel.tsx
@@ -1,6 +1,7 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import { getFirst, omitProps, StandardProps } from '../../util/component-types';
 import { buildModernHybridComponent } from '../../util/state-management';
@@ -16,6 +17,7 @@ const cx = lucidClassNames.bind('&-ExpanderPanel');
 
 const { any, bool, func, node, object, string } = PropTypes;
 
+/** Header */
 export interface IExpanderPanelHeaderProps extends StandardProps {
 	description?: string;
 }
@@ -34,6 +36,7 @@ Header.propTypes = {
 	children: node,
 };
 
+/** ExpanderPanel */
 export interface IExpanderPanelProps extends StandardProps {
 	/** Indicates that the component is in the "expanded" state when true and in
 			the "unexpanded" state when false. */
@@ -46,7 +49,10 @@ export interface IExpanderPanelProps extends StandardProps {
 	/** Controls the presence of padding on the inner content. */
 	hasPadding: boolean;
 
+	/** Optional. The callback that fires when the animation comes to a rest. */
 	onRest?: () => void;
+
+	/** Applies on onRest callback when rest state is closed. */
 	onRestAppliedOnCollapse?: boolean;
 
 	/** Called when the user clicks on the component's header. */
@@ -65,6 +71,18 @@ export interface IExpanderPanelProps extends StandardProps {
 			underlying ExpanderPanel */
 	Header?: React.ReactNode;
 }
+
+/** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
+const nonPassThroughs = [
+	'className',
+	'isExpanded',
+	'onToggle',
+	'onRest',
+	'onRestAppliedOnCollapse',
+	'isDisabled',
+	'hasPadding',
+	'initialState',
+];
 
 class ExpanderPanel extends React.Component<
 	IExpanderPanelProps,
@@ -111,10 +129,15 @@ class ExpanderPanel extends React.Component<
 		*/
 		style: object,
 
-		onRest:
-			func /*Optional. The callback that fires when the animation comes to a rest.*/,
-		onRestAppliedOnCollapse:
-			bool /*Applies on onRest callback when rest state is closed.*/,
+		/** 
+		 	Optional. The callback that fires when the animation comes to a rest.
+		*/
+		onRest: func,
+
+		/* 
+			Applies on onRest callback when rest state is closed.
+		*/
+		onRestAppliedOnCollapse: bool,
 
 		/**
 			prop alternative to Header child component passed through to the
@@ -124,10 +147,7 @@ class ExpanderPanel extends React.Component<
 	};
 
 	static peek = {
-		description: `
-					This is a container that provides a toggle that controls when the
-					content is shown.
-				`,
+		description: `An expandable container that provides a toggle that controls when the \`Panel\` content is shown.`,
 		categories: ['layout'],
 		madeFrom: ['ChevronIcon', 'Expander', 'Panel'],
 	};
@@ -171,12 +191,7 @@ class ExpanderPanel extends React.Component<
 
 		return (
 			<Panel
-				{...omitProps(
-					passThroughs,
-					undefined,
-					_.keys(ExpanderPanel.propTypes),
-					false
-				)}
+				{...(omit(passThroughs, nonPassThroughs) as any)}
 				className={cx(
 					'&',
 					{

--- a/src/components/ExpanderPanel/__snapshots__/ExpanderPanel.spec.tsx.snap
+++ b/src/components/ExpanderPanel/__snapshots__/ExpanderPanel.spec.tsx.snap
@@ -1,148 +1,142 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ExpanderPanel [common] example testing should match snapshot(s) for Basic 1`] = `
-<div>
-  <div
-    class="lucid-Panel lucid-ExpanderPanel lucid-ExpanderPanel-is-collapsed lucid-Panel-is-not-gutterless lucid-Panel-has-margin lucid-Panel-is-scrollable"
+<div
+  class="lucid-Panel lucid-ExpanderPanel lucid-ExpanderPanel-is-collapsed lucid-Panel-is-not-gutterless lucid-Panel-has-margin lucid-Panel-is-scrollable"
+>
+  <header
+    class="lucid-Panel-Header lucid-ExpanderPanel-header"
   >
-    <header
-      class="lucid-Panel-Header lucid-ExpanderPanel-header"
+    <button
+      class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-ExpanderPanel-icon"
+      type="button"
     >
-      <button
-        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-ExpanderPanel-icon"
-        type="button"
+      <span
+        class="lucid-Button-content"
       >
-        <span
-          class="lucid-Button-content"
+        <svg
+          class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+          height="16"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 16 16"
+          width="16"
         >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <path
-              d="M.5 4.5l7.5 7 7.5-7"
-            />
-          </svg>
-        </span>
-      </button>
-      <span>
-        Show More
+          <path
+            d="M.5 4.5l7.5 7 7.5-7"
+          />
+        </svg>
       </span>
-    </header>
-    <section
-      class="lucid-Panel-content"
+    </button>
+    <span>
+      Show More
+    </span>
+  </header>
+  <section
+    class="lucid-Panel-content"
+  >
+    <div
+      class="lucid-Collapsible lucid-ExpanderPanel-content"
+      style="overflow:hidden;padding:0"
     >
       <div
-        class="lucid-Collapsible lucid-ExpanderPanel-content"
-        style="overflow:hidden;padding:0"
-      >
-        <div
-          class="lucid-Collapsible-content"
-          style="margin:0"
-        />
-      </div>
-    </section>
-  </div>
+        class="lucid-Collapsible-content"
+        style="margin:0"
+      />
+    </div>
+  </section>
 </div>
 `;
 
 exports[`ExpanderPanel [common] example testing should match snapshot(s) for BasicWithOnRestCallback 1`] = `
-<div>
-  <div
-    class="lucid-Panel lucid-ExpanderPanel lucid-ExpanderPanel-is-collapsed lucid-Panel-is-not-gutterless lucid-Panel-has-margin lucid-Panel-is-scrollable"
+<div
+  class="lucid-Panel lucid-ExpanderPanel lucid-ExpanderPanel-is-collapsed lucid-Panel-is-not-gutterless lucid-Panel-has-margin lucid-Panel-is-scrollable"
+>
+  <header
+    class="lucid-Panel-Header lucid-ExpanderPanel-header"
   >
-    <header
-      class="lucid-Panel-Header lucid-ExpanderPanel-header"
+    <button
+      class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-ExpanderPanel-icon"
+      type="button"
     >
-      <button
-        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-ExpanderPanel-icon"
-        type="button"
+      <span
+        class="lucid-Button-content"
       >
-        <span
-          class="lucid-Button-content"
+        <svg
+          class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+          height="16"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 16 16"
+          width="16"
         >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <path
-              d="M.5 4.5l7.5 7 7.5-7"
-            />
-          </svg>
-        </span>
-      </button>
-      <span>
-        Show More
+          <path
+            d="M.5 4.5l7.5 7 7.5-7"
+          />
+        </svg>
       </span>
-    </header>
-    <section
-      class="lucid-Panel-content"
+    </button>
+    <span>
+      Show More
+    </span>
+  </header>
+  <section
+    class="lucid-Panel-content"
+  >
+    <div
+      class="lucid-Collapsible lucid-ExpanderPanel-content"
+      style="overflow:hidden;padding:0"
     >
       <div
-        class="lucid-Collapsible lucid-ExpanderPanel-content"
-        style="overflow:hidden;padding:0"
-      >
-        <div
-          class="lucid-Collapsible-content"
-          style="margin:0"
-        />
-      </div>
-    </section>
-  </div>
+        class="lucid-Collapsible-content"
+        style="margin:0"
+      />
+    </div>
+  </section>
 </div>
 `;
 
 exports[`ExpanderPanel [common] example testing should match snapshot(s) for NoPadding 1`] = `
-<div>
-  <div
-    class="lucid-Panel lucid-ExpanderPanel lucid-ExpanderPanel-is-collapsed lucid-Panel-has-margin lucid-Panel-is-scrollable"
+<div
+  class="lucid-Panel lucid-ExpanderPanel lucid-ExpanderPanel-is-collapsed lucid-Panel-has-margin lucid-Panel-is-scrollable"
+>
+  <header
+    class="lucid-Panel-Header lucid-ExpanderPanel-header"
   >
-    <header
-      class="lucid-Panel-Header lucid-ExpanderPanel-header"
+    <button
+      class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-ExpanderPanel-icon"
+      type="button"
     >
-      <button
-        class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-ExpanderPanel-icon"
-        type="button"
+      <span
+        class="lucid-Button-content"
       >
-        <span
-          class="lucid-Button-content"
+        <svg
+          class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+          height="16"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 16 16"
+          width="16"
         >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <path
-              d="M.5 4.5l7.5 7 7.5-7"
-            />
-          </svg>
-        </span>
-      </button>
-      <span>
-        Show More
+          <path
+            d="M.5 4.5l7.5 7 7.5-7"
+          />
+        </svg>
       </span>
-    </header>
-    <section
-      class="lucid-Panel-content"
+    </button>
+    <span>
+      Show More
+    </span>
+  </header>
+  <section
+    class="lucid-Panel-content"
+  >
+    <div
+      class="lucid-Collapsible lucid-ExpanderPanel-content"
+      style="overflow:hidden;padding:0"
     >
       <div
-        class="lucid-Collapsible lucid-ExpanderPanel-content"
-        style="overflow:hidden;padding:0"
-      >
-        <div
-          class="lucid-Collapsible-content"
-          style="margin:0"
-        />
-      </div>
-    </section>
-  </div>
+        class="lucid-Collapsible-content"
+        style="margin:0"
+      />
+    </div>
+  </section>
 </div>
 `;


### PR DESCRIPTION
## PR Checklist

Description of changes:
Replace omitProps method with explicit list of omitted props `nonPassThroughs`
Write Unit test for omitted and included tests
Update Storybook to display SB6 options and use functional examples.

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2565-Expander-ExpanderPanel-Replace-omitProps/?path=/docs/layout-expander--basic
https://docspot.adnxs.net/projects/lucid/CXP-2565-Expander-ExpanderPanel-Replace-omitProps/?path=/docs/layout-expanderpanel--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
