### PR TITLE
Remove omitProps, add unit test and convert story to sb6 for Resizer

### DIFF
--- a/src/components/Resizer/Resizer.spec.tsx
+++ b/src/components/Resizer/Resizer.spec.tsx
@@ -1,7 +1,7 @@
-import _ from 'lodash';
+import _, { keys, forEach, includes } from 'lodash';
 import React from 'react';
 import { common } from '../../util/generic-tests';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import Resizer from './Resizer';
 
 jest.mock('element-resize-detector', () => {
@@ -46,6 +46,60 @@ describe('Resizer', () => {
 			mount(<Resizer>{children}</Resizer>);
 
 			expect(children).toHaveBeenCalledWith(50, 100);
+		});
+	});
+
+	describe('passThroughs', () => {
+		let wrapper: any;
+
+		beforeEach(() => {
+			const props = {
+				width: 100,
+				height: 20,
+				className: 'wut',
+				children: (width, height) => (
+					<div>
+						<div>Width: {width}</div>
+						<div>Height: {height}</div>
+					</div>
+				),
+				style: { marginRight: 10 },
+				initialState: { testData: true },
+				callbackId: 1,
+				'data-testid': 10,
+			};
+			wrapper = shallow(<Resizer {...props} />);
+		});
+
+		afterEach(() => {
+			wrapper.unmount();
+		});
+
+		it('should pass through some props', () => {
+			const rootProps = keys(wrapper.first().props());
+
+			// className is omitted but appears because it is directly added to the element
+			forEach(
+				['data-testid', 'className', 'children', 'width', 'height', 'style'],
+				(prop) => {
+					expect(includes(rootProps, prop)).toBe(true);
+				}
+			);
+
+			expect(wrapper.first().prop(['data-testid'])).toBe(10);
+			expect(wrapper.first().prop(['width'])).toBe(100);
+			expect(wrapper.first().prop(['height'])).toBe(20);
+			expect(wrapper.first().prop(['className'])).toContain('wut');
+			expect(wrapper.first().prop(['style'])).toMatchObject({
+				marginRight: 10,
+			});
+		});
+		it('should omit some props', () => {
+			const rootProps = keys(wrapper.first().props());
+
+			forEach(['initialState', 'callbackId'], (prop) => {
+				expect(includes(rootProps, prop)).toBe(false);
+			});
 		});
 	});
 });

--- a/src/components/Resizer/Resizer.stories.tsx
+++ b/src/components/Resizer/Resizer.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import createClass from 'create-react-class';
-import Resizer from './Resizer';
+import Resizer, { IResizerProps } from './Resizer';
+import { Meta, Story } from '@storybook/react';
 
 export default {
 	title: 'Utility/Resizer',
@@ -8,73 +8,60 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (Resizer as any).peek.description,
+				component: Resizer.peek.description,
 			},
 		},
 	},
-};
+} as Meta;
 
 /* Basic */
-export const Basic = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<Resizer>
-					{(width, height) => (
-						<div>
-							<div>Width: {width}</div>
-							<div>Height: {height}</div>
-						</div>
-					)}
-				</Resizer>
-			);
-		},
-	});
-
-	return <Component />;
+export const Basic: Story<IResizerProps> = (args) => {
+	return (
+		<Resizer>
+			{(width, height) => (
+				<div>
+					<div>Width: {width}</div>
+					<div>Height: {height}</div>
+				</div>
+			)}
+		</Resizer>
+	);
 };
 
 /* With Flex */
-export const WithFlex = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div
-					style={{
-						display: 'flex',
-					}}
-				>
-					<div>Other content</div>
+export const WithFlex: Story<IResizerProps> = (args) => {
+	return (
+		<div
+			style={{
+				display: 'flex',
+			}}
+		>
+			<div>Other content</div>
 
-					<Resizer
+			<Resizer
+				style={{
+					flexGrow: 1,
+					overflow: 'hidden',
+				}}
+			>
+				{(width) => (
+					<div
 						style={{
-							flexGrow: 1,
-							overflow: 'hidden',
+							width,
+							height: width * 0.3,
+							border: '1px solid black',
 						}}
 					>
-						{(width) => (
-							<div
-								style={{
-									width,
-									height: width * 0.3,
-									border: '1px solid black',
-								}}
-							>
-								<div>
-									When using Resizer within a flexed container, its critical to
-									add <code>flexGrow: 1, overflow: 'hidden'</code> to its styles
-									so it will behave correctly.
-								</div>
-								<div>Width: {width}</div>
-								<div>Height: {width * 0.3}</div>
-							</div>
-						)}
-					</Resizer>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+						<div>
+							When using Resizer within a flexed container, its critical to add{' '}
+							<code>flexGrow: 1, overflow: 'hidden'</code> to its styles so it
+							will behave correctly.
+						</div>
+						<div>Width: {width}</div>
+						<div>Height: {width * 0.3}</div>
+					</div>
+				)}
+			</Resizer>
+		</div>
+	);
 };
-WithFlex.storyName = 'WithFlex';

--- a/src/components/Resizer/Resizer.tsx
+++ b/src/components/Resizer/Resizer.tsx
@@ -9,7 +9,7 @@ const cx = lucidClassNames.bind('&-Resizer');
 
 const { func, string } = PropTypes;
 
-interface IResizerProps
+export interface IResizerProps
 	extends StandardProps,
 		React.DetailedHTMLProps<
 			React.HTMLAttributes<HTMLDivElement>,

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -10,13 +10,18 @@ import { ValidationMap } from 'prop-types';
 
 export interface StandardProps {
 	/** Appended to the component-specific class names set on the root element.
-			Value is run through the `classnames` library. */
+	 * Value is run through the `classnames` library. */
 	className?: string;
+
 	/** Any valid React children. */
 	children?: React.ReactNode;
+
 	/** Styles that are passed through to native control. */
 	style?: React.CSSProperties;
 
+	/** A "magic" prop that's always excluded from DOM elements.
+	 * `callbackId` can be used to identify a component in a list
+	 *  without having to create extra closures. */
 	callbackId?: string | number;
 }
 
@@ -279,9 +284,11 @@ export function getFirst<P>(
 // Omit props defined in propTypes of the given type and any extra keys given
 // in third argument
 //
-// We also have a "magic" prop that's always excluded called `callbackId`. That
-// prop can be used to identify a component in a list without having to create
-// extra closures.
+// We also have a "magic" prop called `callbackId`.
+// It can be used to identify a component in a list
+// without having to create extra closures.
+//
+// It is always excluded from a DOM elements
 //
 // Note: The Partial<P> type is referring to the props passed into the omitProps,
 // not the props defined on the component.


### PR DESCRIPTION
## PR Checklist

Description of changes:

- Remove omitProps, 
- add unit test and 
- convert story to sb6 

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2576-Replace-omitProps-Resizer/?path=/docs/utility-resizer--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
