### PR TITLE
BUDE-1755/BUDE-1535: Add special prop to TextFieldValidated that allows custom error text and border color 

### DIFF
--- a/src/components/TextFieldValidated/TextFieldValidated.less
+++ b/src/components/TextFieldValidated/TextFieldValidated.less
@@ -79,5 +79,31 @@
 				border-color: @color-neutral-6;
 			}
 		}
+
+		@keyframes disappearingMessage {
+			from {
+				opacity: 1;
+			}
+			to {
+				opacity: 0;
+			}
+		}
+
+		@keyframes disappearingBorder {
+			to {
+				border-color: @color-borderColor;
+				border-width: 1px;
+			}
+		}
+
+		&.-disappearing {
+			.lucid-Validation-error-content {
+				animation: disappearingMessage 1500ms ease 4s forwards;
+			}
+
+			input {
+				animation: disappearingBorder 1500ms ease 4s forwards;
+			}
+		}
 	}
 }

--- a/src/components/TextFieldValidated/TextFieldValidated.less
+++ b/src/components/TextFieldValidated/TextFieldValidated.less
@@ -20,63 +20,13 @@
 			}
 		}
 
-		&.-success-text {
+		&.-success {
 			.lucid-Validation-error-content {
 				color: @featured-color-success;
 			}
-		}
 
-		&.-success-border {
 			input {
 				border-color: @featured-color-success;
-			}
-		}
-
-		&.-primary-text {
-			.lucid-Validation-error-content {
-				color: @color-primary;
-			}
-		}
-
-		&.-primary-border {
-			input {
-				border-color: @color-primary;
-			}
-		}
-
-		&.-danger-text {
-			.lucid-Validation-error-content {
-				color: @featured-color-danger;
-			}
-		}
-
-		&.-danger-border {
-			input {
-				border-color: @featured-color-danger;
-			}
-		}
-
-		&.-warning-text {
-			.lucid-Validation-error-content {
-				color: @featured-color-warning;
-			}
-		}
-
-		&.-warning-border {
-			input {
-				border-color: @featured-color-warning;
-			}
-		}
-
-		&.-info-text {
-			.lucid-Validation-error-content {
-				color: @color-neutral-6;
-			}
-		}
-
-		&.-info-border {
-			input {
-				border-color: @color-neutral-6;
 			}
 		}
 

--- a/src/components/TextFieldValidated/TextFieldValidated.less
+++ b/src/components/TextFieldValidated/TextFieldValidated.less
@@ -19,5 +19,65 @@
 				border-color: @color-primary;
 			}
 		}
+
+		&.-success-text {
+			.lucid-Validation-error-content {
+				color: @featured-color-success;
+			}
+		}
+
+		&.-success-border {
+			input {
+				border-color: @featured-color-success;
+			}
+		}
+
+		&.-primary-text {
+			.lucid-Validation-error-content {
+				color: @color-primary;
+			}
+		}
+
+		&.-primary-border {
+			input {
+				border-color: @color-primary;
+			}
+		}
+
+		&.-danger-text {
+			.lucid-Validation-error-content {
+				color: @featured-color-danger;
+			}
+		}
+
+		&.-danger-border {
+			input {
+				border-color: @featured-color-danger;
+			}
+		}
+
+		&.-warning-text {
+			.lucid-Validation-error-content {
+				color: @featured-color-warning;
+			}
+		}
+
+		&.-warning-border {
+			input {
+				border-color: @featured-color-warning;
+			}
+		}
+
+		&.-info-text {
+			.lucid-Validation-error-content {
+				color: @color-neutral-6;
+			}
+		}
+
+		&.-info-border {
+			input {
+				border-color: @color-neutral-6;
+			}
+		}
 	}
 }

--- a/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
@@ -27,6 +27,7 @@ describe('TextFieldValidated', () => {
 				'Error',
 				'Info',
 				'initialState',
+				'special',
 			];
 			const style = { height: 20 };
 			const wrapper = shallow(

--- a/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
@@ -27,7 +27,7 @@ describe('TextFieldValidated', () => {
 				'Error',
 				'Info',
 				'initialState',
-				'special',
+				'Success',
 			];
 			const style = { height: 20 };
 			const wrapper = shallow(

--- a/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
@@ -68,10 +68,8 @@ export const ErrorTypes: Story<ITextFieldValidatedProps> = (args) => {
 				value={value}
 				onChangeDebounced={() => {}}
 				Error={null}
-				special={{
-					borderColor: 'success',
-					message: 'This is a special with `success` text and border',
-					textColor: 'success',
+				Success={{
+					message: 'This is a Success',
 				}}
 			/>
 			<TextFieldValidated
@@ -80,23 +78,8 @@ export const ErrorTypes: Story<ITextFieldValidatedProps> = (args) => {
 				value={value}
 				onChangeDebounced={() => {}}
 				Error={null}
-				special={{
-					borderColor: 'primary',
-					message: 'This is a special in the style of an Info',
-					textColor: 'info',
-				}}
-			/>
-			<TextFieldValidated
-				{...args}
-				style={style}
-				value={value}
-				onChangeDebounced={() => {}}
-				Error={null}
-				special={{
-					borderColor: 'success',
-					message:
-						'This is a disappearing special with `success` text and border',
-					textColor: 'success',
+				Success={{
+					message: 'This is a disappearing Success',
 					disappearing: true,
 				}}
 			/>

--- a/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
@@ -62,6 +62,30 @@ export const ErrorTypes: Story<ITextFieldValidatedProps> = (args) => {
 				Error={null}
 				Info={'This is an info'}
 			/>
+			<TextFieldValidated
+				{...args}
+				style={style}
+				value={value}
+				onChangeDebounced={() => {}}
+				Error={null}
+				special={{
+					borderColor: 'success',
+					message: 'This is a special with `success` text and border',
+					textColor: 'success',
+				}}
+			/>
+			<TextFieldValidated
+				{...args}
+				style={style}
+				value={value}
+				onChangeDebounced={() => {}}
+				Error={null}
+				special={{
+					borderColor: 'primary',
+					message: 'This is a special in the style of an Info',
+					textColor: 'info',
+				}}
+			/>
 		</div>
 	);
 };

--- a/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
@@ -23,7 +23,7 @@ const style = {
 };
 
 export const Basic: Story<ITextFieldValidatedProps> = (args) => {
-	return <TextFieldValidated {...args} Error='Nope, not even close!' />;
+	return <TextFieldValidated {...args} />;
 };
 
 export const Debounced: Story<ITextFieldValidatedProps> = (args) => {

--- a/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
@@ -86,6 +86,20 @@ export const ErrorTypes: Story<ITextFieldValidatedProps> = (args) => {
 					textColor: 'info',
 				}}
 			/>
+			<TextFieldValidated
+				{...args}
+				style={style}
+				value={value}
+				onChangeDebounced={() => {}}
+				Error={null}
+				special={{
+					borderColor: 'success',
+					message:
+						'This is a disappearing special with `success` text and border',
+					textColor: 'success',
+					disappearing: true,
+				}}
+			/>
 		</div>
 	);
 };

--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -33,6 +33,11 @@ export interface ITextFieldValidatedProps
 	extends ITextFieldPropsWithPassThroughs {
 	Error?: React.ReactNode;
 	Info?: string;
+	special?: {
+		message: string;
+		textColor: string;
+		borderColor: string;
+	};
 }
 
 export interface ITextFieldValidatedState {
@@ -96,12 +101,35 @@ class TextFieldValidated extends React.Component<
 			);
 		} else if (this.props.Info) {
 			childProps = [this.props.Info];
+		} else if (this.props.special) {
+			childProps = [this.props.special?.message];
 		}
+
+		const isSpecial =
+			!this.props.Error && !this.props.Info && this.props.special;
+
+		const classColorTypes = {
+			'-success-text': isSpecial && this.props.special?.textColor === 'success',
+			'-success-border':
+				isSpecial && this.props.special?.borderColor === 'success',
+			'-primary-text': isSpecial && this.props.special?.textColor === 'primary',
+			'-primary-border':
+				isSpecial && this.props.special?.borderColor === 'primary',
+			'-danger-text': isSpecial && this.props.special?.textColor === 'danger',
+			'-danger-border':
+				isSpecial && this.props.special?.borderColor === 'danger',
+			'-warning-text': isSpecial && this.props.special?.textColor === 'warning',
+			'-warning-border':
+				isSpecial && this.props.special?.borderColor === 'warning',
+			'-info-text': isSpecial && this.props.special?.textColor === 'info',
+			'-info-border': isSpecial && this.props.special?.borderColor === 'info',
+		};
 
 		return (
 			<Validation
 				className={cx('&', className, {
 					'-info': !this.props.Error && this.props.Info,
+					...classColorTypes,
 				})}
 				style={style}
 				Error={childProps}

--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -12,7 +12,7 @@ import { findTypes } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-TextFieldValidated');
 
-const { any, object, string } = PropTypes;
+const { any, object, string, bool } = PropTypes;
 
 export interface ITextFieldValidatedErrorProps extends IValidationProps {
 	description?: string;
@@ -44,6 +44,7 @@ export interface ITextFieldValidatedProps
 		message: string;
 		textColor: string;
 		borderColor: string;
+		disappearing?: boolean;
 	};
 }
 
@@ -88,13 +89,15 @@ class TextFieldValidated extends React.Component<
 		Info: string,
 
 		/**
-			Optional special message that can have the border color and message text styled independently.
+			Optional special message that can have the border color and message text styled independently. Also contains
+		  `disappearing` prop for message that appears and fades away.
 		  Color options for `textColor` and `borderColor`: `['success', 'primary', 'danger', 'warning', 'info']`
 		 */
 		special: shape({
 			message: string,
 			textColor: string,
 			borderColor: string,
+			disappearing: bool,
 		}),
 	};
 
@@ -146,6 +149,7 @@ class TextFieldValidated extends React.Component<
 			<Validation
 				className={cx('&', className, {
 					'-info': !this.props.Error && this.props.Info,
+					'-disappearing': isSpecial && this.props.special?.disappearing,
 					...classColorTypes,
 				})}
 				style={style}

--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { shape } from 'prop-types';
 
 import Validation, { IValidationProps } from '../Validation/Validation';
 import TextField, {
@@ -27,7 +27,14 @@ TextFieldValidatedError.peek = {
 TextFieldValidatedError.propName = 'Error';
 
 /** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
-const nonPassThroughs = ['style', 'className', 'Error', 'Info', 'initialState'];
+const nonPassThroughs = [
+	'style',
+	'className',
+	'Error',
+	'Info',
+	'special',
+	'initialState',
+];
 
 export interface ITextFieldValidatedProps
 	extends ITextFieldPropsWithPassThroughs {
@@ -77,8 +84,18 @@ class TextFieldValidated extends React.Component<
 
 		/**
 			Optional information text that is styled less aggressively than an error
-		*/
+		 */
 		Info: string,
+
+		/**
+			Optional special message that can have the border color and message text styled independently.
+		  Color options for `textColor` and `borderColor`: `['success', 'primary', 'danger', 'warning', 'info']`
+		 */
+		special: shape({
+			message: string,
+			textColor: string,
+			borderColor: string,
+		}),
 	};
 
 	static defaultProps = TextField.defaultProps;

--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -32,7 +32,7 @@ const nonPassThroughs = [
 	'className',
 	'Error',
 	'Info',
-	'special',
+	'Success',
 	'initialState',
 ];
 
@@ -40,10 +40,8 @@ export interface ITextFieldValidatedProps
 	extends ITextFieldPropsWithPassThroughs {
 	Error?: React.ReactNode;
 	Info?: string;
-	special?: {
+	Success?: {
 		message: string;
-		textColor: string;
-		borderColor: string;
 		disappearing?: boolean;
 	};
 }
@@ -89,14 +87,11 @@ class TextFieldValidated extends React.Component<
 		Info: string,
 
 		/**
-			Optional special message that can have the border color and message text styled independently. Also contains
+			Optional information text that is styled as "success". Also contains
 		  `disappearing` prop for message that appears and fades away.
-		  Color options for `textColor` and `borderColor`: `['success', 'primary', 'danger', 'warning', 'info']`
 		 */
-		special: shape({
+		Success: shape({
 			message: string,
-			textColor: string,
-			borderColor: string,
 			disappearing: bool,
 		}),
 	};
@@ -121,36 +116,20 @@ class TextFieldValidated extends React.Component<
 			);
 		} else if (this.props.Info) {
 			childProps = [this.props.Info];
-		} else if (this.props.special) {
-			childProps = [this.props.special?.message];
+		} else if (this.props.Success) {
+			childProps = [this.props.Success?.message];
 		}
 
-		const isSpecial =
-			!this.props.Error && !this.props.Info && this.props.special;
-
-		const classColorTypes = {
-			'-success-text': isSpecial && this.props.special?.textColor === 'success',
-			'-success-border':
-				isSpecial && this.props.special?.borderColor === 'success',
-			'-primary-text': isSpecial && this.props.special?.textColor === 'primary',
-			'-primary-border':
-				isSpecial && this.props.special?.borderColor === 'primary',
-			'-danger-text': isSpecial && this.props.special?.textColor === 'danger',
-			'-danger-border':
-				isSpecial && this.props.special?.borderColor === 'danger',
-			'-warning-text': isSpecial && this.props.special?.textColor === 'warning',
-			'-warning-border':
-				isSpecial && this.props.special?.borderColor === 'warning',
-			'-info-text': isSpecial && this.props.special?.textColor === 'info',
-			'-info-border': isSpecial && this.props.special?.borderColor === 'info',
-		};
+		const isSuccess =
+			!this.props.Error && !this.props.Info && this.props.Success;
 
 		return (
 			<Validation
 				className={cx('&', className, {
 					'-info': !this.props.Error && this.props.Info,
-					'-disappearing': isSpecial && this.props.special?.disappearing,
-					...classColorTypes,
+					'-success':
+						!this.props.Error && !this.props.Info && this.props.Success,
+					'-disappearing': isSuccess && this.props.Success?.disappearing,
 				})}
 				style={style}
 				Error={childProps}

--- a/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
+++ b/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
@@ -100,5 +100,21 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
       This is a special in the style of an Info
     </div>
   </div>
+  <div
+    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -disappearing -success-text -success-border"
+    style="margin-bottom:10px"
+  >
+    <input
+      class="lucid-TextField lucid-TextField-is-single-line"
+      rows="5"
+      type="text"
+      value=""
+    />
+    <div
+      class="lucid-Validation-error-content"
+    >
+      This is a disappearing special with \`success\` text and border
+    </div>
+  </div>
 </div>
 `;

--- a/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
+++ b/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TextFieldValidated [common] example testing should match snapshot(s) for Basic 1`] = `
 <div
-  class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated"
+  class="lucid-Validation lucid-TextFieldValidated"
 >
   <input
     class="lucid-TextField lucid-TextField-is-single-line"
@@ -10,11 +10,6 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
     type="text"
     value=""
   />
-  <div
-    class="lucid-Validation-error-content"
-  >
-    Nope, not even close!
-  </div>
 </div>
 `;
 
@@ -71,6 +66,38 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
       class="lucid-Validation-error-content"
     >
       This is an info
+    </div>
+  </div>
+  <div
+    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -success-text -success-border"
+    style="margin-bottom:10px"
+  >
+    <input
+      class="lucid-TextField lucid-TextField-is-single-line"
+      rows="5"
+      type="text"
+      value=""
+    />
+    <div
+      class="lucid-Validation-error-content"
+    >
+      This is a special with \`success\` text and border
+    </div>
+  </div>
+  <div
+    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -primary-border -info-text"
+    style="margin-bottom:10px"
+  >
+    <input
+      class="lucid-TextField lucid-TextField-is-single-line"
+      rows="5"
+      type="text"
+      value=""
+    />
+    <div
+      class="lucid-Validation-error-content"
+    >
+      This is a special in the style of an Info
     </div>
   </div>
 </div>

--- a/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
+++ b/src/components/TextFieldValidated/__snapshots__/TextFieldValidated.spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
     </div>
   </div>
   <div
-    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -success-text -success-border"
+    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -success"
     style="margin-bottom:10px"
   >
     <input
@@ -81,11 +81,11 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
     <div
       class="lucid-Validation-error-content"
     >
-      This is a special with \`success\` text and border
+      This is a Success
     </div>
   </div>
   <div
-    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -primary-border -info-text"
+    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -success -disappearing"
     style="margin-bottom:10px"
   >
     <input
@@ -97,23 +97,7 @@ exports[`TextFieldValidated [common] example testing should match snapshot(s) fo
     <div
       class="lucid-Validation-error-content"
     >
-      This is a special in the style of an Info
-    </div>
-  </div>
-  <div
-    class="lucid-Validation lucid-Validation-is-error lucid-TextFieldValidated -disappearing -success-text -success-border"
-    style="margin-bottom:10px"
-  >
-    <input
-      class="lucid-TextField lucid-TextField-is-single-line"
-      rows="5"
-      type="text"
-      value=""
-    />
-    <div
-      class="lucid-Validation-error-content"
-    >
-      This is a disappearing special with \`success\` text and border
+      This is a disappearing Success
     </div>
   </div>
 </div>


### PR DESCRIPTION
## PR Checklist

(New PR since [last one](https://github.com/appnexus/lucid/pull/1270) is too out of date)

Update TextFieldValidated to accept a special prop with text and border color strings to style informational messages

Storybook can be viewed [here](https://docspot.adnxs.net/projects/lucid/BUDE-1755/?path=/docs/controls-textfieldvalidated--basic)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
