### PR TITLE
Cxp 2951 text field validated ref error

### DIFF
--- a/src/components/TextField/TextField.spec.tsx
+++ b/src/components/TextField/TextField.spec.tsx
@@ -47,18 +47,15 @@ describe('TextField', () => {
 				'onSubmit',
 				'debounceLevel',
 				'lazyLevel',
-				'ref',
 				'initialState',
 				'callbackId',
 				'children',
 			];
-			const refValue = {};
 			const onChangeDebounced = () => {};
 			const onSubmit = () => {};
 			const wrapper = shallow(
 				<TextField
 					{...defaultProps}
-					ref={refValue}
 					callbackId={0}
 					onChangeDebounced={onChangeDebounced}
 					onSubmit={onSubmit}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -92,9 +92,6 @@ export interface ITextFieldProps extends StandardProps {
 		flowing in to the component until the timer has elapsed.  This was
 		heavily inspired by the [lazy-input](https:/docs.npmjs.com/package/lazy-input) component. */
 	lazyLevel?: number;
-
-	/** A reference to the node accessible at the current attribute of the ref. */
-	ref?: any;
 }
 
 export type ITextFieldPropsWithPassThroughs = Overwrite<
@@ -123,7 +120,6 @@ const nonPassThroughs = [
 	'value',
 	'debounceLevel',
 	'lazyLevel',
-	'ref',
 	'initialState',
 	'callbackId',
 	'children',
@@ -217,15 +213,6 @@ class TextField extends React.Component<
 			[lazy-input](https:/docs.npmjs.com/package/lazy-input) component.
 		*/
 		lazyLevel: number,
-
-		/**
-			 When a ref is passed to an element in render, 
-		 	a reference to the node becomes accessible at the current attribute of the ref.
-		 */
-		ref: oneOfType([
-			PropTypes.func,
-			PropTypes.shape({ current: PropTypes.elementType }),
-		]),
 	};
 
 	state = {

--- a/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import assert from 'assert';
 
 import { common } from '../../util/generic-tests';
@@ -12,6 +12,30 @@ describe('TextFieldValidated', () => {
 	common(TextFieldValidated);
 
 	describe('props', () => {
+		it('Error should display as an error message', () => {
+			const errorMsg = 'Test error!';
+			const wrapper = mount(
+				<TextFieldValidated {...defaultProps} Error={errorMsg} />
+			);
+
+			expect(
+				wrapper.find('.lucid-Validation').hasClass('lucid-Validation-is-error')
+			).toEqual(true);
+			expect(
+				wrapper.find('.lucid-Validation-error-content').contains(errorMsg)
+			).toEqual(true);
+		});
+
+		it('Info should apply the info styling, if there is no error, and an info message', () => {
+			const infoMsg = 'Info message';
+			const wrapper = mount(<TextFieldValidated Error={null} Info={infoMsg} />);
+
+			expect(wrapper.find('.lucid-Validation').hasClass('-info')).toEqual(true);
+			expect(
+				wrapper.find('.lucid-Validation-error-content').contains(infoMsg)
+			).toEqual(true);
+		});
+
 		it('should pass through onBlur prop to TextField', () => {
 			const onBlur = () => {};
 			const wrapper = shallow(
@@ -38,6 +62,7 @@ describe('TextFieldValidated', () => {
 					Info='Info'
 				/>
 			);
+
 			nonPassThroughs.forEach((nonPassThrough) => {
 				assert.strictEqual(
 					wrapper.find(TextField).prop(nonPassThrough),

--- a/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.spec.tsx
@@ -64,11 +64,16 @@ describe('TextFieldValidated', () => {
 			);
 
 			nonPassThroughs.forEach((nonPassThrough) => {
-				assert.strictEqual(
-					wrapper.find(TextField).prop(nonPassThrough),
-					undefined
-				);
+				expect(wrapper.find(TextField).prop(nonPassThrough)).toBe(undefined);
 			});
+		});
+		it('allows certain passthroughs to be spread into TextField subcomponent', () => {
+			const wrapper = shallow(
+				<TextFieldValidated {...defaultProps} callbackId={1} data-testid={10} />
+			);
+
+			expect(wrapper.find(TextField).prop('data-testid')).toBe(10);
+			expect(wrapper.find(TextField).prop('callbackId')).toBe(1);
 		});
 	});
 });

--- a/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
-import createClass from 'create-react-class';
 
 import TextFieldValidated, {
 	ITextFieldValidatedProps,


### PR DESCRIPTION
## PR Checklist

Description of changes:
Fix error warning on ref special prop
Add some more test coverage to TextFieldValidated unit tests

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2951-TextFieldValidated-Ref-Error/?path=/docs/controls-textfieldvalidated--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
