### PR TITLE
Cxp 2571 loading message replace omit props

### DIFF
--- a/src/components/LoadingMessage/LoadingMessage.spec.tsx
+++ b/src/components/LoadingMessage/LoadingMessage.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import assert from 'assert';
+import _, { forEach, has } from 'lodash';
+
 import { common } from '../../util/generic-tests';
 import LoadingMessage from './LoadingMessage';
 import LoadingIcon from '../Icon/LoadingIcon/LoadingIcon';
@@ -123,6 +125,58 @@ describe('LoadingMessage', () => {
 					'A custom body'
 				);
 			});
+		});
+	});
+
+	describe('pass throughs', () => {
+		let wrapper: any;
+
+		beforeEach(() => {
+			const props = {
+				className: 'wut',
+				style: { marginRight: 10 },
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+				Icon: <SuccessIcon />,
+				Title: 'Test Title',
+				Body: 'Test Body',
+			};
+			wrapper = shallow(<LoadingMessage {...props} />);
+		});
+
+		afterEach(() => {
+			wrapper.unmount();
+		});
+
+		it('passes through props not defined in `propTypes` to the root element.', () => {
+			const rootProps = wrapper.find('.lucid-LoadingMessage').props();
+
+			// Note: 'className' is plucked from the pass through object
+			// but still appear becuase they are also directly passed to the root element as a prop.
+			forEach(['className', 'style', 'data-testid', 'children'], (prop) => {
+				expect(has(rootProps, prop)).toBe(true);
+			});
+
+			expect(wrapper.first().prop(['className'])).toContain('wut');
+			expect(wrapper.first().prop(['style'])).toMatchObject({
+				marginRight: 10,
+			});
+			expect(wrapper.first().prop(['data-testid'])).toBe(10);
+		});
+
+		it('omits the props defined in `propTypes` from the root element, plus, in addition, `initialState`.', () => {
+			const rootProps = wrapper.find('.lucid-LoadingMessage').props();
+
+			console.log('rootProps', rootProps);
+			console.log(wrapper.debug());
+			// initialState and callbackId are always both omitted
+			forEach(
+				['Icon', 'Title', 'Body', 'initialState', 'callbackId'],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
 		});
 	});
 });

--- a/src/components/LoadingMessage/LoadingMessage.stories.tsx
+++ b/src/components/LoadingMessage/LoadingMessage.stories.tsx
@@ -1,0 +1,36 @@
+import _ from 'lodash';
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+
+import LoadingMessage, { ILoadingMessageProps } from './LoadingMessage';
+
+export default {
+	title: 'Loading Message/LoadingMessage',
+	component: LoadingMessage,
+	parameters: {
+		docs: {
+			description: {
+				component: LoadingMessage.peek.description,
+			},
+		},
+		layout: 'centered',
+	},
+} as Meta;
+
+export const Basic: Story<ILoadingMessageProps> = (args) => {
+	return <LoadingMessage />;
+};
+
+export const CustomTitle: Story<ILoadingMessageProps> = (args) => {
+	return <LoadingMessage {...args} />;
+};
+CustomTitle.args = {
+	Title: 'A custom title',
+};
+
+export const CustomBody: Story<ILoadingMessageProps> = (args) => {
+	return <LoadingMessage {...args} />;
+};
+CustomBody.args = {
+	Body: 'A custom body',
+};

--- a/src/components/LoadingMessage/LoadingMessage.tsx
+++ b/src/components/LoadingMessage/LoadingMessage.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/prop-types */
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
-import { getFirst, omitProps, StandardProps } from '../../util/component-types';
+import { getFirst, StandardProps } from '../../util/component-types';
 import LoadingIcon from '../Icon/LoadingIcon/LoadingIcon';
 
 const cx = lucidClassNames.bind('&-LoadingMessage');
@@ -88,7 +88,15 @@ export const LoadingMessage = (
 
 	return (
 		<div
-			{...omitProps(passThroughs, undefined, _.keys(LoadingMessage.propTypes))}
+			{...omit(passThroughs, [
+				'className',
+				'children',
+				'Icon',
+				'Title',
+				'Body',
+				'initialState',
+				'callbackId',
+			])}
 			className={cx(
 				'&',
 				{ '&-no-content': _.isNull(titleChildren) && !bodyChildren },

--- a/src/components/LoadingMessage/__snapshots__/LoadingMessage.spec.tsx.snap
+++ b/src/components/LoadingMessage/__snapshots__/LoadingMessage.spec.tsx.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoadingMessage [common] example testing should match snapshot(s) for Basic 1`] = `
+<div
+  class="lucid-LoadingMessage"
+>
+  <svg
+    class="lucid-Icon lucid-Icon-color-primary lucid-LoadingIcon"
+    height="16"
+    preserveAspectRatio="xMidYMid meet"
+    style="animation-duration:1.25s"
+    viewBox="0 0 100 100"
+    width="16"
+  >
+    <rect
+      fill="none"
+      height="100"
+      width="100"
+      x="0"
+      y="0"
+    />
+    <circle
+      class="lucid-LoadingIcon-circle"
+      cx="50"
+      cy="50"
+      r="40"
+    />
+    <circle
+      class="lucid-LoadingIcon-spinner"
+      cx="50"
+      cy="50"
+      r="40"
+      style="animation-duration:1.25s"
+    />
+  </svg>
+  <h3
+    class="lucid-LoadingMessage-title"
+  >
+    Loading
+  </h3>
+</div>
+`;
+
+exports[`LoadingMessage [common] example testing should match snapshot(s) for CustomBody 1`] = `
+<div
+  class="lucid-LoadingMessage"
+>
+  <svg
+    class="lucid-Icon lucid-Icon-color-primary lucid-LoadingIcon"
+    height="16"
+    preserveAspectRatio="xMidYMid meet"
+    style="animation-duration:1.25s"
+    viewBox="0 0 100 100"
+    width="16"
+  >
+    <rect
+      fill="none"
+      height="100"
+      width="100"
+      x="0"
+      y="0"
+    />
+    <circle
+      class="lucid-LoadingIcon-circle"
+      cx="50"
+      cy="50"
+      r="40"
+    />
+    <circle
+      class="lucid-LoadingIcon-spinner"
+      cx="50"
+      cy="50"
+      r="40"
+      style="animation-duration:1.25s"
+    />
+  </svg>
+  <h3
+    class="lucid-LoadingMessage-title"
+  >
+    Loading
+  </h3>
+  <span
+    class="lucid-LoadingMessage-body"
+  >
+    A custom body
+  </span>
+</div>
+`;
+
+exports[`LoadingMessage [common] example testing should match snapshot(s) for CustomTitle 1`] = `
+<div
+  class="lucid-LoadingMessage"
+>
+  <svg
+    class="lucid-Icon lucid-Icon-color-primary lucid-LoadingIcon"
+    height="16"
+    preserveAspectRatio="xMidYMid meet"
+    style="animation-duration:1.25s"
+    viewBox="0 0 100 100"
+    width="16"
+  >
+    <rect
+      fill="none"
+      height="100"
+      width="100"
+      x="0"
+      y="0"
+    />
+    <circle
+      class="lucid-LoadingIcon-circle"
+      cx="50"
+      cy="50"
+      r="40"
+    />
+    <circle
+      class="lucid-LoadingIcon-spinner"
+      cx="50"
+      cy="50"
+      r="40"
+      style="animation-duration:1.25s"
+    />
+  </svg>
+  <h3
+    class="lucid-LoadingMessage-title"
+  >
+    A custom title
+  </h3>
+</div>
+`;

--- a/src/components/SidePanel/SidePanel.spec.tsx
+++ b/src/components/SidePanel/SidePanel.spec.tsx
@@ -1,3 +1,4 @@
+import _, { forEach, has } from 'lodash';
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 
@@ -8,6 +9,101 @@ import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
 
 describe('SidePanel', () => {
 	common(SidePanel);
+
+	describe('pass throughs', () => {
+		let wrapper: any;
+		const defaultProps = SidePanel.defaultProps;
+
+		beforeEach(() => {
+			const props = {
+				...defaultProps,
+				className: 'wut',
+				isModal: false,
+				isExpanded: false,
+				isAnimated: false,
+				isResizeDisabled: true,
+				position: 'left' as any,
+				preventBodyScroll: true,
+				topOffset: 10,
+				width: 1000,
+				minWidth: 500,
+				maxWidth: 2000,
+				style: { marginRight: 10 },
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+				Header: (
+					<div>
+						<strong>Rich content</strong>
+					</div>
+				),
+			};
+			wrapper = shallow(<SidePanel {...props} />);
+		});
+
+		afterEach(() => {
+			wrapper.unmount();
+		});
+
+		it('passes through props not defined in `propTypes` to the root element.', () => {
+			const rootProps = wrapper.find('.lucid-SidePanel').props();
+
+			// Note: 'className', 'style' and 'isAnimated' are plucked from the pass through object
+			// but still appear becuase they are also directly passed to the root `Overlay` element as a prop.
+			// 'isShown' appears because it is calculated based on the 'isExpanded' prop.
+			// The root `Overlay` element is not a DOM element so 'callbackId', if it exists, is also passed through.
+			forEach(
+				[
+					'className',
+					'isShown',
+					'onEscape',
+					'isAnimated',
+					'style',
+					'isModal',
+					'data-testid',
+					'callbackId',
+					'children',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				}
+			);
+
+			expect(wrapper.first().prop(['className'])).toContain('wut');
+			expect(wrapper.first().prop(['isShown'])).toBe(false); // set based on isExpaneded
+			expect(wrapper.first().prop(['isAnimated'])).toBe(false);
+			expect(wrapper.first().prop(['isModal'])).toBe(false);
+			expect(wrapper.first().prop(['style'])).toMatchObject({
+				marginRight: 10,
+			});
+			expect(wrapper.first().prop(['data-testid'])).toBe(10);
+			expect(wrapper.first().prop(['callbackId'])).toBe(1);
+		});
+
+		it('omits the props defined in `propTypes` from the root element, plus, in addition, `initialState`.', () => {
+			const rootProps = wrapper.find('.lucid-SidePanel').props();
+
+			forEach(
+				[
+					'Header',
+					'isExpanded',
+					'isResizeDisabled',
+					'onCollapse',
+					'onResize',
+					'position',
+					'preventBodyScroll',
+					'width',
+					'minWidth',
+					'maxWidth',
+					'topOffset',
+					'initialState',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
+		});
+	});
 
 	describe('Events', () => {
 		describe('onCollapse', () => {
@@ -85,8 +181,23 @@ describe('SidePanel', () => {
 	});
 
 	describe('position', () => {
-		it('should match snapshot', () => {
+		it('should match snapshot and apply the appropriate class', () => {
 			const wrapper = shallow(<SidePanel position='left' />);
+			expect(
+				wrapper
+					.find('.lucid-SidePanel')
+					.hasClass('lucid-SidePanel-position-left')
+			).toEqual(true);
+			expect(wrapper).toMatchSnapshot();
+		});
+
+		it('should match snapshot and apply the appropriate class', () => {
+			const wrapper = shallow(<SidePanel position='right' />);
+			expect(
+				wrapper
+					.find('.lucid-SidePanel')
+					.hasClass('lucid-SidePanel-position-right')
+			).toEqual(true);
 			expect(wrapper).toMatchSnapshot();
 		});
 	});
@@ -99,16 +210,25 @@ describe('SidePanel', () => {
 	});
 
 	describe('isAnimated', () => {
-		it('should match snapshot', () => {
-			const wrapper = shallow(<SidePanel isAnimated={false} />);
+		it('should match snapshot and apply the appropriate class', () => {
+			const wrapper = shallow(<SidePanel isAnimated={true} />);
+			expect(
+				wrapper.find('.lucid-SidePanel').hasClass('lucid-SidePanel-is-animated')
+			).toEqual(true);
 			expect(wrapper).toMatchSnapshot();
 		});
 	});
 
 	describe('isExpanded', () => {
-		it('should match snapshot', () => {
-			const wrapper = shallow(<SidePanel isExpanded={false} />);
+		it('should match snapshot and apply the appropriate class', () => {
+			const wrapper = shallow(<SidePanel isExpanded={true} />);
+
+			wrapper.setState({ isExpanded: true });
+
 			expect(wrapper).toMatchSnapshot();
+			expect(
+				wrapper.find('.lucid-SidePanel').hasClass('lucid-SidePanel-is-expanded')
+			).toEqual(true);
 		});
 	});
 

--- a/src/components/SidePanel/SidePanel.stories.tsx
+++ b/src/components/SidePanel/SidePanel.stories.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+
 import Panel from '../Panel/Panel';
-import SidePanel from './SidePanel';
+import SidePanel, { ISidePanelProps } from './SidePanel';
 import ResponsiveGrid from '../ResponsiveGrid/ResponsiveGrid';
 
 export default {
@@ -9,566 +11,458 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (SidePanel as any).peek.description,
+				component: SidePanel.peek.description,
 			},
 		},
 	},
-};
+	args: SidePanel.defaultProps,
+} as Meta;
 
 /* No Modal */
-export const NoModal = () => {
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
+export const NoModal: Story<ISidePanelProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
-		render() {
-			return (
-				<section>
-					<p>
-						modal can be disabled in the underlying Overlay component to allow
-						interaction with the background
-					</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
+	return (
+		<section>
+			<p>
+				modal can be disabled in the underlying Overlay component to allow
+				interaction with the background
+			</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-					<SidePanel
-						isModal={false}
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-						Header='Stumptown keytar schlitz'
-					>
-						<p>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+			<SidePanel
+				isModal={false}
+				isExpanded={isExpanded}
+				onCollapse={handleToggle}
+				Header='Stumptown keytar schlitz'
+			>
+				<p>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-NoModal.storyName = 'NoModal';
 
 /* With Defaults */
-export const WithDefaults = () => {
+export const WithDefaults: Story<ISidePanelProps> = (args) => {
 	const margins = {
 		margin: '0 0 16px 0',
 	};
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
+	return (
+		<section>
+			<p>expand and collapse SidePanel by passing the isExpanded prop</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-		render() {
-			return (
-				<section>
-					<p>expand and collapse SidePanel by passing the isExpanded prop</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
-
-					<SidePanel
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-					>
-						<p style={margins}>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p style={margins}>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+			<SidePanel isExpanded={isExpanded} onCollapse={handleToggle}>
+				<p style={margins}>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p style={margins}>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-WithDefaults.storyName = 'WithDefaults';
 
 /* With Header */
-export const WithHeader = () => {
+export const WithHeader: Story<ISidePanelProps> = (args) => {
 	const margins = {
 		margin: '0 0 16px 0',
 	};
 
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
+	return (
+		<section>
+			<p>render a header with a close button</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-		render() {
-			return (
-				<section>
-					<p>render a header with a close button</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
-
-					<SidePanel
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-						width={500}
-					>
-						<SidePanel.Header>
-							<div>
-								<div>
-									<strong>Rich content</strong>
-								</div>
-							</div>
-						</SidePanel.Header>
-						<p style={margins}>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p style={margins}>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+			<SidePanel isExpanded={isExpanded} onCollapse={handleToggle} width={500}>
+				<SidePanel.Header>
+					<div>
+						<div>
+							<strong>Rich content</strong>
+						</div>
+					</div>
+				</SidePanel.Header>
+				<p style={margins}>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p style={margins}>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-WithHeader.storyName = 'WithHeader';
 
 /* With Left Position */
-export const WithLeftPosition = () => {
+export const WithLeftPosition: Story<ISidePanelProps> = (args) => {
 	const margins = {
 		margin: '0 0 16px 0',
 	};
 
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
+	return (
+		<section>
+			<p>position of the SidePanel can be aligned on either side of the page</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-		render() {
-			return (
-				<section>
-					<p>
-						position of the SidePanel can be aligned on either side of the page
-					</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
-
-					<SidePanel
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-						position='left'
-						Header='Stumptown keytar schlitz'
-					>
-						<p style={margins}>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p style={margins}>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+			<SidePanel
+				isExpanded={isExpanded}
+				onCollapse={handleToggle}
+				position='left'
+				Header='Stumptown keytar schlitz'
+			>
+				<p style={margins}>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p style={margins}>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-WithLeftPosition.storyName = 'WithLeftPosition';
 
 /* Without Animation */
-export const WithoutAnimation = () => {
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
+export const WithoutAnimation: Story<ISidePanelProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
+	return (
+		<section>
+			<p>transition animations can be disabled if desired</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-		render() {
-			return (
-				<section>
-					<p>transition animations can be disabled if desired</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
-
-					<SidePanel
-						isAnimated={false}
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-						Header='Stumptown keytar schlitz'
-					>
-						<p>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+			<SidePanel
+				isAnimated={false}
+				isExpanded={isExpanded}
+				onCollapse={handleToggle}
+				Header='Stumptown keytar schlitz'
+			>
+				<p>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-WithoutAnimation.storyName = 'WithoutAnimation';
 
 /* Without Resize */
-export const WithoutResize = () => {
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
+export const WithoutResize: Story<ISidePanelProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
-		render() {
-			return (
-				<section>
-					<p>prevent resizing width by hiding the resizer</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
+	return (
+		<section>
+			<p>prevent resizing width by hiding the resizer</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-					<SidePanel
-						isResizeDisabled
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-						Header='Stumptown keytar schlitz'
-					>
-						<p>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+			<SidePanel
+				isResizeDisabled
+				isExpanded={isExpanded}
+				onCollapse={handleToggle}
+				Header='Stumptown keytar schlitz'
+			>
+				<p>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-WithoutResize.storyName = 'WithoutResize';
 
 /* With Resize */
-export const WithResize = () => {
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true, width: 240 };
-			this.handleToggle = this.handleToggle.bind(this);
-			this.handleResize = this.handleResize.bind(this);
-		}
+export const WithResize: Story<ISidePanelProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(true);
+	const [width, setWidth] = useState(240);
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
-		handleResize(width: any) {
-			this.setState({
-				width,
-			});
-		}
+	const handleResize = (width) => {
+		setWidth(width);
+	};
 
-		render() {
-			return (
-				<section>
-					<p>resized width is obtatined with a callback</p>
-					<p>SidePanel width: {this.state.width}</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
+	return (
+		<section>
+			<p>resized width is obtatined with a callback</p>
+			<p>SidePanel width: {width}</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-					<SidePanel
-						isExpanded={this.state.isExpanded}
-						width={this.state.width}
-						onCollapse={this.handleToggle}
-						Header='Stumptown keytar schlitz'
-						onResize={this.handleResize}
-					>
-						<p>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+			<SidePanel
+				isExpanded={isExpanded}
+				width={width}
+				onCollapse={handleToggle}
+				Header='Stumptown keytar schlitz'
+				onResize={handleResize}
+			>
+				<p>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-WithResize.storyName = 'WithResize';
 
 /* With Top Margin */
-export const WithTopMargin = () => {
+export const WithTopMargin: Story<ISidePanelProps> = (args) => {
 	const margins = {
 		margin: '0 0 16px 0',
 	};
-	class Component extends React.Component<any, any> {
-		constructor(props: any, state: any) {
-			super(props, state);
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
 
-		handleToggle() {
-			this.setState({
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		render() {
-			return (
-				<section>
-					<p>render the component with a top margin</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
-					<SidePanel
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-						topOffset={50}
-					>
-						<SidePanel.Header>
-							<div>
-								<div>
-									<strong>Rich content</strong>
-								</div>
-							</div>
-						</SidePanel.Header>
-						<p style={margins}>
-							Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
-							crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-							helvetica kitsch farm-to-table thundercats. Occupy hammock
-							waistcoat pabst ethical. Sartorial umami cardigan, farm-to-table
-							bespoke 90's schlitz cray drinking vinegar actually freegan
-							bushwick wolf. Shabby chic tofu celiac shaman, twee af squid blue
-							bottle street art. Lumbersexual lo-fi stumptown, iceland locavore
-							tacos chillwave portland beard celiac polaroid.
-						</p>
-						<p style={margins}>
-							Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk
-							four loko selfies ramps pop-up coloring book before they sold out
-							yuccie biodiesel. Yuccie taxidermy beard, +1 church-key umami echo
-							park synth. Fanny pack farm-to-table pok pok, next level trust
-							fund live-edge asymmetrical art party intelligentsia listicle
-							sriracha. Tote bag ugh meggings, selfies vegan blog locavore
-							messenger bag chambray etsy heirloom cronut enamel pin hammock
-							umami. Bushwick venmo activated charcoal, mumblecore skateboard
-							hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
-							sold out blog iPhone subway tile, truffaut dreamcatcher organic
-							raclette portland whatever brooklyn succulents flexitarian
-							gentrify cray. Kogi subway tile gochujang dreamcatcher.
-						</p>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+	return (
+		<section>
+			<p>render the component with a top margin</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
+
+			<SidePanel
+				isExpanded={isExpanded}
+				onCollapse={handleToggle}
+				topOffset={50}
+			>
+				<SidePanel.Header>
+					<div>
+						<div>
+							<strong>Rich content</strong>
+						</div>
+					</div>
+				</SidePanel.Header>
+				<p style={margins}>
+					Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+					crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+					helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+					pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+					schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+					chic tofu celiac shaman, twee af squid blue bottle street art.
+					Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+					portland beard celiac polaroid.
+				</p>
+				<p style={margins}>
+					Keffiyeh kinfolk lumbersexual, austin ennui sustainable mlkshk four
+					loko selfies ramps pop-up coloring book before they sold out yuccie
+					biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+					synth. Fanny pack farm-to-table pok pok, next level trust fund
+					live-edge asymmetrical art party intelligentsia listicle sriracha.
+					Tote bag ugh meggings, selfies vegan blog locavore messenger bag
+					chambray etsy heirloom cronut enamel pin hammock umami. Bushwick venmo
+					activated charcoal, mumblecore skateboard hashtag literally brooklyn
+					etsy ennui 3 wolf moon. Before they sold out blog iPhone subway tile,
+					truffaut dreamcatcher organic raclette portland whatever brooklyn
+					succulents flexitarian gentrify cray. Kogi subway tile gochujang
+					dreamcatcher.
+				</p>
+			</SidePanel>
+		</section>
+	);
 };
-WithTopMargin.storyName = 'WithTopMargin';
 
 /* With Responsive Grid */
-export const WithResponsiveGrid = () => {
-	class Component extends React.Component {
-		//@ts-ignore
-		constructor(...args) {
-			//@ts-ignore
-			super(...(args as any[]));
-			this.state = { isExpanded: true };
-			this.handleToggle = this.handleToggle.bind(this);
-		}
+export const WithResponsiveGrid: Story<ISidePanelProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(true);
 
-		handleToggle() {
-			this.setState({
-				//@ts-ignore
-				isExpanded: !this.state.isExpanded,
-			});
-		}
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
-		render() {
-			return (
-				<section>
-					<p>
-						modal can be disabled in the underlying Overlay component to allow
-						interaction with the background
-					</p>
-					<button onClick={this.handleToggle}>Toggle SidePanel</button>
+	return (
+		<section>
+			<p>
+				modal can be disabled in the underlying Overlay component to allow
+				interaction with the background
+			</p>
+			<button onClick={handleToggle}>Toggle SidePanel</button>
 
-					<SidePanel
-						isModal={false}
-						//@ts-ignore
-						isExpanded={this.state.isExpanded}
-						onCollapse={this.handleToggle}
-						Header='Stumptown keytar schlitz'
-					>
-						<div>
-							<Panel hasMargin={false} style={{ marginBottom: '12px' }}>
+			<SidePanel
+				isModal={false}
+				isExpanded={isExpanded}
+				onCollapse={handleToggle}
+				Header='Stumptown keytar schlitz'
+			>
+				<div>
+					<Panel hasMargin={false} style={{ marginBottom: '12px' }}>
+						Stumptown keytar schlitz, vinyl vexillologist humblebrag sartorial
+						crucifix cornhole. Four dollar toast 8-bit taiyaki asymmetrical
+						helvetica kitsch farm-to-table thundercats. Occupy hammock waistcoat
+						pabst ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+						schlitz cray drinking vinegar actually freegan bushwick wolf. Shabby
+						chic tofu celiac shaman, twee af squid blue bottle street art.
+						Lumbersexual lo-fi stumptown, iceland locavore tacos chillwave
+						portland beard celiac polaroid.
+					</Panel>
+					<ResponsiveGrid breakPoints={[480, 960]}>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>1</Panel.Header>
 								Stumptown keytar schlitz, vinyl vexillologist humblebrag
 								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
 								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
@@ -577,289 +471,260 @@ export const WithResponsiveGrid = () => {
 								actually freegan bushwick wolf. Shabby chic tofu celiac shaman,
 								twee af squid blue bottle street art. Lumbersexual lo-fi
 								stumptown, iceland locavore tacos chillwave portland beard
-								celiac polaroid.
+								celiac polaroid Keffiyeh kinfolk lumbersexual, austin ennui
+								sustainable mlkshk four loko selfies ramps pop-up coloring book
+								before they sold out yuccie biodiesel. Yuccie taxidermy beard,
+								+1 church-key umami echo park synth. Fanny pack farm-to-table
+								pok pok, next level trust fund live-edge asymmetrical art party
+								intelligentsia listicle sriracha. Tote bag ugh meggings, selfies
+								vegan blog locavore messenger bag chambray etsy heirloom cronut
+								enamel pin hammock umami. Bushwick venmo activated charcoal,
+								mumblecore skateboard hashtag literally brooklyn etsy ennui 3
+								wolf moon. Before they sold out blog iPhone subway tile,
+								truffaut dreamcatcher organic raclette portland whatever
+								brooklyn succulents flexitarian gentrify cray. Kogi subway tile
+								gochujang dreamcatcher.
 							</Panel>
-							<ResponsiveGrid breakPoints={[480, 960]}>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>1</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art.
-										Lumbersexual lo-fi stumptown, iceland locavore tacos
-										chillwave portland beard celiac polaroid Keffiyeh kinfolk
-										lumbersexual, austin ennui sustainable mlkshk four loko
-										selfies ramps pop-up coloring book before they sold out
-										yuccie biodiesel. Yuccie taxidermy beard, +1 church-key
-										umami echo park synth. Fanny pack farm-to-table pok pok,
-										next level trust fund live-edge asymmetrical art party
-										intelligentsia listicle sriracha. Tote bag ugh meggings,
-										selfies vegan blog locavore messenger bag chambray etsy
-										heirloom cronut enamel pin hammock umami. Bushwick venmo
-										activated charcoal, mumblecore skateboard hashtag literally
-										brooklyn etsy ennui 3 wolf moon. Before they sold out blog
-										iPhone subway tile, truffaut dreamcatcher organic raclette
-										portland whatever brooklyn succulents flexitarian gentrify
-										cray. Kogi subway tile gochujang dreamcatcher.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>2</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby xitarian
-										gentrify cray. Kogi subway tile gochujang dreamcatcher.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>3</Panel.Header>
-										trust fund live-edge asymmetrical art party intelligentsia
-										listicle sriracha. Tote bag ugh meggings, selfies vegan blog
-										locavore messenger bag chambray etsy heirloom cronut enamel
-										pin hammock umami. Bushwick venmo activated charcoal,
-										mumblecore skateboard hashtag literally brooklyn etsy ennui
-										3 wolf moon. Before they sold out blog iPhone subway tile,
-										truffaut dreamcatcher organic raclette portland whatever
-										brooklyn succulents flexitarian gentrify cray. Kogi subway
-										tile gochujang dreamcatcher.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>4</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art.
-										Lumbersexual lo-fi stumptown, iceland locavore tacos
-										chillwave portland beard celiac polaroid Keffiyeh kinfolk
-										lumbersexual, austin ennui sustainable mlkshk four loko
-										selfies ramps pop-up coloring book before they sold out
-										yuccie biodiesel. Yuccie taxidermy beard, +1 church-key
-										umami echo park synth. Fanny pack farm-to-table pok pok,
-										next level trust fund live-edge asymmetrical art party
-										intelligentsia listicle sriracha. Tote bag ugh meggings,
-										selfies vegan blog locavore messenger bag chambray etsy
-										heirloom cronut enamel pin hammock umami. Bushwick venmo
-										activated charcoal, mumblecore skateboard hashtag literally
-										brooklyn etsy ennui 3 wolf moon. Before they sold out blog
-										iPhone subway tile, truffaut dreamcatcher organic raclette
-										portland whatever brooklyn succulents flexitarian gentrify
-										cray. Kogi subway tile gochujang dreamcatcher crucifix
-										cornhole. Four dollar toast 8-bit taiyaki asymmetrical
-										helvetica kitsch farm-to-table thundercats. Occupy hammock
-										waistcoat pabst ethical. Sartorial umami cardigan,
-										farm-to-table bespoke 90's schlitz cray drinking vinegar
-										actually freegan bushwick wolf. Shabby chic tofu celiac
-										shaman, twee af squid blue bottle street art. Lumbersexual
-										lo-fi stumptown, iceland locavore tacos chillwave.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>5</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art.
-										Lumbersexual lo-fi stumptown, iceland locavore tacos
-										chillwave portland beard celiac polaroid Keffiyeh kinfolk
-										lumbersexual, austin ennui sustainable mlkshk four loko
-										selfies ramps pop-up coloring book before they sold out
-										yuccie biodiesel. Yuccie taxidermy beard, +1 church-key
-										umami echo park synth. Fanny pack farm-to-table pok pok,
-										next level trust fund live-edge asymmetrical art party
-										intelligentsia listicle sriracha. Tote bag ugh meggings,
-										selfies vegan blog locavore messenger bag chambray etsy
-										heirloom cronut enamel pin hammock umami. Bushwick venmo
-										activated charcoal, mumblecore skateboard hashtag literally
-										brooklyn etsy ennui 3 wolf moon. Before they sold out blog
-										iPhone subway tile, truffaut dreamcatcher organic raclette
-										portland whatever brooklyn succulents flexitarian gentrify
-										cray. Kogi subway tile gochujang dreamcatcher.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>6</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art.
-										brooklyn etsy ennui 3 wolf moon. Before they sold out blog
-										iPhone subway tile, truffaut dreamcatcher organic raclette
-										portland whatever brooklyn succulents flexitarian gentrify
-										cray. Kogi subway tile gochujang dreamcatcher Lumbersexual
-										lo-fi stumptown, iceland locavore tacos chillwave portland
-										beard celiac polaroid Keffiyeh kinfolk lumbersexual, austin
-										ennui sustainable mlkshk four loko selfies ramps pop-up
-										coloring book before they sold out yuccie biodiesel. Yuccie
-										taxidermy beard, +1 church-key umami echo park synth. Fanny
-										pack farm-to-table pok pok, next level trust fund live-edge
-										asymmetrical art party intelligentsia listicle sriracha.
-										Tote bag ugh meggings, selfies vegan blog locavore messenger
-										bag chambray etsy heirloom cronut enamel pin hammock umami.
-										Bushwick venmo activated charcoal, mumblecore skateboard
-										hashtag literally brooklyn etsy ennui 3 wolf moon. Before
-										they sold out blog iPhone subway tile, truffaut dreamcatcher
-										organic raclette portland whatever brooklyn succulents
-										flexitarian gentrify cray. Kogi subway tile gochujang
-										dreamcatcher.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>7</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>8</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art. they
-										sold out yuccie biodiesel. Yuccie taxidermy beard, +1
-										church-key umami echo park synth. Fanny pack farm-to-table
-										pok pok, next level trust fund live-edge asymmetrical art
-										party intelligentsia listicle sriracha. Tote bag ugh
-										meggings, selfies vegan blog locavore messenger bag chambray
-										etsy heirloom cronut enamel pin hammock umami. Bushwick
-										venmo activated charcoal, mumblecore skateboard hashtag
-										literally brooklyn etsy ennui 3 wolf moon. Before they sold
-										out blog iPhone subway tile, truffaut dreamcatcher organic
-										raclette portland whatever brooklyn succulents flexitarian
-										gentrify cray. Kogi subway tile gochujang dreamcatcher.
-										kitsch farm-to-table thundercats. Occupy hammock waistcoat
-										pabst ethical. Sartorial umami cardigan, farm-to-table
-										bespoke 90's schlitz cray drinking vinegar actually freegan
-										bushwick wolf. Shabby chic tofu celiac shaman, twee af squid
-										blue bottle street art. they sold out yuccie biodiesel.
-										Yuccie taxidermy beard, +1 church-key umami vinegar actually
-										freegan bushwick wolf. Shabby chic tofu celiac shaman, twee
-										af squid blue bottle street art. they sold out yuccie
-										biodiesel. Yuccie taxidermy beard, +1 church-key umami
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>9</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art.
-										Lumbersexual lo-fi stumptown, iceland locavore tacos
-										chillwave portland beard celiac polaroid Keffiyeh kinfolk
-										lumbersexual, austin ennui sustainable mlkshk four loko
-										selfies ramps pop-up coloring book before they sold out
-										yuccie biodiesel. Yuccie taxidermy beard, +1 church-key
-										umami echo park synth. Fanny pack farm-to-table pok pok,
-										next level trust fund live-edge asymmetrical art party
-										intelligentsia listicle sriracha. Tote bag ugh meggings,
-										selfies vegan blog locavore messenger bag chambray etsy
-										heirloom cronut enamel pin hammock umami. Bushwick venmo
-										activated charcoal, mumblecore skateboard hashtag literally
-										brooklyn etsy ennui 3 wolf moon. Before they sold out blog
-										iPhone subway tile, truffaut dreamcatcher organic raclette
-										portland whatever brooklyn succulents flexitarian gentrify
-										cray. Kogi subway tile gochujang dreamcatcher. Stumptown
-										keytar schlitz, vinyl vexillologist humblebrag sartorial
-										crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art.
-										Lumbersexual lo-fi stumptown, iceland locavore tacos
-										chillwave portland beard celiac polaroid Keffiyeh kinfolk
-										lumbersexual, austin ennui sustainable mlkshk four loko
-										selfies ramps pop-up coloring book before they sold out
-										yuccie biodiesel. Yuccie taxidermy beard, +1 church-key
-										umami echo park synth. Fanny pack farm-to-table pok pok,
-										next level trust fund live-edge asymmetrical art party
-										intelligentsia listicle sriracha. Tote bag ugh meggings,
-										selfies vegan blog locavore messenger bag chambray etsy
-										heirloom cronut enamel pin hammock umami. Bushwick venmo
-										activated charcoal, mumblecore skateboard hashtag literally
-										brooklyn etsy ennui 3 wolf moon. Before they sold out blog
-										iPhone subway tile, truffaut dreamcatcher organic raclette
-										portland whatever brooklyn succulents flexitarian gentrify
-										cray. Kogi subway tile gochujang dreamcatcher.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>10</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst ethical. Sartorial umami
-										cardigan, farm-to-table bespoke 90's schlitz cray drinking
-										vinegar actually freegan bushwick wolf. Shabby chic tofu
-										celiac shaman, twee af squid blue bottle street art.
-										Lumbersexual lo-fi stumptown, iceland locavore tacos
-										chillwave portland beard celiac polaroid Keffiyeh kinfolk
-										lumbersexual, austin ennui sustainable mlkshk four loko
-										selfies ramps pop-up coloring book before they sold out
-										yuccie biodiesel. Yuccie taxidermy beard, +1 church-key
-										umami echo park synth. Fanny pack farm-to-table pok pok,
-										next level trust fund live-edge asymmetrical art party
-										intelligentsia listicle sriracha. Tote bag ugh meggings,
-										selfies vegan blog locavore messenger bag chambray etsy
-										heirloom cronut enamel pin hammock umami. Bushwick venmo
-										activated charcoal, mumblecore skateboard hashtag literally
-										brooklyn etsy ennui 3 wolf moon. Before they sold out blog
-										iPhone subway tile, truffaut dreamcatcher organic raclette
-										portland whatever brooklyn succulents flexitarian gentrify
-										cray. Kogi subway tile gochujang dreamcatcher.
-									</Panel>
-								</ResponsiveGrid.Cell>
-								<ResponsiveGrid.Cell>
-									<Panel hasMargin={false}>
-										<Panel.Header>11</Panel.Header>
-										Stumptown keytar schlitz, vinyl vexillologist humblebrag
-										sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
-										asymmetrical helvetica kitsch farm-to-table thundercats.
-										Occupy hammock waistcoat pabst.
-									</Panel>
-								</ResponsiveGrid.Cell>
-							</ResponsiveGrid>
-						</div>
-					</SidePanel>
-				</section>
-			);
-		}
-	}
-	return <Component />;
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>2</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby xitarian gentrify cray.
+								Kogi subway tile gochujang dreamcatcher.
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>3</Panel.Header>
+								trust fund live-edge asymmetrical art party intelligentsia
+								listicle sriracha. Tote bag ugh meggings, selfies vegan blog
+								locavore messenger bag chambray etsy heirloom cronut enamel pin
+								hammock umami. Bushwick venmo activated charcoal, mumblecore
+								skateboard hashtag literally brooklyn etsy ennui 3 wolf moon.
+								Before they sold out blog iPhone subway tile, truffaut
+								dreamcatcher organic raclette portland whatever brooklyn
+								succulents flexitarian gentrify cray. Kogi subway tile gochujang
+								dreamcatcher.
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>4</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby chic tofu celiac shaman,
+								twee af squid blue bottle street art. Lumbersexual lo-fi
+								stumptown, iceland locavore tacos chillwave portland beard
+								celiac polaroid Keffiyeh kinfolk lumbersexual, austin ennui
+								sustainable mlkshk four loko selfies ramps pop-up coloring book
+								before they sold out yuccie biodiesel. Yuccie taxidermy beard,
+								+1 church-key umami echo park synth. Fanny pack farm-to-table
+								pok pok, next level trust fund live-edge asymmetrical art party
+								intelligentsia listicle sriracha. Tote bag ugh meggings, selfies
+								vegan blog locavore messenger bag chambray etsy heirloom cronut
+								enamel pin hammock umami. Bushwick venmo activated charcoal,
+								mumblecore skateboard hashtag literally brooklyn etsy ennui 3
+								wolf moon. Before they sold out blog iPhone subway tile,
+								truffaut dreamcatcher organic raclette portland whatever
+								brooklyn succulents flexitarian gentrify cray. Kogi subway tile
+								gochujang dreamcatcher crucifix cornhole. Four dollar toast
+								8-bit taiyaki asymmetrical helvetica kitsch farm-to-table
+								thundercats. Occupy hammock waistcoat pabst ethical. Sartorial
+								umami cardigan, farm-to-table bespoke 90's schlitz cray drinking
+								vinegar actually freegan bushwick wolf. Shabby chic tofu celiac
+								shaman, twee af squid blue bottle street art. Lumbersexual lo-fi
+								stumptown, iceland locavore tacos chillwave.
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>5</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby chic tofu celiac shaman,
+								twee af squid blue bottle street art. Lumbersexual lo-fi
+								stumptown, iceland locavore tacos chillwave portland beard
+								celiac polaroid Keffiyeh kinfolk lumbersexual, austin ennui
+								sustainable mlkshk four loko selfies ramps pop-up coloring book
+								before they sold out yuccie biodiesel. Yuccie taxidermy beard,
+								+1 church-key umami echo park synth. Fanny pack farm-to-table
+								pok pok, next level trust fund live-edge asymmetrical art party
+								intelligentsia listicle sriracha. Tote bag ugh meggings, selfies
+								vegan blog locavore messenger bag chambray etsy heirloom cronut
+								enamel pin hammock umami. Bushwick venmo activated charcoal,
+								mumblecore skateboard hashtag literally brooklyn etsy ennui 3
+								wolf moon. Before they sold out blog iPhone subway tile,
+								truffaut dreamcatcher organic raclette portland whatever
+								brooklyn succulents flexitarian gentrify cray. Kogi subway tile
+								gochujang dreamcatcher.
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>6</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby chic tofu celiac shaman,
+								twee af squid blue bottle street art. brooklyn etsy ennui 3 wolf
+								moon. Before they sold out blog iPhone subway tile, truffaut
+								dreamcatcher organic raclette portland whatever brooklyn
+								succulents flexitarian gentrify cray. Kogi subway tile gochujang
+								dreamcatcher Lumbersexual lo-fi stumptown, iceland locavore
+								tacos chillwave portland beard celiac polaroid Keffiyeh kinfolk
+								lumbersexual, austin ennui sustainable mlkshk four loko selfies
+								ramps pop-up coloring book before they sold out yuccie
+								biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+								synth. Fanny pack farm-to-table pok pok, next level trust fund
+								live-edge asymmetrical art party intelligentsia listicle
+								sriracha. Tote bag ugh meggings, selfies vegan blog locavore
+								messenger bag chambray etsy heirloom cronut enamel pin hammock
+								umami. Bushwick venmo activated charcoal, mumblecore skateboard
+								hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
+								sold out blog iPhone subway tile, truffaut dreamcatcher organic
+								raclette portland whatever brooklyn succulents flexitarian
+								gentrify cray. Kogi subway tile gochujang dreamcatcher.
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>7</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>8</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby chic tofu celiac shaman,
+								twee af squid blue bottle street art. they sold out yuccie
+								biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+								synth. Fanny pack farm-to-table pok pok, next level trust fund
+								live-edge asymmetrical art party intelligentsia listicle
+								sriracha. Tote bag ugh meggings, selfies vegan blog locavore
+								messenger bag chambray etsy heirloom cronut enamel pin hammock
+								umami. Bushwick venmo activated charcoal, mumblecore skateboard
+								hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
+								sold out blog iPhone subway tile, truffaut dreamcatcher organic
+								raclette portland whatever brooklyn succulents flexitarian
+								gentrify cray. Kogi subway tile gochujang dreamcatcher. kitsch
+								farm-to-table thundercats. Occupy hammock waistcoat pabst
+								ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+								schlitz cray drinking vinegar actually freegan bushwick wolf.
+								Shabby chic tofu celiac shaman, twee af squid blue bottle street
+								art. they sold out yuccie biodiesel. Yuccie taxidermy beard, +1
+								church-key umami vinegar actually freegan bushwick wolf. Shabby
+								chic tofu celiac shaman, twee af squid blue bottle street art.
+								they sold out yuccie biodiesel. Yuccie taxidermy beard, +1
+								church-key umami
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>9</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby chic tofu celiac shaman,
+								twee af squid blue bottle street art. Lumbersexual lo-fi
+								stumptown, iceland locavore tacos chillwave portland beard
+								celiac polaroid Keffiyeh kinfolk lumbersexual, austin ennui
+								sustainable mlkshk four loko selfies ramps pop-up coloring book
+								before they sold out yuccie biodiesel. Yuccie taxidermy beard,
+								+1 church-key umami echo park synth. Fanny pack farm-to-table
+								pok pok, next level trust fund live-edge asymmetrical art party
+								intelligentsia listicle sriracha. Tote bag ugh meggings, selfies
+								vegan blog locavore messenger bag chambray etsy heirloom cronut
+								enamel pin hammock umami. Bushwick venmo activated charcoal,
+								mumblecore skateboard hashtag literally brooklyn etsy ennui 3
+								wolf moon. Before they sold out blog iPhone subway tile,
+								truffaut dreamcatcher organic raclette portland whatever
+								brooklyn succulents flexitarian gentrify cray. Kogi subway tile
+								gochujang dreamcatcher. Stumptown keytar schlitz, vinyl
+								vexillologist humblebrag sartorial crucifix cornhole. Four
+								dollar toast 8-bit taiyaki asymmetrical helvetica kitsch
+								farm-to-table thundercats. Occupy hammock waistcoat pabst
+								ethical. Sartorial umami cardigan, farm-to-table bespoke 90's
+								schlitz cray drinking vinegar actually freegan bushwick wolf.
+								Shabby chic tofu celiac shaman, twee af squid blue bottle street
+								art. Lumbersexual lo-fi stumptown, iceland locavore tacos
+								chillwave portland beard celiac polaroid Keffiyeh kinfolk
+								lumbersexual, austin ennui sustainable mlkshk four loko selfies
+								ramps pop-up coloring book before they sold out yuccie
+								biodiesel. Yuccie taxidermy beard, +1 church-key umami echo park
+								synth. Fanny pack farm-to-table pok pok, next level trust fund
+								live-edge asymmetrical art party intelligentsia listicle
+								sriracha. Tote bag ugh meggings, selfies vegan blog locavore
+								messenger bag chambray etsy heirloom cronut enamel pin hammock
+								umami. Bushwick venmo activated charcoal, mumblecore skateboard
+								hashtag literally brooklyn etsy ennui 3 wolf moon. Before they
+								sold out blog iPhone subway tile, truffaut dreamcatcher organic
+								raclette portland whatever brooklyn succulents flexitarian
+								gentrify cray. Kogi subway tile gochujang dreamcatcher.
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>10</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst ethical. Sartorial umami cardigan,
+								farm-to-table bespoke 90's schlitz cray drinking vinegar
+								actually freegan bushwick wolf. Shabby chic tofu celiac shaman,
+								twee af squid blue bottle street art. Lumbersexual lo-fi
+								stumptown, iceland locavore tacos chillwave portland beard
+								celiac polaroid Keffiyeh kinfolk lumbersexual, austin ennui
+								sustainable mlkshk four loko selfies ramps pop-up coloring book
+								before they sold out yuccie biodiesel. Yuccie taxidermy beard,
+								+1 church-key umami echo park synth. Fanny pack farm-to-table
+								pok pok, next level trust fund live-edge asymmetrical art party
+								intelligentsia listicle sriracha. Tote bag ugh meggings, selfies
+								vegan blog locavore messenger bag chambray etsy heirloom cronut
+								enamel pin hammock umami. Bushwick venmo activated charcoal,
+								mumblecore skateboard hashtag literally brooklyn etsy ennui 3
+								wolf moon. Before they sold out blog iPhone subway tile,
+								truffaut dreamcatcher organic raclette portland whatever
+								brooklyn succulents flexitarian gentrify cray. Kogi subway tile
+								gochujang dreamcatcher.
+							</Panel>
+						</ResponsiveGrid.Cell>
+						<ResponsiveGrid.Cell>
+							<Panel hasMargin={false}>
+								<Panel.Header>11</Panel.Header>
+								Stumptown keytar schlitz, vinyl vexillologist humblebrag
+								sartorial crucifix cornhole. Four dollar toast 8-bit taiyaki
+								asymmetrical helvetica kitsch farm-to-table thundercats. Occupy
+								hammock waistcoat pabst.
+							</Panel>
+						</ResponsiveGrid.Cell>
+					</ResponsiveGrid>
+				</div>
+			</SidePanel>
+		</section>
+	);
 };
-WithResponsiveGrid.storyName = 'WithResponsiveGrid';

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -1,18 +1,20 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import Overlay, { IOverlayProps } from '../Overlay/Overlay';
 import GripperVerticalIcon from '../Icon/GripperVerticalIcon/GripperVerticalIcon';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
 import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
 import Button from '../Button/Button';
-import { getFirst, omitProps, StandardProps } from '../../util/component-types';
+import { getFirst, StandardProps } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-SidePanel');
 
 const { any, bool, func, oneOf, node, number, string, oneOfType } = PropTypes;
 
+/* SidePanel Header **/
 const SidePanelHeader = (_props: StandardProps): null => null;
 SidePanelHeader.displayName = 'SidePanel.Header';
 SidePanelHeader.propName = 'Header';
@@ -29,6 +31,7 @@ SidePanelHeader.propTypes = {
 	children: node,
 };
 
+/** Side Panel */
 export interface ISidePanelProps extends Partial<IOverlayProps> {
 	/** Alternative to using `<SidePanel.Header>`. */
 	Header?: string | (React.ReactNode & { props: StandardProps });
@@ -82,6 +85,25 @@ export interface ISidePanelProps extends Partial<IOverlayProps> {
 	/** Sets the top margin for the panel. Defaults to \`0\`. */
 	topOffset: number | string;
 }
+
+/** TODO: Remove the 'nonPassThroughs' when the component is converted to a functional component */
+const nonPassThroughs = [
+	'children',
+	'className',
+	'Header',
+	'isAnimated',
+	'isExpanded',
+	'isResizeDisabled',
+	'onCollapse',
+	'onResize',
+	'position',
+	'preventBodyScroll',
+	'width',
+	'minWidth',
+	'maxWidth',
+	'topOffset',
+	'initialState',
+];
 
 interface ISidePanelState {
 	isResizing: boolean;
@@ -303,12 +325,7 @@ class SidePanel extends React.Component<ISidePanelProps, ISidePanelState, {}> {
 				style={{
 					marginTop: topOffset,
 				}}
-				{...omitProps(
-					passThroughs,
-					undefined,
-					_.keys(SidePanel.propTypes),
-					false
-				)}
+				{...omit(passThroughs, nonPassThroughs)}
 			>
 				<div
 					className={cx('&-pane')}

--- a/src/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/src/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -189,10 +189,10 @@ exports[`SidePanel Header should match snapshot 1`] = `
 </Overlay>
 `;
 
-exports[`SidePanel isAnimated should match snapshot 1`] = `
+exports[`SidePanel isAnimated should match snapshot and apply the appropriate class 1`] = `
 <Overlay
-  className="lucid-SidePanel lucid-SidePanel-is-expanded lucid-SidePanel-position-right"
-  isAnimated={false}
+  className="lucid-SidePanel lucid-SidePanel-is-expanded lucid-SidePanel-position-right lucid-SidePanel-is-animated"
+  isAnimated={true}
   isModal={true}
   isShown={true}
   onBackgroundClick={[Function]}
@@ -242,12 +242,12 @@ exports[`SidePanel isAnimated should match snapshot 1`] = `
 </Overlay>
 `;
 
-exports[`SidePanel isExpanded should match snapshot 1`] = `
+exports[`SidePanel isExpanded should match snapshot and apply the appropriate class 1`] = `
 <Overlay
-  className="lucid-SidePanel lucid-SidePanel-position-right lucid-SidePanel-is-animated"
+  className="lucid-SidePanel lucid-SidePanel-is-expanded lucid-SidePanel-position-right lucid-SidePanel-is-animated"
   isAnimated={true}
   isModal={true}
-  isShown={false}
+  isShown={true}
   onBackgroundClick={[Function]}
   onEscape={[Function]}
   style={
@@ -329,9 +329,62 @@ exports[`SidePanel isResizeDisabled should match snapshot 1`] = `
 </Overlay>
 `;
 
-exports[`SidePanel position should match snapshot 1`] = `
+exports[`SidePanel position should match snapshot and apply the appropriate class 1`] = `
 <Overlay
   className="lucid-SidePanel lucid-SidePanel-is-expanded lucid-SidePanel-position-left lucid-SidePanel-is-animated"
+  isAnimated={true}
+  isModal={true}
+  isShown={true}
+  onBackgroundClick={[Function]}
+  onEscape={[Function]}
+  style={
+    Object {
+      "marginTop": 0,
+    }
+  }
+>
+  <div
+    className="lucid-SidePanel-pane"
+    style={
+      Object {
+        "marginTop": 0,
+        "width": 240,
+      }
+    }
+  >
+    <div
+      className="lucid-SidePanel-body"
+    >
+      <DragCaptureZone
+        className="lucid-SidePanel-grabber"
+        onDrag={[Function]}
+        onDragCancel={[Function]}
+        onDragEnd={[Function]}
+        onDragStart={[Function]}
+      >
+        <GripperVerticalIcon
+          aspectRatio="xMidYMid meet"
+          color="primary"
+          isClickable={false}
+          isDisabled={false}
+          onClick={[Function]}
+          onSelect={[Function]}
+          size={16}
+          viewBox="0 0 16 16"
+          width="20"
+        />
+      </DragCaptureZone>
+      <div
+        className="lucid-SidePanel-content"
+      />
+    </div>
+  </div>
+</Overlay>
+`;
+
+exports[`SidePanel position should match snapshot and apply the appropriate class 2`] = `
+<Overlay
+  className="lucid-SidePanel lucid-SidePanel-is-expanded lucid-SidePanel-position-right lucid-SidePanel-is-animated"
   isAnimated={true}
   isModal={true}
   isShown={true}

--- a/src/styles/components.less
+++ b/src/styles/components.less
@@ -56,6 +56,7 @@
 @import '../components/LineChart/LineChart';
 @import '../components/DraggableLineChart/DraggableLineChart';
 @import '../components/LoadingIndicator/LoadingIndicator';
+@import '../components/LoadingMessage/LoadingMessage';
 @import '../components/LoadingSkeletons/LoadingSkeleton';
 @import '../components/NotchedTag/NotchedTag';
 @import '../components/VerticalListMenu/VerticalListMenu';


### PR DESCRIPTION
## PR Checklist

Description of changes:
For LoadingMessage:
* replace omitProps with an explicit list of props.
* add Storybook story for LoadingMessage
* add unit test to ensure the correct props are being omitted and passed through to the underlying root element

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2571-LoadingMessage-replace-omitProps/?path=/docs/loading-message-loadingmessage--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
