### PR TITLE
Cxp 2573 pie chart and tool tip replace omit props

### DIFF
--- a/src/components/PieChart/PieChart.spec.tsx
+++ b/src/components/PieChart/PieChart.spec.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable comma-spacing */
-import _ from 'lodash';
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { common } from '../../util/generic-tests';
@@ -9,6 +9,7 @@ import sinon from 'sinon';
 import { PieChartDumb as PieChart } from './PieChart';
 import Line from '../Line/Line';
 import { ToolTipDumb as ToolTip } from '../ToolTip/ToolTip';
+import * as chartConstants from '../../constants/charts';
 
 jest.mock('d3-shape', () => ({
 	arc: jest.fn(() => ({
@@ -244,6 +245,140 @@ describe('PieChart', () => {
 
 				assert.equal(wrapper.find(ToolTip.Body).prop('children'), '200');
 			});
+		});
+	});
+
+	describe('pass throughs', () => {
+		let wrapper: any;
+		const defaultProps = PieChart.defaultProps;
+		const tooltipDefaultProps = ToolTip.defaultProps;
+		const { Body } = ToolTip;
+
+		const data = [
+			{ x: 'Leslie', y: 60 },
+			{ x: 'Ron', y: 40 },
+			{ x: 'Tom', y: 30 },
+			{ x: 'Gary', y: 20 },
+			{ x: 'Ben', y: 15 },
+		];
+
+		beforeEach(() => {
+			const props = {
+				...defaultProps,
+				height: 100,
+				width: 200,
+				margin: { top: 11, right: 12, bottom: 13, left: 14 },
+				palette: chartConstants.PALETTE_30,
+				colorMap: { clicks: '#abc123' },
+				data: data,
+				hasToolTips: false,
+				hasStroke: false,
+				isDonut: true,
+				isHovering: true,
+				hoveringIndex: 1,
+				onMouseOver: noop,
+				onMouseOut: noop,
+				donutWidth: 20,
+				ToolTip: {
+					...tooltipDefaultProps,
+					className: 'foo bar',
+					isCloseable: true,
+					isLight: true,
+					onClose: noop,
+					flyOutStyle: { marginLeft: 10 },
+					flyOutMaxWidth: 1000,
+					direction: 'right' as any,
+					alignment: 'end' as any,
+					isExpanded: true,
+					onMouseOver: noop,
+					onMouseOut: noop,
+					portalId: '11',
+					Title: 'Test Title',
+					Body: <Body>ToolTip Test Body.</Body>,
+					Target: <div>Example Test Target</div>,
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				},
+				className: 'wut',
+				style: { marginRight: 10 },
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+			};
+			wrapper = shallow(<PieChart {...props} />);
+		});
+
+		afterEach(() => {
+			wrapper.unmount();
+		});
+
+		it('passes through props not defined in `propTypes` to the root element.', () => {
+			const rootProps = wrapper.find('.lucid-PieChart').props();
+
+			expect(wrapper.first().prop(['className'])).toContain('wut');
+			expect(wrapper.first().prop(['style'])).toMatchObject({
+				marginRight: 10,
+			});
+			expect(wrapper.first().prop(['height'])).toBe(100);
+			expect(wrapper.first().prop(['width'])).toBe(200);
+			expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+			// 'className' 'with', 'height' and 'style' are plucked from the pass through object
+			// but still appear becuase they are also directly passed to the root element as a prop
+			forEach(['className', 'style', 'data-testid'], (prop) => {
+				expect(has(rootProps, prop)).toBe(true);
+			});
+		});
+		it('omits all the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId` and any toolTip props) from the root element', () => {
+			const rootProps = wrapper.find('.lucid-PieChart').props();
+
+			// ensure that omitted PieChart props are not passed through
+			forEach(
+				[
+					'margin',
+					'data',
+					'hasToolTips',
+					'hasStroke',
+					'palette',
+					'colorMap',
+					'ToolTip',
+					'isDonut',
+					'isHovering',
+					'hoveringIndex',
+					'onMouseOver',
+					'onMouseOut',
+					'donutWidth',
+					'xAxisField',
+					'xAxisFormatter',
+					'yAxisField',
+					'yAxisFormatter',
+					'initialState',
+					'callbackId',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
+
+			// ensure that omitted ToolTip props are not passed through
+			forEach(
+				[
+					'isCloseable',
+					'isLight',
+					'onClose',
+					'flyOutStyle',
+					'flyOutMaxWidth',
+					'Title',
+					'Body',
+					'Target',
+					'initialState',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
 		});
 	});
 });

--- a/src/components/PieChart/PieChart.stories.tsx
+++ b/src/components/PieChart/PieChart.stories.tsx
@@ -1,8 +1,10 @@
+import _ from 'lodash';
 import React from 'react';
 import createClass from 'create-react-class';
-import _ from 'lodash';
+import { Meta, Story } from '@storybook/react';
+
 import * as chartConstants from '../../constants/charts';
-import PieChart from './PieChart';
+import PieChart, { IPieChartProps } from './PieChart';
 import Legend from '../Legend/Legend';
 
 export default {
@@ -11,16 +13,15 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (PieChart as any).peek.description,
+				component: PieChart.peek.description,
 			},
 		},
 	},
-};
+	args: PieChart.defaultProps,
+} as Meta;
 
 /* Basic */
-export const Basic = () => {
-	/* eslint-disable comma-spacing */
-
+export const Basic: Story<IPieChartProps> = (args) => {
 	const data = [
 		{ x: 'Leslie', y: 60 },
 		{ x: 'Ron', y: 40 },
@@ -33,45 +34,45 @@ export const Basic = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<PieChart data={data} />
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_0_5}
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_1_5}
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_2_5}
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_3_5}
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_4_5}
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_5_5}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<PieChart data={data} />
+			<PieChart
+				data={data}
+				{...args}
+				palette={chartConstants.PALETTE_MONOCHROME_0_5}
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_1_5}
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_2_5}
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_3_5}
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_4_5}
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_5_5}
+			/>
+		</section>
+	);
 };
 
 /* Basic Donuts */
-export const BasicDonuts = () => {
+export const BasicDonuts: Story<IPieChartProps> = (args) => {
 	/* eslint-disable comma-spacing */
 
 	const data = [
@@ -86,52 +87,51 @@ export const BasicDonuts = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<PieChart data={data} isDonut />
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_0_5}
-						isDonut
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_1_5}
-						isDonut
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_2_5}
-						isDonut
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_3_5}
-						isDonut
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_4_5}
-						isDonut
-					/>
-					<PieChart
-						data={data}
-						palette={chartConstants.PALETTE_MONOCHROME_5_5}
-						isDonut
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<PieChart {...args} data={data} isDonut />
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_0_5}
+				isDonut
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_1_5}
+				isDonut
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_2_5}
+				isDonut
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_3_5}
+				isDonut
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_4_5}
+				isDonut
+			/>
+			<PieChart
+				{...args}
+				data={data}
+				palette={chartConstants.PALETTE_MONOCHROME_5_5}
+				isDonut
+			/>
+		</section>
+	);
 };
-BasicDonuts.storyName = 'BasicDonuts';
 
 /* Legend */
-export const LegendTest = () => {
+export const LegendTest: Story<IPieChartProps> = (args) => {
 	const data = [
 		{ x: 'Leslie', y: 80 },
 		{ x: 'Tom', y: 20 },
@@ -147,34 +147,27 @@ export const LegendTest = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<PieChart data={data} palette={palette} />
-					<Legend>
-						{_.map(data, (d, index) => (
-							<Legend.Item
-								key={index}
-								color={palette[index % palette.length]}
-								hasPoint
-								pointKind={1}
-							>
-								{d.x}
-							</Legend.Item>
-						))}
-					</Legend>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<PieChart {...args} data={data} palette={palette} />
+			<Legend>
+				{_.map(data, (d, index) => (
+					<Legend.Item
+						key={index}
+						color={palette[index % palette.length]}
+						hasPoint
+						pointKind={1}
+					>
+						{d.x}
+					</Legend.Item>
+				))}
+			</Legend>
+		</section>
+	);
 };
-LegendTest.storyName = 'Legend';
 
 /* Color Map */
-export const ColorMap = () => {
+export const ColorMap: Story<IPieChartProps> = (args) => {
 	/* eslint-disable comma-spacing */
 
 	const data = [
@@ -189,28 +182,22 @@ export const ColorMap = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<PieChart
-						data={data}
-						colorMap={{
-							Tammy: chartConstants.COLOR_BAD,
-							Leslie: chartConstants.COLOR_GOOD,
-						}}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<PieChart
+				{...args}
+				data={data}
+				colorMap={{
+					Tammy: chartConstants.COLOR_BAD,
+					Leslie: chartConstants.COLOR_GOOD,
+				}}
+			/>
+		</section>
+	);
 };
-ColorMap.storyName = 'ColorMap';
 
 /* Percents */
-export const Percents = () => {
+export const Percents: Story<IPieChartProps> = (args) => {
 	/* eslint-disable comma-spacing */
 
 	const data = [
@@ -227,28 +214,21 @@ export const Percents = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<PieChart
-						data={data}
-						yAxisFormatter={(value: number) => {
-							return `${((value / total) * 100).toFixed(1)}%`;
-						}}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<PieChart
+				{...args}
+				data={data}
+				yAxisFormatter={(value: number) => {
+					return `${((value / total) * 100).toFixed(1)}%`;
+				}}
+			/>
+		</section>
+	);
 };
 
 /* Small With No Stroke Or Hover */
-export const SmallWithNoStrokeOrHover = () => {
-	/* eslint-disable comma-spacing */
-
+export const SmallWithNoStrokeOrHover: Story<IPieChartProps> = (args) => {
 	const data = [
 		{ x: 'Leslie', y: 60 },
 		{ x: 'Ron', y: 40 },
@@ -261,28 +241,22 @@ export const SmallWithNoStrokeOrHover = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<PieChart
-						margin={{
-							top: 0,
-							right: 0,
-							bottom: 0,
-							left: 0,
-						}}
-						width={25}
-						height={25}
-						data={data}
-						hasStroke={false}
-						isHovering={false}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<PieChart
+				{...args}
+				margin={{
+					top: 0,
+					right: 0,
+					bottom: 0,
+					left: 0,
+				}}
+				width={25}
+				height={25}
+				data={data}
+				hasStroke={false}
+				isHovering={false}
+			/>
+		</section>
+	);
 };
-SmallWithNoStrokeOrHover.storyName = 'SmallWithNoStrokeOrHover';

--- a/src/components/PieChart/PieChart.tsx
+++ b/src/components/PieChart/PieChart.tsx
@@ -1,6 +1,7 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	omitProps,
@@ -15,6 +16,7 @@ import Line from '../../components/Line/Line';
 import {
 	ToolTipDumb as ToolTip,
 	IToolTipProps,
+	nonPassThroughs as toolTipNonPassThroughs,
 } from '../../components/ToolTip/ToolTip';
 
 import reducers, { IPieChartState } from './PieChart.reducers';
@@ -141,6 +143,32 @@ export interface IPieChartPropsRaw extends StandardProps {
 	yAxisFormatter: (y: number) => string | number;
 }
 
+const nonPassThroughs = [
+	'style',
+	'className',
+	'height',
+	'width',
+	'margin',
+	'data',
+	'hasToolTips',
+	'hasStroke',
+	'palette',
+	'colorMap',
+	'ToolTip',
+	'isDonut',
+	'isHovering',
+	'hoveringIndex',
+	'onMouseOver',
+	'onMouseOut',
+	'donutWidth',
+	'xAxisField',
+	'xAxisFormatter',
+	'yAxisField',
+	'yAxisFormatter',
+	'initialState',
+	'callbackId',
+];
+
 export type IPieChartProps = Overwrite<
 	React.SVGProps<SVGGElement>,
 	IPieChartPropsRaw
@@ -210,10 +238,9 @@ const PieChart = (props: IPieChartProps) => {
 
 	const svgClasses = cx(className, '&');
 
-	const pieChartProps = omitProps(
-		omitProps(passThroughs, undefined, _.keys(ToolTip.propTypes)),
-		undefined,
-		_.keys(PieChart.propTypes)
+	const pieChartProps: any = omit(
+		omit(passThroughs, toolTipNonPassThroughs.concat(['callbackId'])),
+		nonPassThroughs
 	);
 
 	// TODO: Consider displaying something specific when there is no data,

--- a/src/components/PieChart/__snapshots__/PieChart.spec.tsx.snap
+++ b/src/components/PieChart/__snapshots__/PieChart.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PieChart [common] example testing should match snapshot(s) for Basic 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -620,11 +620,11 @@ exports[`PieChart [common] example testing should match snapshot(s) for Basic 1`
       </g>
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`PieChart [common] example testing should match snapshot(s) for BasicDonuts 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -1243,11 +1243,11 @@ exports[`PieChart [common] example testing should match snapshot(s) for BasicDon
       </g>
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`PieChart [common] example testing should match snapshot(s) for ColorMap 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -1338,11 +1338,11 @@ exports[`PieChart [common] example testing should match snapshot(s) for ColorMap
       </g>
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`PieChart [common] example testing should match snapshot(s) for LegendTest 1`] = `
-<div
+<section
   style="display:flex;align-items:center;padding-top:4rem"
 >
   <svg
@@ -1487,11 +1487,11 @@ exports[`PieChart [common] example testing should match snapshot(s) for LegendTe
       Ann
     </li>
   </ul>
-</div>
+</section>
 `;
 
 exports[`PieChart [common] example testing should match snapshot(s) for Percents 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -1582,11 +1582,11 @@ exports[`PieChart [common] example testing should match snapshot(s) for Percents
       </g>
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`PieChart [common] example testing should match snapshot(s) for SmallWithNoStrokeOrHover 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -1677,5 +1677,5 @@ exports[`PieChart [common] example testing should match snapshot(s) for SmallWit
       </g>
     </g>
   </svg>
-</div>
+</section>
 `;

--- a/src/components/ToolTip/ToolTip.spec.tsx
+++ b/src/components/ToolTip/ToolTip.spec.tsx
@@ -1,8 +1,9 @@
-import _ from 'lodash';
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import { ToolTipDumb as ToolTip } from './ToolTip';
 import ContextMenu from '../ContextMenu/ContextMenu';
@@ -321,6 +322,98 @@ describe('ToolTip', () => {
 					wrapper.find(ContextMenu).prop('portalId'),
 					'foo-portal-id',
 					'must equal "foo-portal-id"'
+				);
+			});
+		});
+
+		describe('pass throughs', () => {
+			let wrapper: any;
+			const defaultProps = ToolTip.defaultProps;
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					className: 'wut',
+					isCloseable: true,
+					isLight: true,
+					onClose: noop,
+					flyOutStyle: { marginLeft: 10 },
+					flyOutMaxWidth: 1000,
+					direction: 'right' as any,
+					alignment: 'end' as any,
+					isExpanded: true,
+					onMouseOver: noop,
+					onMouseOut: noop,
+					portalId: '11',
+					Title: 'Test Title',
+					Body: <Body>ToolTip Test Body.</Body>,
+					Target: <div>Example Test Target</div>,
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<ToolTip {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through - to the root element - props not defined in `propTypes`', () => {
+				const rootProps = wrapper.find('.lucid-ToolTip').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+				expect(wrapper.first().prop(['callbackId'])).toBe(1);
+
+				// 'className' and 'style' are plucked from the pass through object
+				// but still appear becuase they are also directly passed to the root element as a prop
+				// callbackId is passed through because the ContextMenu root element is not a DOM element
+				forEach(
+					[
+						'className',
+						'alignment',
+						'direction',
+						'directonOffset',
+						'getAlignmentOffset',
+						'isExpanded',
+						'style',
+						'portalId',
+						'data-testid',
+						'onMouseOver',
+						'onMouseOut',
+						'children',
+						'minWidthOffset',
+						'onClickOut',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits - from the root element `initialState` and the props defined in `propTypes`', () => {
+				const rootProps = wrapper.find('.lucid-ToolTip').props();
+
+				forEach(
+					[
+						'isCloseable',
+						'isLight',
+						'onClose',
+						'flyOutStyle',
+						'flyOutMaxWidth',
+						'Title',
+						'Body',
+						'Target',
+						'initialState',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
 				);
 			});
 		});

--- a/src/components/ToolTip/ToolTip.stories.tsx
+++ b/src/components/ToolTip/ToolTip.stories.tsx
@@ -55,6 +55,7 @@ export default {
 			},
 		},
 	},
+	args: ToolTip.defaultProps,
 } as Meta;
 
 export const Basic: Story<IToolTipProps> = (args) => {
@@ -103,7 +104,7 @@ export const DirectionAndAlignmentVariants: Story<IToolTipProps> = (args) => {
 							key={`${direction}${alignment}`}
 							style={{ margin: '30px' }}
 						>
-							<ToolTip direction={direction} alignment={alignment}>
+							<ToolTip {...args} direction={direction} alignment={alignment}>
 								<Body>
 									ToolTip: is a utility component to create a transient message
 									anchored to another component. My direction is "{direction}".
@@ -147,7 +148,7 @@ export const ToolTipWithButton: Story<IToolTipProps> = (args) => {
 };
 
 /* Interactive */
-export const Interactive = () => {
+export const Interactive: Story<IToolTipProps> = (args) => {
 	const { Target, Title, Body } = ToolTip;
 
 	type Direction = 'right' | 'up' | 'down' | 'left';
@@ -156,55 +157,48 @@ export const Interactive = () => {
 	const directions: Direction[] = ['right', 'up', 'down', 'left'];
 	const alignments: Alignment[] = ['start', 'center', 'end'];
 
-	const Component = createClass({
-		render() {
-			return (
-				<section style={{ display: 'flex', flexDirection: 'row' }}>
-					{_.map(directions, (direction) => (
+	return (
+		<section style={{ display: 'flex', flexDirection: 'row' }}>
+			{_.map(directions, (direction) => (
+				<section
+					key={direction}
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+						flexGrow: 1,
+					}}
+				>
+					{_.map(alignments, (alignment) => (
 						<section
-							key={direction}
-							style={{
-								display: 'flex',
-								flexDirection: 'column',
-								alignItems: 'center',
-								flexGrow: 1,
-							}}
+							key={`${direction}${alignment}`}
+							style={{ margin: '30px' }}
 						>
-							{_.map(alignments, (alignment) => (
-								<section
-									key={`${direction}${alignment}`}
-									style={{ margin: '30px' }}
-								>
-									<ToolTip direction={direction} alignment={alignment}>
-										<Title>
-											Title: {direction} {alignment}
-										</Title>
-										<Body>
-											ToolTip is a utility component to create a transient
-											message anchored to another component. My direction is "
-											{direction}
-											". My alignment is "{alignment}".
-										</Body>
-										<Target>
-											<div>
-												Target {direction} {alignment}
-											</div>
-										</Target>
-									</ToolTip>
-								</section>
-							))}
+							<ToolTip {...args} direction={direction} alignment={alignment}>
+								<Title>
+									Title: {direction} {alignment}
+								</Title>
+								<Body>
+									ToolTip is a utility component to create a transient message
+									anchored to another component. My direction is "{direction}
+									". My alignment is "{alignment}".
+								</Body>
+								<Target>
+									<div>
+										Target {direction} {alignment}
+									</div>
+								</Target>
+							</ToolTip>
 						</section>
 					))}
 				</section>
-			);
-		},
-	});
-
-	return <Component />;
+			))}
+		</section>
+	);
 };
 
 /* Variants */
-export const Variants = () => {
+export const Variants: Story<IToolTipProps> = ({ ...args }) => {
 	const { Target, Title, Body } = ToolTipDumb;
 
 	const Component = createClass({
@@ -226,7 +220,7 @@ export const Variants = () => {
 						}}
 					>
 						<div style={{ marginTop: 60, marginBottom: 60 }}>
-							<ToolTipDumb isExpanded={this.state.isExpanded}>
+							<ToolTipDumb {...args} isExpanded={this.state.isExpanded}>
 								<Body>
 									ToolTip is a utility component to create a transient message
 									anchored to another component.
@@ -335,51 +329,43 @@ export const Variants = () => {
 };
 
 /* Unchanging */
-export const Unchanging = () => {
+export const Unchanging: Story<IToolTipProps> = (args) => {
 	const { Target, Title, Body } = ToolTipDumb;
 
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						display: 'flex',
-						flexDirection: 'column',
-						alignItems: 'center',
-					}}
-				>
-					{_.map(['right', 'up', 'down', 'left'], (direction) =>
-						_.map(['start', 'center', 'end'], (alignment) => (
-							<section
-								key={`${direction}${alignment}`}
-								style={{ margin: '90px' }}
-							>
-								<ToolTipDumb
-									direction={direction as any}
-									alignment={alignment as any}
-									isExpanded={true}
-								>
-									<Title>
-										Title: {direction} {alignment}
-									</Title>
-									<Body>
-										ToolTip is a utility component to create a transient message
-										anchored to another component. My direction is "{direction}
-										". My alignment is "{alignment}".
-									</Body>
-									<Target>
-										<div>
-											Target {direction} {alignment}
-										</div>
-									</Target>
-								</ToolTipDumb>
-							</section>
-						))
-					)}
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+			}}
+		>
+			{_.map(['right', 'up', 'down', 'left'], (direction) =>
+				_.map(['start', 'center', 'end'], (alignment) => (
+					<section key={`${direction}${alignment}`} style={{ margin: '90px' }}>
+						<ToolTipDumb
+							{...args}
+							direction={direction as any}
+							alignment={alignment as any}
+							isExpanded={true}
+						>
+							<Title>
+								Title: {direction} {alignment}
+							</Title>
+							<Body>
+								ToolTip is a utility component to create a transient message
+								anchored to another component. My direction is "{direction}
+								". My alignment is "{alignment}".
+							</Body>
+							<Target>
+								<div>
+									Target {direction} {alignment}
+								</div>
+							</Target>
+						</ToolTipDumb>
+					</section>
+				))
+			)}
+		</section>
+	);
 };

--- a/src/components/ToolTip/ToolTip.tsx
+++ b/src/components/ToolTip/ToolTip.tsx
@@ -1,16 +1,13 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import ContextMenu from '../ContextMenu/ContextMenu';
 import CloseIcon from '../Icon/CloseIcon/CloseIcon';
 import { IIconProps } from '../Icon/Icon';
 import * as reducers from './ToolTip.reducers';
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	StandardProps,
-	findTypes,
-	omitProps,
-} from '../../util/component-types';
+import { StandardProps, findTypes } from '../../util/component-types';
 import { buildModernHybridComponent } from '../../util/state-management';
 
 const cx = lucidClassNames.bind('&-ToolTip');
@@ -58,13 +55,13 @@ ToolTipBody.peek = {
 };
 ToolTipBody.propName = 'Body';
 
+/** ToolTip */
 export interface IToolTipState {
 	isExpanded: boolean;
 	isMouseOverFlyout: boolean;
 	isMouseOverTarget: boolean;
 }
 
-/** ToolTip */
 export interface IToolTipProps extends StandardProps {
 	/** Set this to `true` if you want to have a `x` close icon. */
 	isCloseable?: boolean;
@@ -118,6 +115,28 @@ export interface IToolTipProps extends StandardProps {
 	 * Defaults to a generated `id`. */
 	portalId?: string | null;
 }
+
+/** TODO: Remove nonPassThroughs when the component is converted to a functional component */
+export const nonPassThroughs = [
+	'children',
+	'className',
+	'isCloseable',
+	'isLight',
+	'onClose',
+	'style',
+	'flyOutStyle',
+	'flyOutMaxWidth',
+	'direction',
+	'alignment',
+	'isExpanded',
+	'onMouseOver',
+	'onMouseOut',
+	'portalId',
+	'Title',
+	'Body',
+	'Target',
+	'initialState',
+];
 
 class ToolTip extends React.Component<IToolTipProps, IToolTipState> {
 	constructor(props: IToolTipProps) {
@@ -344,12 +363,7 @@ class ToolTip extends React.Component<IToolTipProps, IToolTipState> {
 				isExpanded={isExpanded}
 				style={style}
 				portalId={portalId}
-				{...omitProps(
-					passThroughs,
-					undefined,
-					_.keys(ToolTip.propTypes),
-					false
-				)}
+				{...omit(passThroughs, nonPassThroughs)}
 				onMouseOver={this.handleMouseOverTarget}
 				onMouseOut={this.handleMouseOutTarget}
 			>


### PR DESCRIPTION
## PR Checklist

Description of changes:

- ToolTip and Pie Chart replace omitProps with explicit list of props
- Add unit tests for omitted pass throughs
- Update Storybook stories
- Update snapshot

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2573-PieChart-replace-omitProps/?path=/docs/visualizations-piechart--basic
https://docspot.adnxs.net/projects/lucid/CXP-2573-PieChart-replace-omitProps/?path=/docs/communication-tooltip--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two core team engineer approvals
- [ ] One core team UX approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
