### PR TITLE
Cxp 2970 slide panel replace omit props

### DIFF
--- a/src/components/SlidePanel/SlidePanel.spec.tsx
+++ b/src/components/SlidePanel/SlidePanel.spec.tsx
@@ -1,8 +1,11 @@
-import { shallow } from 'enzyme';
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
+import { shallow, mount } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import * as domHelpers from '../../util/dom-helpers';
 import SlidePanel from './SlidePanel';
+import CalendarIcon from '../Icon/CalendarIcon/CalendarIcon';
 
 const { Slide } = SlidePanel;
 
@@ -111,6 +114,121 @@ describe('SlidePanel', () => {
 				jest.runAllTimers();
 
 				expect(slidePanelInstance.offsetTranslate).toBe(5);
+			});
+		});
+
+		describe('root pass throughs', () => {
+			let wrapper: any;
+			let props: any;
+			const defaultProps = SlidePanel.defaultProps;
+
+			beforeEach(() => {
+				props = {
+					...defaultProps,
+					slidesToShow: 2,
+					offset: 1,
+					isAnimated: false,
+					onSwipe: noop,
+					Slide: <CalendarIcon style={{ width: '100%', height: '30vh' }} />,
+					isLooped: true,
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<SlidePanel {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-SlidePanel').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' and 'style' are plucked from the pass through object
+				// but still appear becuase they are also directly passed to the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits all the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) to the root element', () => {
+				const rootProps = wrapper.find('.lucid-SlidePanel').props();
+
+				forEach(
+					[
+						'Slide',
+						'slidesToShow',
+						'offset',
+						'isAnimated',
+						'isLooped',
+						'onSwipe',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
+			});
+
+			describe('slidestrip child component', () => {
+				let slidestripWrapper: any;
+
+				beforeEach(() => {
+					slidestripWrapper = mount(
+						<SlidePanel {...props} className='dub' data-testid={11} />
+					);
+				});
+
+				afterEach(() => {
+					slidestripWrapper.unmount();
+				});
+
+				it('passes through props not defined in `propTypes` to the slidestrip element.', () => {
+					const slidestripProps = slidestripWrapper
+						.find('.lucid-SlidePanel-slidestrip')
+						.props();
+
+					expect(slidestripWrapper.first().prop(['className'])).toContain(
+						'dub'
+					);
+					expect(slidestripWrapper.first().prop(['data-testid'])).toBe(11);
+
+					// 'className' and 'style' are plucked from the pass through object
+					// but still appear becuase they are also directly passed to the root element as a prop
+					forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+						expect(has(slidestripProps, prop)).toBe(true);
+					});
+				});
+				it('omits all the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the slidestrip element', () => {
+					const slidestripProps = slidestripWrapper
+						.find('.lucid-SlidePanel-slidestrip')
+						.props();
+
+					forEach(
+						[
+							'Slide',
+							'slidesToShow',
+							'offset',
+							'isAnimated',
+							'isLooped',
+							'onSwipe',
+							'initialState',
+							'callbackId',
+						],
+						(prop) => {
+							expect(has(slidestripProps, prop)).toBe(false);
+						}
+					);
+				});
 			});
 		});
 	});

--- a/src/components/SlidePanel/SlidePanel.stories.tsx
+++ b/src/components/SlidePanel/SlidePanel.stories.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import createClass from 'create-react-class';
-import SlidePanel from './SlidePanel';
+import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+
+import SlidePanel, { ISlidePanelSlideProps } from './SlidePanel';
 import Button from '../Button/Button';
 import AnalyzeDataIcon from '../Icon/AnalyzeDataIcon/AnalyzeDataIcon';
 import CalendarIcon from '../Icon/CalendarIcon/CalendarIcon';
@@ -16,104 +17,89 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (SlidePanel as any).peek.description,
+				component: SlidePanel.peek.description,
 			},
 		},
 	},
-};
+	args: SlidePanel.defaultProps,
+} as Meta;
 
 /* Looped Slides */
-export const LoopedSlides = () => {
+export const LoopedSlides: Story<ISlidePanelSlideProps> = (args) => {
 	const Slide = SlidePanel.Slide;
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				offset: 0,
-			};
-		},
+	const [offset, setOffset] = useState(0);
 
-		handlePrev() {
-			this.setState({
-				offset: this.state.offset - 1,
-			});
-		},
+	const handlePrev = () => {
+		setOffset(offset - 1);
+	};
 
-		handleNext() {
-			this.setState({
-				offset: this.state.offset + 1,
-			});
-		},
+	const handleNext = () => {
+		setOffset(offset + 1);
+	};
 
-		handleSwipe(slidesSwiped: any) {
-			this.setState({
-				offset: this.state.offset + slidesSwiped,
-			});
-		},
+	const handleSwipe = (slidesSwiped: any) => {
+		setOffset(offset + slidesSwiped);
+	};
 
-		render() {
-			return (
-				<section>
-					<Button onClick={this.handlePrev}>Backward</Button>
-					<Button onClick={this.handleNext}>Forward</Button>
-					Current offset: {this.state.offset}
-					<SlidePanel
-						slidesToShow={2}
-						offset={this.state.offset}
-						onSwipe={this.handleSwipe}
-						isLooped={true}
-					>
-						<Slide>
-							<AnalyzeDataIcon
-								style={{
-									width: '100%',
-									height: '30vh',
-									background: 'whitesmoke',
-								}}
-							/>
-						</Slide>
-						<Slide>
-							<CalendarIcon style={{ width: '100%', height: '30vh' }} />
-						</Slide>
-						<Slide>
-							<DuplicateIcon
-								style={{
-									width: '100%',
-									height: '30vh',
-									background: 'whitesmoke',
-								}}
-							/>
-						</Slide>
-						<Slide>
-							<EditIcon style={{ width: '100%', height: '30vh' }} />
-						</Slide>
-						<Slide>
-							<FileIcon
-								style={{
-									width: '100%',
-									height: '30vh',
-									background: 'whitesmoke',
-								}}
-							/>
-						</Slide>
-						<Slide>
-							<ImageIcon
-								style={{
-									width: '100%',
-									height: '30vh',
-									background: 'whitesmoke',
-								}}
-							/>
-						</Slide>
-						<Slide>
-							<SettingsIcon style={{ width: '100%', height: '30vh' }} />
-						</Slide>
-					</SlidePanel>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section>
+			<Button onClick={handlePrev}>Backward</Button>
+			<Button onClick={handleNext}>Forward</Button>
+			Current offset: {offset}
+			<SlidePanel
+				{...args}
+				slidesToShow={2}
+				offset={offset}
+				onSwipe={handleSwipe}
+				isLooped={true}
+			>
+				<Slide>
+					<AnalyzeDataIcon
+						style={{
+							width: '100%',
+							height: '30vh',
+							background: 'whitesmoke',
+						}}
+					/>
+				</Slide>
+				<Slide>
+					<CalendarIcon style={{ width: '100%', height: '30vh' }} />
+				</Slide>
+				<Slide>
+					<DuplicateIcon
+						style={{
+							width: '100%',
+							height: '30vh',
+							background: 'whitesmoke',
+						}}
+					/>
+				</Slide>
+				<Slide>
+					<EditIcon style={{ width: '100%', height: '30vh' }} />
+				</Slide>
+				<Slide>
+					<FileIcon
+						style={{
+							width: '100%',
+							height: '30vh',
+							background: 'whitesmoke',
+						}}
+					/>
+				</Slide>
+				<Slide>
+					<ImageIcon
+						style={{
+							width: '100%',
+							height: '30vh',
+							background: 'whitesmoke',
+						}}
+					/>
+				</Slide>
+				<Slide>
+					<SettingsIcon style={{ width: '100%', height: '30vh' }} />
+				</Slide>
+			</SlidePanel>
+		</section>
+	);
 };
-LoopedSlides.storyName = 'LoopedSlides';

--- a/src/components/SlidePanel/SlidePanel.tsx
+++ b/src/components/SlidePanel/SlidePanel.tsx
@@ -1,15 +1,12 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Motion, spring, PlainStyle } from 'react-motion';
+
 import { QUICK_SLIDE_MOTION } from '../../constants/motion-spring';
 import { lucidClassNames } from '../../util/style-helpers';
 import { shiftChildren } from '../../util/dom-helpers';
-import {
-	findTypes,
-	omitProps,
-	StandardProps,
-} from '../../util/component-types';
+import { findTypes, StandardProps } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-SlidePanel');
 
@@ -17,6 +14,7 @@ const { bool, func, node, number, string, any } = PropTypes;
 
 const modulo = (n: number, a: number): number => a - n * Math.floor(a / n);
 
+/** Slide Panel Slide */
 export interface ISlidePanelSlideProps extends StandardProps {
 	description?: string;
 }
@@ -29,6 +27,7 @@ class SlidePanelSlide extends React.Component<ISlidePanelSlideProps, {}, {}> {
 	}
 }
 
+/** Slide Panel */
 export interface ISlidePanelProps
 	extends StandardProps,
 		React.DetailedHTMLProps<
@@ -58,6 +57,18 @@ export interface ISlidePanelProps
 	) => void;
 }
 
+const nonPassThroughs = [
+	'className',
+	'children',
+	'Slide',
+	'slidesToShow',
+	'offset',
+	'isAnimated',
+	'isLooped',
+	'onSwipe',
+	'initialState',
+	'callbackId',
+];
 interface ISlidePanelState {
 	translateXPixel: number;
 	startX: number;
@@ -241,7 +252,7 @@ class SlidePanel extends React.Component<
 
 		return (
 			<div
-				{...omitProps(passThroughs, undefined, _.keys(SlidePanel.propTypes))}
+				{...omit(passThroughs, nonPassThroughs)}
 				ref={this.rootHTMLDivElement}
 				className={cx('&', className)}
 			>
@@ -266,11 +277,7 @@ class SlidePanel extends React.Component<
 				>
 					{(tween: PlainStyle): JSX.Element => (
 						<div
-							{...omitProps(
-								passThroughs,
-								undefined,
-								_.keys(SlidePanel.propTypes)
-							)}
+							{...omit(passThroughs, nonPassThroughs)}
 							className={cx('&-slidestrip', className)}
 							style={{
 								transform: this.state.isDragging


### PR DESCRIPTION
## PR Checklist

Description of changes:
Replace omitProps with explicit list of props for SlidePanel
Add unit test for omitted props
Update Storybook to SB6 and functional stories

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2970-SlidePanel-replace-omitProps/?path=/docs/private-slidepanel--looped-slides

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x
<img width="1158" alt="Screen Shot 2022-04-13 at 3 53 32 PM" src="https://user-images.githubusercontent.com/19521671/163282864-14c5462a-7a60-4d1b-9a02-e6f131a4799f.png">
] PR has one of the `semver-` labels
