### PR TITLE
Cxp 2574 points replace omit props

### DIFF
--- a/src/components/PieChart/PieChart.stories.tsx
+++ b/src/components/PieChart/PieChart.stories.tsx
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import React from 'react';
-import createClass from 'create-react-class';
 import { Meta, Story } from '@storybook/react';
 
 import * as chartConstants from '../../constants/charts';

--- a/src/components/Points/Points.spec.tsx
+++ b/src/components/Points/Points.spec.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable comma-spacing */
-
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import assert from 'assert';
 import * as d3Scale from 'd3-scale';
+
 import { common } from '../../util/generic-tests';
 import { shallow } from 'enzyme';
+import * as chartConstants from '../../constants/charts';
 
 import Points from './Points';
 import Point from '../Point/Point';
@@ -364,6 +366,75 @@ describe('Points', () => {
 
 				assert.equal(wrapper.find(Point).at(5).prop('x'), 100);
 				assert.equal(wrapper.find(Point).at(5).prop('y'), 0);
+			});
+		});
+
+		describe('pass throughs', () => {
+			let wrapper: any;
+			const defaultProps = Points.defaultProps;
+			const data = [{ x: 'one', y0: 4, y1: 5, y2: 6, y3: 7 }];
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					data,
+					xField: 'x-test',
+					yFields: ['y0-test', 'y1-test'],
+					colorOffset: 10,
+					hasStroke: false,
+					isStacked: true,
+					palette: chartConstants.PALETTE_30,
+					xScale: defaultXScale,
+					yScale: defaultYScale,
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<Points {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-Points').props();
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' is plucked from the pass through object
+				// but still appears becuase is is are also directly passed on the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits all the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-Points').props();
+				forEach(
+					[
+						'palette',
+						'colorMap',
+						'data',
+						'xScale',
+						'yScale',
+						'xField',
+						'yFields',
+						'yStackedMax',
+						'colorOffset',
+						'hasStroke',
+						'isStacked',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
 			});
 		});
 	});

--- a/src/components/Points/Points.stories.tsx
+++ b/src/components/Points/Points.stories.tsx
@@ -1,9 +1,12 @@
 import _ from 'lodash';
 import React from 'react';
 import createClass from 'create-react-class';
+import { Meta, Story } from '@storybook/react';
+
 import * as chartConstants from '../../constants/charts';
 import * as d3Scale from 'd3-scale';
 import Points from './Points';
+import { IPointsProps } from '../Points/Points';
 
 export default {
 	title: 'Visualizations/Points',
@@ -11,14 +14,15 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (Points as any).peek.description,
+				component: Points.peek.description,
 			},
 		},
 	},
-};
+	args: Points.defaultProps,
+} as Meta;
 
-/* Basic */
-export const Basic = () => {
+/* Basic Points */
+export const Basic: Story<IPointsProps> = (args) => {
 	/* eslint-disable comma-spacing */
 
 	const width = 1000;
@@ -59,28 +63,23 @@ export const Basic = () => {
 		.domain([0, yMax])
 		.range([innerHeight, 0]);
 
-	const Component = createClass({
-		render() {
-			return (
-				<svg width={width} height={height}>
-					<g transform={`translate(${margin.left}, ${margin.top})`}>
-						<Points
-							data={data}
-							xScale={xScale}
-							yScale={yScale}
-							yFields={yFields}
-						/>
-					</g>
-				</svg>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<svg width={width} height={height}>
+			<g transform={`translate(${margin.left}, ${margin.top})`}>
+				<Points
+					{...args}
+					data={data}
+					xScale={xScale}
+					yScale={yScale}
+					yFields={yFields}
+				/>
+			</g>
+		</svg>
+	);
 };
 
 /* Custom Colors */
-export const CustomColors = () => {
+export const CustomColors: Story<IPointsProps> = (args) => {
 	/* eslint-disable comma-spacing */
 
 	const width = 1000;
@@ -121,29 +120,23 @@ export const CustomColors = () => {
 		.domain([0, yMax])
 		.range([innerHeight, 0]);
 
-	const Component = createClass({
-		render() {
-			return (
-				<svg width={width} height={height}>
-					<g transform={`translate(${margin.left}, ${margin.top})`}>
-						<Points
-							data={data}
-							xScale={xScale}
-							yScale={yScale}
-							yFields={yFields}
-							colorMap={{
-								y0: chartConstants.COLOR_BAD,
-								y1: chartConstants.COLOR_GOOD,
-								y2: '#ff8800',
-								y3: '#abc123',
-							}}
-						/>
-					</g>
-				</svg>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<svg width={width} height={height}>
+			<g transform={`translate(${margin.left}, ${margin.top})`}>
+				<Points
+					{...args}
+					data={data}
+					xScale={xScale}
+					yScale={yScale}
+					yFields={yFields}
+					colorMap={{
+						y0: chartConstants.COLOR_BAD,
+						y1: chartConstants.COLOR_GOOD,
+						y2: '#ff8800',
+						y3: '#abc123',
+					}}
+				/>
+			</g>
+		</svg>
+	);
 };
-CustomColors.storyName = 'CustomColors';

--- a/src/components/Points/Points.tsx
+++ b/src/components/Points/Points.tsx
@@ -1,11 +1,12 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { lucidClassNames } from '../../util/style-helpers';
-import { StandardProps, omitProps } from '../../util/component-types';
-import { groupByFields } from '../../util/chart-helpers';
-import * as d3Shape from 'd3-shape';
 import * as d3Scale from 'd3-scale';
+import * as d3Shape from 'd3-shape';
+
+import { lucidClassNames } from '../../util/style-helpers';
+import { StandardProps } from '../../util/component-types';
+import { groupByFields } from '../../util/chart-helpers';
 import * as chartConstants from '../../constants/charts';
 
 import Point from '../Point/Point';
@@ -114,6 +115,23 @@ export interface IPointsProps
 	hasStroke: boolean;
 }
 
+const nonPassThroughs = [
+	'className',
+	'palette',
+	'colorMap',
+	'data',
+	'xScale',
+	'yScale',
+	'xField',
+	'yFields',
+	'yStackedMax',
+	'colorOffset',
+	'hasStroke',
+	'isStacked',
+	'initialState',
+	'callbackId',
+];
+
 const defaultProps = {
 	xField: 'x',
 	yFields: ['y'],
@@ -158,10 +176,7 @@ export const Points = (props: IPointsProps): React.ReactElement => {
 	}
 
 	return (
-		<g
-			{...omitProps(passThroughs, undefined, _.keys(Points.propTypes))}
-			className={cx(className, '&')}
-		>
+		<g {...omit(passThroughs, nonPassThroughs)} className={cx(className, '&')}>
 			{_.map(transformedData, (d, dIndex): any[] =>
 				_.map(d, (series, seriesIndex): JSX.Element | undefined => {
 					if (isValidSeries(series)) {
@@ -194,7 +209,7 @@ Points.defaultProps = defaultProps;
 Points.displayName = 'Points';
 
 Points.peek = {
-	description: `*For use within an \`svg\`*. Put some points on that data.`,
+	description: `For use within an \`svg\`. Put some points on that data.`,
 	categories: ['visualizations', 'chart primitives'],
 	madeFrom: ['Point'],
 };


### PR DESCRIPTION
## PR Checklist

Description of changes:
Update Points stories to SB6 and replace deprecated omitProps method with explicit list of omitted props.

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2574-Points-replace-omitProps/?path=/docs/visualizations-points--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
