### PR TITLE
Cxp 2575 Portal replace omit props

### DIFF
--- a/src/components/Portal/Portal.spec.tsx
+++ b/src/components/Portal/Portal.spec.tsx
@@ -1,3 +1,4 @@
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import assert from 'assert';
 import { mount, shallow } from 'enzyme';
@@ -37,6 +38,60 @@ describe('Portal', () => {
 				);
 
 				wrapper.unmount();
+			});
+		});
+
+		describe('pass throughs', () => {
+			let wrapper: any;
+
+			const className = 'wut';
+
+			beforeEach(() => {
+				const props = {
+					portalId: 'example-portal123',
+					'data-test-id': className,
+					onClick: noop,
+					className,
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<Portal {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-Portal').props();
+
+				expect(wrapper.find('.lucid-Portal').prop(['className'])).toContain(
+					className
+				);
+				expect(wrapper.find('.lucid-Portal').prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.find('.lucid-Portal').prop(['data-testid'])).toBe(10);
+				expect(wrapper.find('.lucid-Portal').prop(['data-test-id'])).toBe(
+					className
+				);
+
+				// 'className' is plucked from the pass through object
+				// but still appears becuase is is are also directly passed on the root element as a prop
+				forEach(
+					['className', 'data-test-id', 'data-testid', 'style', 'children'],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-Portal').props();
+				forEach(['portalId', 'initialState', 'callbackId'], (prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				});
 			});
 		});
 	});

--- a/src/components/Portal/Portal.stories.tsx
+++ b/src/components/Portal/Portal.stories.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import createClass from 'create-react-class';
+import { Meta, Story } from '@storybook/react';
+
 import PropTypes from 'prop-types';
-import Portal from './Portal';
+import Portal, { IPortalProps } from './Portal';
 import Button from '../Button/Button';
 
 export default {
@@ -10,77 +12,69 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (Portal as any).peek.description,
+				component: Portal.peek.description,
 			},
 		},
 	},
-};
+} as Meta;
 
 /* Basic */
-export const Basic = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				left: 216,
-				top: 460,
-			};
-		},
-
-		handleClick(event) {
-			const { height, width } = event.target.getBoundingClientRect();
-
-			this.setState({
-				left: event.pageX - width / 2,
-				top: event.pageY - height / 2,
-			});
-		},
-
-		render() {
-			const { left, top } = this.state;
-			return (
-				<Portal
-					portalId='example-portal123'
-					className='example-portal-container'
-					style={{
-						width: 128,
-						height: 128,
-						backgroundColor: '#2abbb0',
-						color: '#fff',
-						boxShadow: '0 0 36px rgba(0, 0, 0, 0.5)',
-						transition: 'left .5s, top .5s',
-						display: 'flex',
-						flexDirection: 'column',
-						justifyContent: 'center',
-						alignItems: 'center',
-						cursor: 'pointer',
-						position: 'absolute',
-						left: left,
-						top: top,
-					}}
-					onClick={this.handleClick}
-				>
-					<section
-						style={{
-							pointerEvents: 'none',
-							textAlign: 'center',
-						}}
-					>
-						<p>click to move</p>
-						<p>
-							({left}, {top})
-						</p>
-						<p>inspect me</p>
-					</section>
-				</Portal>
-			);
-		},
+export const Basic: Story<IPortalProps> = (args) => {
+	const [state, setState] = useState({
+		left: 216,
+		top: 460,
 	});
 
-	return <Component />;
+	const handleClick = (event) => {
+		const { height, width } = event.target.getBoundingClientRect();
+
+		setState({
+			left: event.pageX - width / 2,
+			top: event.pageY - height / 2,
+		});
+	};
+
+	const { left, top } = state;
+	return (
+		<Portal
+			portalId='example-portal123'
+			className='example-portal-container'
+			style={{
+				width: 128,
+				height: 128,
+				backgroundColor: '#2abbb0',
+				color: '#fff',
+				boxShadow: '0 0 36px rgba(0, 0, 0, 0.5)',
+				transition: 'left .5s, top .5s',
+				display: 'flex',
+				flexDirection: 'column',
+				justifyContent: 'center',
+				alignItems: 'center',
+				cursor: 'pointer',
+				position: 'absolute',
+				left: left,
+				top: top,
+			}}
+			onClick={handleClick}
+		>
+			<section
+				style={{
+					pointerEvents: 'none',
+					textAlign: 'center',
+				}}
+			>
+				<p>click to move</p>
+				<p>
+					({left}, {top})
+				</p>
+				<p>inspect me</p>
+			</section>
+		</Portal>
+	);
 };
 
 /* Context */
-export const Context = () => {
+export const Context: Story<IPortalProps> = () => {
 	const context: any = React.createContext({
 		display: 'hello',
 	});

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import { omitProps, StandardProps } from '../../util/component-types';
+
+import { StandardProps } from '../../util/component-types';
 import { lucidClassNames } from '../../util/style-helpers';
 import classNames from 'classnames';
 
@@ -80,7 +81,13 @@ class Portal extends React.Component<IPortalProps, IPortalState, {}> {
 					<div
 						data-test-id={this.props.className}
 						className={classNames(cx('&'), this.props.className)}
-						{...omitProps(this.props, undefined, _.keys(Portal.propTypes))}
+						{...omit(this.props, [
+							'className',
+							'children',
+							'portalId',
+							'initialState',
+							'callbackId',
+						])}
 					>
 						{this.props.children}
 					</div>,


### PR DESCRIPTION
## PR Checklist

Description of changes:

- Add unit test for pass throughs
- Update stories to SB6 and functional comp
- Replace omitProps with explicit list of props

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2575-Portal-Replace-omitProps/?path=/docs/utility-portal--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
