### PR TITLE
Cxp 2591 validation replace omit props

### DIFF
--- a/src/components/Validation/Validation.spec.tsx
+++ b/src/components/Validation/Validation.spec.tsx
@@ -1,8 +1,11 @@
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import assert from 'assert';
+
 import { common } from '../../util/generic-tests';
 import { shallow } from 'enzyme';
 import Validation from './Validation';
+import TextField from '../TextField/TextField';
 
 describe('Validation', () => {
 	common(Validation, {
@@ -79,6 +82,52 @@ describe('Validation', () => {
 						wrapper.find('.lucid-Validation-error-content').text(),
 						'foo'
 					);
+				});
+			});
+		});
+
+		describe('pass throughs for root div component', () => {
+			let wrapper: any;
+
+			const className = 'wut';
+
+			beforeEach(() => {
+				const props = {
+					Error: <span>'test error'</span>,
+					children: <TextField value='Text Field Text' />,
+					className,
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<Validation {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-Validation').props();
+
+				expect(wrapper.first().prop(['className'])).toContain(className);
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' is plucked from the pass through object
+				// but still appears becuase is is are also directly passed on the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits the component specific props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-Validation').props();
+
+				forEach(['Error', 'initialState', 'callbackId'], (prop) => {
+					expect(has(rootProps, prop)).toBe(false);
 				});
 			});
 		});

--- a/src/components/Validation/Validation.stories.tsx
+++ b/src/components/Validation/Validation.stories.tsx
@@ -19,7 +19,7 @@ export default {
 /* Basic */
 export const Basic: Story<IValidationProps> = (args) => {
 	return (
-		<div>
+		<section>
 			<p>Text field with Error prop (Method 1)</p>
 			<Validation {...args} Error='Error One'>
 				<TextField value='Text Field Text' />
@@ -51,6 +51,6 @@ export const Basic: Story<IValidationProps> = (args) => {
 				</Validation.Error>
 				<TextField isMultiLine rows={3} value='Text Area Text' />
 			</Validation>
-		</div>
+		</section>
 	);
 };

--- a/src/components/Validation/Validation.tsx
+++ b/src/components/Validation/Validation.tsx
@@ -1,14 +1,15 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import { getFirst, omitProps, StandardProps } from '../../util/component-types';
+import { getFirst, StandardProps } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-Validation');
 
 const { string, any } = PropTypes;
 
+/** Validation Error */
 export interface IValidationErrorProps extends StandardProps {
 	description?: string;
 }
@@ -23,6 +24,7 @@ ValidationError.propTypes = {
 	children: any,
 };
 
+/** Validation */
 export interface IValidationProps
 	extends StandardProps,
 		React.DetailedHTMLProps<
@@ -41,7 +43,13 @@ export const Validation = (props: IValidationProps): React.ReactElement => {
 
 	return (
 		<div
-			{..._.omit(passThroughs, ['Error'])}
+			{...omit(passThroughs, [
+				'Error',
+				'className',
+				'children',
+				'initialState',
+				'callbackId',
+			])}
 			className={cx(
 				'&',
 				{
@@ -55,7 +63,7 @@ export const Validation = (props: IValidationProps): React.ReactElement => {
 			errorChildProps.children &&
 			errorChildProps.children !== true ? (
 				<div
-					{..._.omit(errorChildProps, ['initialState', 'callbackId'])}
+					{...omit(errorChildProps, ['initialState', 'callbackId'])}
 					className={cx('&-error-content', errorChildProps.className)}
 				>
 					{errorChildProps.children}

--- a/src/components/Validation/__snapshots__/Validation.spec.tsx.snap
+++ b/src/components/Validation/__snapshots__/Validation.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Validation [common] example testing should match snapshot(s) for Basic 1`] = `
-<div>
+<section>
   <p>
     Text field with Error prop (Method 1)
   </p>
@@ -79,5 +79,5 @@ exports[`Validation [common] example testing should match snapshot(s) for Basic 
       Error FOUR TEST
     </div>
   </div>
-</div>
+</section>
 `;


### PR DESCRIPTION
## PR Checklist

Description of changes to Validation:
- Add unit test for omitted props
- Fix import error in Validation story
- Revise omitted props for root div
- Update Validation snapshot

Storybook
https://docspot.adnxs.net/projects/lucid/CXP-2591-Validation-replace-omitProps/?path=/docs/helpers-validation--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
