### PR TITLE
Cxp switch switch labeled replace omit props

### DIFF
--- a/src/components/Switch/Switch.spec.tsx
+++ b/src/components/Switch/Switch.spec.tsx
@@ -1,11 +1,10 @@
-import _ from 'lodash';
-import assert from 'assert';
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
+import assert from 'assert';
 import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 
 import { common, controls } from '../../util/generic-tests';
-
 import Switch from './Switch';
 
 describe('Switch', () => {
@@ -46,32 +45,83 @@ describe('Switch', () => {
 		});
 
 		describe('pass throughs', () => {
-			it('passes through all props not defined in `propTypes` to the native input.', () => {
-				const wrapper = mount(
-					<Switch
-						className='wut'
-						isDisabled={true}
-						isSelected={true}
-						style={{ fontWeight: 'bold' }}
-						onSelect={_.noop}
-						{...{
-							foo: 1,
-							bar: 2,
-							baz: 3,
-							qux: 4,
-							quux: 5,
-						}}
-					/>
-				);
-				const nativeProps = _.keys(
-					wrapper.find('input[type="checkbox"]').props()
-				);
+			let wrapper: any;
+			const className = 'wut';
 
+			beforeEach(() => {
+				const defaultProps = Switch.defaultProps;
+
+				const props = {
+					...defaultProps,
+					isDisabled: true,
+					isSelected: true,
+					style: { fontWeight: 'bold' },
+					onSelect: noop,
+					isIncludeExclude: true,
+					className,
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+					...{
+						foo: 1,
+						bar: 2,
+						baz: 3,
+						qux: 4,
+						quux: 5,
+					},
+				};
+
+				wrapper = shallow(<Switch {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through all props not defined in `propTypes` to the native input element.', () => {
+				const inputProps = wrapper.find('.lucid-Switch-native').props();
+
+				// 'className', 'onChange', 'checked', 'disabled' and 'type'
+				// all appear becuase they are directly passed on the root element as a prop
 				// It should pass `foo`, `bar`, `baz`, `qux`, and `quux` through
 				// to the native input.
-				_.forEach(['foo', 'bar', 'baz', 'qux', 'quux'], (prop) => {
-					assert(_.includes(nativeProps, prop));
-				});
+				_.forEach(
+					[
+						'foo',
+						'bar',
+						'baz',
+						'qux',
+						'quux',
+						'onChange',
+						'checked',
+						'disabled',
+						'type',
+						'className',
+						'data-testid',
+					],
+					(prop) => {
+						expect(has(inputProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits the component specific props defined in `propTypes` (plus, in addition, `children`, `initialState`, and `callbackId`) from the root element', () => {
+				const inputProps = wrapper.find('.lucid-Switch-native').props();
+
+				forEach(
+					[
+						'isDisabled',
+						'isSelected',
+						'onSelect',
+						'style',
+						'isIncludeExclude',
+						'initialState',
+						'callbackId',
+						'children',
+					],
+					(prop) => {
+						expect(has(inputProps, prop)).toBe(false);
+					}
+				);
 			});
 		});
 	});

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react';
 import _ from 'lodash';
+import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+
 import Switch, { ISwitchProps } from './Switch';
 
 export default {
@@ -13,9 +14,18 @@ export default {
 			},
 		},
 	},
+	args: Switch.defaultProps,
 } as Meta;
 
-export const Basic: Story<ISwitchProps> = (args) => <Switch {...args} />;
+export const Basic: Story<ISwitchProps> = (args) => {
+	const [selected, setSelected] = useState(true);
+
+	const handleSelect = () => {
+		setSelected(!selected);
+	};
+
+	return <Switch {...args} onSelect={handleSelect} isSelected={selected} />;
+};
 
 export const Selected: Story<ISwitchProps> = (args) => (
 	<Switch {...args} title='Selected' isSelected={true} />

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React, { createRef } from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
@@ -109,11 +109,7 @@ export const Switch = (props: ISwitchProps): React.ReactElement => {
 		>
 			<input
 				onChange={_.noop}
-				{...omitProps(
-					passThroughs,
-					undefined,
-					['children'].concat(_.keys(Switch.propTypes))
-				)}
+				{...omit(passThroughs, ['initialState', 'callbackId', 'children'])}
 				checked={isSelected}
 				className={cx('&-native')}
 				disabled={isDisabled}

--- a/src/components/Switch/__snapshots__/Switch.spec.tsx.snap
+++ b/src/components/Switch/__snapshots__/Switch.spec.tsx.snap
@@ -2,9 +2,10 @@
 
 exports[`Switch [common] example testing should match snapshot(s) for Basic 1`] = `
 <span
-  class="lucid-Switch"
+  class="lucid-Switch lucid-Switch-is-selected"
 >
   <input
+    checked=""
     class="lucid-Switch-native"
     type="checkbox"
   />


### PR DESCRIPTION
## PR Checklist

Description of changes to `Switch`:
* Add stateful Basic story 
* Replace omitProps with explicit list of props
* Update unit test
* Update snapshot

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-Switch-SwitchLabeled-replace-omitProps/?path=/docs/controls-switch--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
