### PR TITLE
Cxp 2529 vertical list menu& splithorizontal replace omit props

### DIFF
--- a/src/components/SplitHorizontal/SplitHorizontal.spec.tsx
+++ b/src/components/SplitHorizontal/SplitHorizontal.spec.tsx
@@ -1,9 +1,13 @@
+import _, { forEach, has } from 'lodash';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import assert from 'assert';
-import _ from 'lodash';
+
 import { common } from '../../util/generic-tests';
-import SplitHorizontal from './SplitHorizontal';
+import SplitHorizontal, {
+	SplitHorizontalTopPane,
+	SplitHorizontalBottomPane,
+} from './SplitHorizontal';
 import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
 import { Motion } from 'react-motion';
 import { MOSTLY_STABLE_DELAY } from '../../../tests/constants';
@@ -281,6 +285,71 @@ describe('SplitHorizontal', () => {
 				expect(event).toEqual(lastArg.event);
 			});
 		});
+
+		describe('root pass throughs', () => {
+			let wrapper: any;
+			const defaultProps = SplitHorizontal.defaultProps;
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					isExpanded: false,
+					isAnimated: true,
+					collapseShift: 1,
+					TopPane: <p>post-ironic etsy roof party</p>,
+					BottomPane: <p>heirloom street art church-key</p>,
+					Divider: 'D I V I D E R',
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<SplitHorizontal {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-SplitHorizontal').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' and style are plucked from the pass through object
+				// but still appears becuase each one is also directly added to the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-SplitHorizontal').props();
+				forEach(
+					[
+						'isExpanded',
+						'isAnimated',
+						'onResizing',
+						'onResize',
+						'collapseShift',
+						'TopPane',
+						'BottomPane',
+						'Divider',
+						'onSelect',
+						'onToggle',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
+			});
+		});
 	});
 
 	describe('child components', () => {
@@ -344,6 +413,68 @@ describe('SplitHorizontal', () => {
 					'must set the flexBasis to match the given height'
 				);
 			});
+
+			describe('TopPane pass throughs', () => {
+				let topPaneWrapper: any;
+				const topPaneDefaultProps = SplitHorizontalTopPane.defaultProps;
+
+				beforeEach(() => {
+					const props = {
+						...topPaneDefaultProps,
+						height: 321,
+						isPrimary: true,
+						className: 'wut',
+						initialState: { test: true },
+						callbackId: 1,
+						'data-testid': 10,
+					};
+
+					topPaneWrapper = mount(
+						<SplitHorizontal>
+							<SplitHorizontal.TopPane {...props}>
+								Search Filters
+							</SplitHorizontal.TopPane>
+						</SplitHorizontal>
+					);
+				});
+
+				afterEach(() => {
+					topPaneWrapper.unmount();
+				});
+
+				it('should pass through props not defined in the TopPane `propTypes`', () => {
+					const topPaneProps = topPaneWrapper
+						.find('.lucid-SplitHorizontal-TopPane')
+						.props();
+
+					expect(
+						topPaneWrapper
+							.find('.lucid-SplitHorizontal-TopPane')
+							.prop(['className'])
+					).toContain('wut');
+					expect(
+						topPaneWrapper
+							.find('.lucid-SplitHorizontal-TopPane')
+							.prop(['data-testid'])
+					).toBe(10);
+
+					forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+						expect(has(topPaneProps, prop)).toBe(true);
+					});
+				});
+				it('omits the props defined in TopPane `propTypes`, (plus, in addition, `initialState`, and `callbackId`) from the TopPane element', () => {
+					const topPaneProps = topPaneWrapper
+						.find('.lucid-SplitHorizontal-TopPane')
+						.props();
+
+					forEach(
+						['height', 'isPrimary', 'initialState', 'callbackId'],
+						(prop) => {
+							expect(has(topPaneProps, prop)).toBe(false);
+						}
+					);
+				});
+			});
 		});
 
 		describe('BottomPane', () => {
@@ -378,12 +509,12 @@ describe('SplitHorizontal', () => {
 				);
 
 				const motionWrapper = wrapper.find(Motion).shallow();
-				const TopPane = motionWrapper.find(
+				const BottomPane = motionWrapper.find(
 					'.lucid-SplitHorizontal-inner > .lucid-SplitHorizontal-TopPane'
 				);
 
 				assert(
-					TopPane.hasClass('lucid-SplitHorizontal-is-secondary'),
+					BottomPane.hasClass('lucid-SplitHorizontal-is-secondary'),
 					'must have the secondary className'
 				);
 			});
@@ -407,6 +538,68 @@ describe('SplitHorizontal', () => {
 					BottomPane.prop('style').flexBasis,
 					'must set the flexBasis to match the given height'
 				);
+			});
+
+			describe('BottomPane pass throughs', () => {
+				let bottomPaneWrapper: any;
+				const bottomPaneDefaultProps = SplitHorizontalBottomPane.defaultProps;
+
+				beforeEach(() => {
+					const props = {
+						...bottomPaneDefaultProps,
+						height: 321,
+						isPrimary: true,
+						className: 'wut',
+						initialState: { test: true },
+						callbackId: 1,
+						'data-testid': 10,
+					};
+
+					bottomPaneWrapper = mount(
+						<SplitHorizontal>
+							<SplitHorizontal.BottomPane {...props}>
+								Search Filters
+							</SplitHorizontal.BottomPane>
+						</SplitHorizontal>
+					);
+				});
+
+				afterEach(() => {
+					bottomPaneWrapper.unmount();
+				});
+
+				it('should pass through props not defined in the BottomPane `propTypes`', () => {
+					const bottomPaneProps = bottomPaneWrapper
+						.find('.lucid-SplitHorizontal-BottomPane')
+						.props();
+
+					expect(
+						bottomPaneWrapper
+							.find('.lucid-SplitHorizontal-BottomPane')
+							.prop(['className'])
+					).toContain('wut');
+					expect(
+						bottomPaneWrapper
+							.find('.lucid-SplitHorizontal-BottomPane')
+							.prop(['data-testid'])
+					).toBe(10);
+
+					forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+						expect(has(bottomPaneProps, prop)).toBe(true);
+					});
+				});
+				it('omits the props defined in BottomPane `propTypes`, (plus, in addition, `initialState`, and `callbackId`) from the TopPane element', () => {
+					const bottomPaneProps = bottomPaneWrapper
+						.find('.lucid-SplitHorizontal-BottomPane')
+						.props();
+
+					forEach(
+						['height', 'isPrimary', 'initialState', 'callbackId'],
+						(prop) => {
+							expect(has(bottomPaneProps, prop)).toBe(false);
+						}
+					);
+				});
 			});
 		});
 

--- a/src/components/SplitHorizontal/SplitHorizontal.stories.tsx
+++ b/src/components/SplitHorizontal/SplitHorizontal.stories.tsx
@@ -20,7 +20,7 @@ export default {
 /* Default Split */
 export const DefaultSplit: Story<ISplitHorizontalProps> = (args) => {
 	return (
-		<SplitHorizontal {...args}>
+		<SplitHorizontal {...(args as any)}>
 			<SplitHorizontal.TopPane>
 				<p>
 					Bicycle rights tofu hashtag blue bottle viral. Mixtape kinfolk
@@ -72,7 +72,7 @@ export const AnimatedCollapse: Story<ISplitHorizontalProps> = (args) => {
 
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
-							{...args}
+							{...(args as any)}
 							style={{ height: '100%' }}
 							isAnimated
 							isExpanded={this.state.isExpanded}
@@ -137,7 +137,7 @@ export const SetPaneAsPrimary: Story<ISplitHorizontalProps> = (args) => {
 
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
-							{...args}
+							{...(args as any)}
 							style={{ height: '100%' }}
 							isAnimated
 							isExpanded={this.state.isExpanded}
@@ -183,7 +183,7 @@ export const SetPaneAsPrimary: Story<ISplitHorizontalProps> = (args) => {
 export const SetHeightOfPane: Story<ISplitHorizontalProps> = (args) => {
 	return (
 		<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
-			<SplitHorizontal {...args}>
+			<SplitHorizontal {...(args as any as any)}>
 				<SplitHorizontal.TopPane height={64}>
 					<p>
 						Jean shorts reprehenderit in, commodo godard skateboard retro
@@ -217,7 +217,7 @@ export const SetHeightOfPane: Story<ISplitHorizontalProps> = (args) => {
 /* Customize Divider */
 export const CustomizeDivider: Story<ISplitHorizontalProps> = (args) => {
 	return (
-		<SplitHorizontal {...args}>
+		<SplitHorizontal {...(args as any)}>
 			<SplitHorizontal.TopPane>
 				<p>
 					Waistcoat man bun sartorial, PBR&B artisan blue bottle laboris disrupt
@@ -278,7 +278,10 @@ export const NoAnimation: Story<ISplitHorizontalProps> = (args) => {
 					<button onClick={this.handleToggle}>toggle</button>
 
 					<section style={{ outline: '1px solid #e3e3e3' }}>
-						<SplitHorizontal {...args} isExpanded={this.state.isExpanded}>
+						<SplitHorizontal
+							{...(args as any)}
+							isExpanded={this.state.isExpanded}
+						>
 							<SplitHorizontal.TopPane>
 								<p>
 									Magna non tacos, et raw denim food truck mixtape semiotics
@@ -337,7 +340,7 @@ export const CollapseShift: Story<ISplitHorizontalProps> = (args) => {
 
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
-							{...args}
+							{...(args as any)}
 							style={{ height: '100%' }}
 							collapseShift={64}
 							isAnimated
@@ -403,7 +406,7 @@ export const HandleResize: Story<ISplitHorizontalProps> = (args) => {
 					New Height: {`${this.state.newHeight}`}
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
-							{...args}
+							{...(args as any)}
 							style={{ height: '100%' }}
 							onResizing={this.handleResizing}
 							onResize={this.handleResize}

--- a/src/components/SplitHorizontal/SplitHorizontal.stories.tsx
+++ b/src/components/SplitHorizontal/SplitHorizontal.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import createClass from 'create-react-class';
-import SplitHorizontal from './SplitHorizontal';
+import { Meta, Story } from '@storybook/react';
+
+import SplitHorizontal, { ISplitHorizontalProps } from './SplitHorizontal';
 
 export default {
 	title: 'Private/SplitHorizontal',
@@ -8,58 +10,51 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (SplitHorizontal as any).peek.description,
+				component: SplitHorizontal.peek.description,
 			},
 		},
 	},
-};
+	args: SplitHorizontal.defaultProps,
+} as Meta;
 
 /* Default Split */
-export const DefaultSplit = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<SplitHorizontal>
-					<SplitHorizontal.TopPane>
-						<p>
-							Bicycle rights tofu hashtag blue bottle viral. Mixtape kinfolk
-							mustache, iPhone godard voluptate direct trade pork belly truffaut
-							duis sunt. 8-bit microdosing retro, excepteur direct trade offal
-							listicle kale chips selvage master cleanse sustainable laborum
-							migas helvetica. Man bun esse synth man braid fashion axe
-							post-ironic id, fanny pack PBR&B. Scenester truffaut culpa yr
-							heirloom, fanny pack intelligentsia dreamcatcher dolore nisi green
-							juice ad you probably haven't heard of them raw denim. Before they
-							sold out laborum poutine 90's, blog voluptate chambray whatever.
-							Excepteur ea kinfolk, irure photo booth brooklyn art party master
-							cleanse mlkshk pug.
-						</p>
-					</SplitHorizontal.TopPane>
-					<SplitHorizontal.BottomPane>
-						<p>
-							Aliquip hella incididunt, fashion axe irure small batch
-							single-origin coffee ullamco. Offal fugiat salvia brooklyn
-							meditation occaecat polaroid, fashion axe culpa intelligentsia.
-							Sint ex intelligentsia fixie assumenda sriracha laborum, portland
-							literally bespoke you probably haven't heard of them. Delectus
-							skateboard put a bird on it, in kale chips messenger bag lo-fi.
-							Cred nihil tote bag street art, id et velit authentic ullamco
-							excepteur cold-pressed fixie shabby chic art party blue bottle.
-							Mumblecore tempor selvage cray put a bird on it. Flexitarian
-							crucifix tempor do pinterest, cornhole street art fap affogato
-							selfies distillery consectetur listicle.
-						</p>
-					</SplitHorizontal.BottomPane>
-				</SplitHorizontal>
-			);
-		},
-	});
-
-	return <Component />;
+export const DefaultSplit: Story<ISplitHorizontalProps> = (args) => {
+	return (
+		<SplitHorizontal {...args}>
+			<SplitHorizontal.TopPane>
+				<p>
+					Bicycle rights tofu hashtag blue bottle viral. Mixtape kinfolk
+					mustache, iPhone godard voluptate direct trade pork belly truffaut
+					duis sunt. 8-bit microdosing retro, excepteur direct trade offal
+					listicle kale chips selvage master cleanse sustainable laborum migas
+					helvetica. Man bun esse synth man braid fashion axe post-ironic id,
+					fanny pack PBR&B. Scenester truffaut culpa yr heirloom, fanny pack
+					intelligentsia dreamcatcher dolore nisi green juice ad you probably
+					haven't heard of them raw denim. Before they sold out laborum poutine
+					90's, blog voluptate chambray whatever. Excepteur ea kinfolk, irure
+					photo booth brooklyn art party master cleanse mlkshk pug.
+				</p>
+			</SplitHorizontal.TopPane>
+			<SplitHorizontal.BottomPane>
+				<p>
+					Aliquip hella incididunt, fashion axe irure small batch single-origin
+					coffee ullamco. Offal fugiat salvia brooklyn meditation occaecat
+					polaroid, fashion axe culpa intelligentsia. Sint ex intelligentsia
+					fixie assumenda sriracha laborum, portland literally bespoke you
+					probably haven't heard of them. Delectus skateboard put a bird on it,
+					in kale chips messenger bag lo-fi. Cred nihil tote bag street art, id
+					et velit authentic ullamco excepteur cold-pressed fixie shabby chic
+					art party blue bottle. Mumblecore tempor selvage cray put a bird on
+					it. Flexitarian crucifix tempor do pinterest, cornhole street art fap
+					affogato selfies distillery consectetur listicle.
+				</p>
+			</SplitHorizontal.BottomPane>
+		</SplitHorizontal>
+	);
 };
 
 /* Animated Collapse */
-export const AnimatedCollapse = () => {
+export const AnimatedCollapse: Story<ISplitHorizontalProps> = (args) => {
 	const Component = createClass({
 		getInitialState() {
 			return {
@@ -77,6 +72,7 @@ export const AnimatedCollapse = () => {
 
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
+							{...args}
 							style={{ height: '100%' }}
 							isAnimated
 							isExpanded={this.state.isExpanded}
@@ -121,10 +117,9 @@ export const AnimatedCollapse = () => {
 
 	return <Component />;
 };
-AnimatedCollapse.storyName = 'AnimatedCollapse';
 
 /* Set Pane As Primary */
-export const SetPaneAsPrimary = () => {
+export const SetPaneAsPrimary: Story<ISplitHorizontalProps> = (args) => {
 	const Component = createClass({
 		getInitialState() {
 			return {
@@ -142,6 +137,7 @@ export const SetPaneAsPrimary = () => {
 
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
+							{...args}
 							style={{ height: '100%' }}
 							isAnimated
 							isExpanded={this.state.isExpanded}
@@ -182,108 +178,90 @@ export const SetPaneAsPrimary = () => {
 
 	return <Component />;
 };
-SetPaneAsPrimary.storyName = 'SetPaneAsPrimary';
 
 /* Set Height Of Pane */
-export const SetHeightOfPane = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
-					<SplitHorizontal>
-						<SplitHorizontal.TopPane height={64}>
-							<p>
-								Jean shorts reprehenderit in, commodo godard skateboard retro
-								heirloom street art church-key. Gochujang sint hella food truck,
-								officia next level sriracha listicle knausgaard try-hard 3 wolf
-								moon kale chips. Offal scenester quinoa, hammock qui sint direct
-								trade heirloom. Bushwick letterpress pabst, odio nihil sapiente
-								ex cold-pressed flannel laboris wayfarers retro marfa jean
-								shorts. Chia next level cardigan, deserunt church-key
-								asymmetrical ennui messenger bag portland. Aute selvage cred
-								gastropub freegan literally. Readymade artisan distillery
-								occaecat qui.
-							</p>
-						</SplitHorizontal.TopPane>
-						<SplitHorizontal.BottomPane isPrimary>
-							<p>
-								Plaid wolf cold-pressed, post-ironic etsy roof party tilde
-								tattooed pug stumptown sed tofu art party ennui. Asymmetrical
-								wayfarers dolor dolore, nisi mollit sed austin skateboard
-								readymade 90's tumblr fugiat sint shoreditch. Cillum
-								intelligentsia esse next level polaroid, beard vero. Qui
-								polaroid portland beard artisan. Mixtape qui hella est. Fap
-								consectetur freegan roof party duis mollit. Mixtape swag
-								mustache, twee fashion axe sustainable ennui aliquip mlkshk
-								gastropub seitan commodo photo booth blue bottle.
-							</p>
-						</SplitHorizontal.BottomPane>
-					</SplitHorizontal>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const SetHeightOfPane: Story<ISplitHorizontalProps> = (args) => {
+	return (
+		<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
+			<SplitHorizontal {...args}>
+				<SplitHorizontal.TopPane height={64}>
+					<p>
+						Jean shorts reprehenderit in, commodo godard skateboard retro
+						heirloom street art church-key. Gochujang sint hella food truck,
+						officia next level sriracha listicle knausgaard try-hard 3 wolf moon
+						kale chips. Offal scenester quinoa, hammock qui sint direct trade
+						heirloom. Bushwick letterpress pabst, odio nihil sapiente ex
+						cold-pressed flannel laboris wayfarers retro marfa jean shorts. Chia
+						next level cardigan, deserunt church-key asymmetrical ennui
+						messenger bag portland. Aute selvage cred gastropub freegan
+						literally. Readymade artisan distillery occaecat qui.
+					</p>
+				</SplitHorizontal.TopPane>
+				<SplitHorizontal.BottomPane isPrimary>
+					<p>
+						Plaid wolf cold-pressed, post-ironic etsy roof party tilde tattooed
+						pug stumptown sed tofu art party ennui. Asymmetrical wayfarers dolor
+						dolore, nisi mollit sed austin skateboard readymade 90's tumblr
+						fugiat sint shoreditch. Cillum intelligentsia esse next level
+						polaroid, beard vero. Qui polaroid portland beard artisan. Mixtape
+						qui hella est. Fap consectetur freegan roof party duis mollit.
+						Mixtape swag mustache, twee fashion axe sustainable ennui aliquip
+						mlkshk gastropub seitan commodo photo booth blue bottle.
+					</p>
+				</SplitHorizontal.BottomPane>
+			</SplitHorizontal>
+		</section>
+	);
 };
-SetHeightOfPane.storyName = 'SetHeightOfPane';
 
 /* Customize Divider */
-export const CustomizeDivider = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<SplitHorizontal>
-					<SplitHorizontal.TopPane>
-						<p>
-							Waistcoat man bun sartorial, PBR&B artisan blue bottle laboris
-							disrupt pug dreamcatcher readymade gluten-free fingerstache
-							placeat. Enim salvia celiac, veniam polaroid stumptown velit
-							PBR&B. Ramps delectus cupidatat dolore. Portland try-hard
-							slow-carb cronut, drinking vinegar readymade nulla pug aliqua cray
-							VHS eiusmod odio incididunt wolf. 3 wolf moon gentrify mustache
-							blog freegan, literally ut helvetica stumptown godard synth direct
-							trade. Sapiente slow-carb deep v, YOLO direct trade irony before
-							they sold out tempor. Sunt aliqua seitan banjo.
-						</p>
-					</SplitHorizontal.TopPane>
+export const CustomizeDivider: Story<ISplitHorizontalProps> = (args) => {
+	return (
+		<SplitHorizontal {...args}>
+			<SplitHorizontal.TopPane>
+				<p>
+					Waistcoat man bun sartorial, PBR&B artisan blue bottle laboris disrupt
+					pug dreamcatcher readymade gluten-free fingerstache placeat. Enim
+					salvia celiac, veniam polaroid stumptown velit PBR&B. Ramps delectus
+					cupidatat dolore. Portland try-hard slow-carb cronut, drinking vinegar
+					readymade nulla pug aliqua cray VHS eiusmod odio incididunt wolf. 3
+					wolf moon gentrify mustache blog freegan, literally ut helvetica
+					stumptown godard synth direct trade. Sapiente slow-carb deep v, YOLO
+					direct trade irony before they sold out tempor. Sunt aliqua seitan
+					banjo.
+				</p>
+			</SplitHorizontal.TopPane>
 
-					<SplitHorizontal.Divider
-						style={{
-							height: 18,
-							background: 'gray',
-							color: 'white',
-							textAlign: 'center',
-						}}
-					>
-						D I V I D E R
-					</SplitHorizontal.Divider>
+			<SplitHorizontal.Divider
+				style={{
+					height: 18,
+					background: 'gray',
+					color: 'white',
+					textAlign: 'center',
+				}}
+			>
+				D I V I D E R
+			</SplitHorizontal.Divider>
 
-					<SplitHorizontal.BottomPane>
-						<p>
-							Exercitation fixie distillery pickled, gentrify meh laborum
-							accusamus quinoa street art craft beer migas affogato chia. PBR&B
-							cillum dolore, tilde sed eu tote bag narwhal vero schlitz chambray
-							viral raw denim velit single-origin coffee. Occupy tempor hashtag
-							non. Wayfarers bitters blog fixie mollit flexitarian forage.
-							Listicle sriracha bespoke, laborum direct trade skateboard cliche
-							umami selvage velit art party sartorial forage veniam. Authentic
-							tattooed nesciunt before they sold out, blue bottle bicycle rights
-							gastropub magna veniam hammock. Sint venmo nihil, meditation
-							voluptate readymade banh mi.
-						</p>
-					</SplitHorizontal.BottomPane>
-				</SplitHorizontal>
-			);
-		},
-	});
-
-	return <Component />;
+			<SplitHorizontal.BottomPane>
+				<p>
+					Exercitation fixie distillery pickled, gentrify meh laborum accusamus
+					quinoa street art craft beer migas affogato chia. PBR&B cillum dolore,
+					tilde sed eu tote bag narwhal vero schlitz chambray viral raw denim
+					velit single-origin coffee. Occupy tempor hashtag non. Wayfarers
+					bitters blog fixie mollit flexitarian forage. Listicle sriracha
+					bespoke, laborum direct trade skateboard cliche umami selvage velit
+					art party sartorial forage veniam. Authentic tattooed nesciunt before
+					they sold out, blue bottle bicycle rights gastropub magna veniam
+					hammock. Sint venmo nihil, meditation voluptate readymade banh mi.
+				</p>
+			</SplitHorizontal.BottomPane>
+		</SplitHorizontal>
+	);
 };
-CustomizeDivider.storyName = 'CustomizeDivider';
 
 /* No Animation */
-export const NoAnimation = () => {
+export const NoAnimation: Story<ISplitHorizontalProps> = (args) => {
 	const Component = createClass({
 		getInitialState() {
 			return {
@@ -300,7 +278,7 @@ export const NoAnimation = () => {
 					<button onClick={this.handleToggle}>toggle</button>
 
 					<section style={{ outline: '1px solid #e3e3e3' }}>
-						<SplitHorizontal isExpanded={this.state.isExpanded}>
+						<SplitHorizontal {...args} isExpanded={this.state.isExpanded}>
 							<SplitHorizontal.TopPane>
 								<p>
 									Magna non tacos, et raw denim food truck mixtape semiotics
@@ -339,10 +317,9 @@ export const NoAnimation = () => {
 
 	return <Component />;
 };
-NoAnimation.storyName = 'NoAnimation';
 
 /* Collapse Shift */
-export const CollapseShift = () => {
+export const CollapseShift: Story<ISplitHorizontalProps> = (args) => {
 	const Component = createClass({
 		getInitialState() {
 			return {
@@ -360,6 +337,7 @@ export const CollapseShift = () => {
 
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
+							{...args}
 							style={{ height: '100%' }}
 							collapseShift={64}
 							isAnimated
@@ -401,10 +379,9 @@ export const CollapseShift = () => {
 
 	return <Component />;
 };
-CollapseShift.storyName = 'CollapseShift';
 
 /* Handle Resize */
-export const HandleResize = () => {
+export const HandleResize: Story<ISplitHorizontalProps> = (args) => {
 	const Component = createClass({
 		getInitialState() {
 			return {
@@ -426,6 +403,7 @@ export const HandleResize = () => {
 					New Height: {`${this.state.newHeight}`}
 					<section style={{ height: 300, outline: '1px solid #e3e3e3' }}>
 						<SplitHorizontal
+							{...args}
 							style={{ height: '100%' }}
 							onResizing={this.handleResizing}
 							onResize={this.handleResize}
@@ -469,4 +447,3 @@ export const HandleResize = () => {
 
 	return <Component />;
 };
-HandleResize.storyName = 'HandleResize';

--- a/src/components/SplitHorizontal/SplitHorizontal.tsx
+++ b/src/components/SplitHorizontal/SplitHorizontal.tsx
@@ -1,12 +1,9 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React, { RefObject } from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	filterTypes,
-	omitProps,
-	StandardProps,
-} from '../../util/component-types';
+import { filterTypes, StandardProps } from '../../util/component-types';
 import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
 import { Motion, spring, OpaqueConfig } from 'react-motion';
 import { QUICK_SLIDE_MOTION } from '../../constants/motion-spring';
@@ -15,9 +12,12 @@ const cx = lucidClassNames.bind('&-SplitHorizontal');
 
 const { bool, func, node, number, string, oneOfType } = PropTypes;
 
+/** SplitHorizontal TopPane */
+
 export interface ISplitHorizontalTopPaneProps extends StandardProps {
 	/** Set height of this pane. */
 	height?: number | string;
+
 	/** Define this pane as the primary content pane. When the split is
 		collapsed, this pane becomes full height. */
 	isPrimary: boolean;
@@ -49,6 +49,7 @@ SplitHorizontalTopPane.defaultProps = {
 	isPrimary: false,
 };
 
+/** SplitHorizontal Bottom Pane */
 export interface ISplitHorizontalBottomPaneProps extends StandardProps {
 	/** Set height of this pane. */
 	height?: number | string;
@@ -56,7 +57,7 @@ export interface ISplitHorizontalBottomPaneProps extends StandardProps {
 		collapsed, this pane becomes full height. */
 	isPrimary: boolean;
 }
-const SplitHorizontalBottomPane = (
+export const SplitHorizontalBottomPane = (
 	_props: ISplitHorizontalBottomPaneProps
 ): null => null;
 SplitHorizontalBottomPane.displayName = 'SplitHorizontal.BottomPane';
@@ -83,6 +84,7 @@ SplitHorizontalBottomPane.defaultProps = {
 	isPrimary: false,
 };
 
+/** SplitHorizontal Divider */
 export interface ISplitHorizontalDividerProps extends StandardProps {}
 const SplitHorizontalDivider = (_props: ISplitHorizontalDividerProps): null =>
 	null;
@@ -98,6 +100,7 @@ SplitHorizontalDivider.propTypes = {
 	children: node,
 };
 
+/** Split Horizontal */
 export interface ISplitHorizontalProps
 	extends StandardProps,
 		React.DetailedHTMLProps<
@@ -137,6 +140,24 @@ export interface ISplitHorizontalProps
 	/** Use this prop to shift the collapsed position by a known value. */
 	collapseShift: number;
 }
+
+const nonPassThroughs = [
+	'className',
+	'children',
+	'isExpanded',
+	'isAnimated',
+	'onResizing',
+	'onResize',
+	'collapseShift',
+	'TopPane',
+	'BottomPane',
+	'Divider',
+	'onSelect',
+	'onToggle',
+	'initialState',
+	'callbackId',
+];
+
 interface ISplitHorizontalState {
 	collapseAmount: number;
 	isAnimated: boolean;
@@ -485,7 +506,7 @@ class SplitHorizontal extends React.Component<
 
 		return (
 			<div
-				{...omitProps(this.props, undefined, _.keys(SplitHorizontal.propTypes))}
+				{...omit(passThroughs, nonPassThroughs)}
 				className={cx(
 					'&',
 					{
@@ -525,11 +546,12 @@ class SplitHorizontal extends React.Component<
 							}}
 						>
 							<div
-								{...omitProps(
-									topPaneProps,
-									undefined,
-									_.keys(SplitHorizontalTopPane.propTypes)
-								)}
+								{...omit(topPaneProps, [
+									'height',
+									'isPrimary',
+									'initialState',
+									'callbackId',
+								])}
 								className={cx(
 									'&-TopPane',
 									{
@@ -556,12 +578,11 @@ class SplitHorizontal extends React.Component<
 								{topPaneProps.children}
 							</div>
 							<DragCaptureZone
-								{...omitProps(
-									dividerProps,
-									undefined,
-									_.keys(SplitHorizontalDivider.propTypes),
-									false
-								)}
+								{...omit(dividerProps, [
+									'children',
+									'initialState',
+									'callbackId',
+								])}
 								className={cx('&-Divider', dividerProps.className)}
 								onDragStart={this.handleDragStart}
 								onDrag={this.handleDrag}
@@ -575,11 +596,12 @@ class SplitHorizontal extends React.Component<
 								{dividerProps.children || ' '}
 							</DragCaptureZone>
 							<div
-								{...omitProps(
-									bottomPaneProps,
-									undefined,
-									_.keys(SplitHorizontalBottomPane.propTypes)
-								)}
+								{...omit(bottomPaneProps, [
+									'height',
+									'isPrimary',
+									'initialState',
+									'callbackId',
+								])}
 								className={cx(
 									'&-BottomPane',
 									{

--- a/src/components/VerticalListMenu/VerticalListMenu.spec.tsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.spec.tsx
@@ -1,4 +1,4 @@
-import _, { forEach, has, noop } from 'lodash';
+import _, { forEach, has } from 'lodash';
 import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';

--- a/src/components/VerticalListMenu/VerticalListMenu.spec.tsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.spec.tsx
@@ -1,10 +1,11 @@
-import _ from 'lodash';
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import assert from 'assert';
+import sinon from 'sinon';
 import { shallow, mount } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import { VerticalListMenuDumb as VerticalListMenu } from './VerticalListMenu';
-import sinon from 'sinon';
 
 describe('VerticalListMenu', () => {
 	common(VerticalListMenu);
@@ -212,6 +213,61 @@ describe('VerticalListMenu', () => {
 				assert(
 					_.has(onToggle.args[0][1], 'props'),
 					'missing `props` on the onToggle callback'
+				);
+			});
+		});
+
+		describe('pass throughs', () => {
+			let wrapper: any;
+			const defaultProps = VerticalListMenu.defaultProps;
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					selectedIndices: [1],
+					expandedIndicies: [1, 2],
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<VerticalListMenu {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-VerticalListMenu').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' and style are plucked from the pass through object
+				// but still appears becuase each one is also directly added to the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-VerticalListMenu').props();
+				forEach(
+					[
+						'selectedIndices',
+						'expandedIndices',
+						'onSelect',
+						'onToggle',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
 				);
 			});
 		});

--- a/src/components/VerticalListMenu/VerticalListMenu.stories.tsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.stories.tsx
@@ -27,7 +27,7 @@ function addKeys(children: any) {
 const Template: Story<IVerticalListMenuProps> = (args) => {
 	return (
 		<section>
-			<VerticalListMenu {...args} style={{ width: 250 }} />
+			<VerticalListMenu {...(args as any)} style={{ width: 250 }} />
 		</section>
 	);
 };
@@ -54,7 +54,7 @@ export const NestedWithExpander: Story<IVerticalListMenuProps> = (args) => {
 	};
 	return (
 		<VerticalListMenu
-			{...args}
+			{...(args as any)}
 			style={{ width: 250 }}
 			onSelect={partial(handleSelect, 'one')}
 			selectedIndices={currentList === 'one' ? selectedIndices : []}
@@ -104,7 +104,7 @@ export const NestedFullWidth: Story<IVerticalListMenuProps> = (args) => {
 	};
 	return (
 		<VerticalListMenu
-			{...args}
+			{...(args as any)}
 			onSelect={partial(handleSelect, 'one')}
 			selectedIndices={currentList === 'one' ? selectedIndices : []}
 		>

--- a/src/components/VerticalListMenu/VerticalListMenu.stories.tsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.stories.tsx
@@ -1,7 +1,8 @@
 import { map, times, partial } from 'lodash';
 import React, { useState } from 'react';
-import { Meta } from '@storybook/react';
-import VerticalListMenu from './VerticalListMenu';
+import { Meta, Story } from '@storybook/react';
+
+import VerticalListMenu, { IVerticalListMenuProps } from './VerticalListMenu';
 
 //👇 Provide Storybook with the component name, 'section', any subcomponents and a description
 export default {
@@ -14,6 +15,7 @@ export default {
 			},
 		},
 	},
+	args: VerticalListMenu.defaultProps,
 } as Meta;
 
 //👇 Add a key prop to each child element of the array
@@ -22,7 +24,7 @@ function addKeys(children: any) {
 }
 
 //👇 Create a “template” of how args map to rendering
-const Template: any = (args) => {
+const Template: Story<IVerticalListMenuProps> = (args) => {
 	return (
 		<section>
 			<VerticalListMenu {...args} style={{ width: 250 }} />
@@ -32,8 +34,8 @@ const Template: any = (args) => {
 
 //👇 Each story then reuses that template
 
-/**Default */
-export const Basic = Template.bind({});
+/** Basic VerticalListMenu */
+export const Basic: Story<IVerticalListMenuProps> = Template.bind({});
 Basic.args = {
 	children: addKeys([
 		<VerticalListMenu.Item>Level one</VerticalListMenu.Item>,
@@ -43,7 +45,7 @@ Basic.args = {
 };
 
 /** Nested With Expander */
-export const NestedWithExpander = () => {
+export const NestedWithExpander: Story<IVerticalListMenuProps> = (args) => {
 	const [currentList, setCurrentList] = useState('one');
 	const [selectedIndices, setSelectedIndices] = useState([0]);
 	const handleSelect = (currentList: string, index: number) => {
@@ -52,6 +54,7 @@ export const NestedWithExpander = () => {
 	};
 	return (
 		<VerticalListMenu
+			{...args}
 			style={{ width: 250 }}
 			onSelect={partial(handleSelect, 'one')}
 			selectedIndices={currentList === 'one' ? selectedIndices : []}
@@ -92,7 +95,7 @@ export const NestedWithExpander = () => {
 };
 
 /** Nested Full Width */
-export const NestedFullWidth = () => {
+export const NestedFullWidth: Story<IVerticalListMenuProps> = (args) => {
 	const [currentList, setCurrentList] = useState('one');
 	const [selectedIndices, setSelectedIndices] = useState([0]);
 	const handleSelect = (currentList: string, index: number) => {
@@ -101,6 +104,7 @@ export const NestedFullWidth = () => {
 	};
 	return (
 		<VerticalListMenu
+			{...args}
 			onSelect={partial(handleSelect, 'one')}
 			selectedIndices={currentList === 'one' ? selectedIndices : []}
 		>
@@ -142,7 +146,7 @@ export const NestedFullWidth = () => {
 };
 
 /** No Animations */
-export const NoAnimations = Template.bind({});
+export const NoAnimations: Story<IVerticalListMenuProps> = Template.bind({});
 NoAnimations.args = {
 	children: addKeys([
 		<VerticalListMenu.Item>Level one</VerticalListMenu.Item>,

--- a/src/components/VerticalListMenu/VerticalListMenu.tsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
@@ -275,11 +275,17 @@ class VerticalListMenu extends React.Component<
 
 		return (
 			<ul
-				{...omitProps(
-					passThroughs,
-					undefined,
-					_.keys(VerticalListMenu.propTypes)
-				)}
+				{...(omit(passThroughs, [
+					'children',
+					'className',
+					'style',
+					'selectedIndices',
+					'expandedIndices',
+					'onSelect',
+					'onToggle',
+					'initialState',
+					'callbackId',
+				]) as any)}
 				className={cx('&', className)}
 				style={style}
 			>


### PR DESCRIPTION
## PR Checklist

Description of changes:
VerticalListMenu & Split Horizontal
replace omitProps with explicit list of props

Link(s) to Storybook on docspot:

https://docspot.adnxs.net/projects/lucid/CXP-2529-VerticalListMenu-replace-omitProps/?path=/docs/navigation-verticallistmenu--basic

https://docspot.adnxs.net/projects/lucid/CXP-2529-VerticalListMenu-replace-omitProps/?path=/docs/private-splithorizontal--default-split


- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
