### PR TITLE
Cxp 2581 split button replace omit props

### DIFF
--- a/src/components/SplitButton/SplitButton.spec.tsx
+++ b/src/components/SplitButton/SplitButton.spec.tsx
@@ -1,10 +1,73 @@
-import { shallow } from 'enzyme';
+import _, { forEach, has } from 'lodash';
 import React from 'react';
+import { shallow } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import { SplitButtonDumb as SplitButton } from './SplitButton';
 
 describe('SplitButton', () => {
 	common(SplitButton);
+
+	describe('props', () => {
+		describe('root pass throughs', () => {
+			let wrapper: any;
+			const defaultProps = SplitButton.defaultProps;
+
+			beforeEach(() => {
+				const props = {
+					...defaultProps,
+					children: <SplitButton.Button>One</SplitButton.Button>,
+					direction: 'up' as any,
+					kind: 'danger' as any,
+					size: 'small' as any,
+					type: 'button',
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<SplitButton {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-SplitButton').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className', 'direction' and 'onSelect' are plucked from the pass through object
+				// but still appears becuase each one is also directly added to the root element as a prop
+				forEach(
+					['className', 'data-testid', 'direction', 'onSelect', 'children'],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-SplitButton').props();
+
+				// Note that the SplitButton root element is not a DOM Element
+				// It is a DropMenu, so it should probably not omit `callbackId`
+				// However, that is the way that it has been working for years,
+				// so I did not modify it when I removed `omitProps` - NJY 18 Apr 22.
+				forEach(
+					['DropMenu', 'kind', 'size', 'type', 'initialState', 'callbackId'],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
+			});
+		});
+	});
 
 	describe('click handlers', () => {
 		const handleClick = jest.fn();

--- a/src/components/SplitButton/SplitButton.stories.tsx
+++ b/src/components/SplitButton/SplitButton.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import createClass from 'create-react-class';
-import SplitButton from './SplitButton';
+import { Meta, Story } from '@storybook/react';
+
+import SplitButton, { ISplitButtonProps } from './SplitButton';
 
 export default {
 	title: 'Controls/SplitButton',
@@ -8,110 +9,87 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (SplitButton as any).peek.description,
+				component: SplitButton.peek.description,
 			},
 		},
 	},
-};
+	args: SplitButton.defaultProps,
+} as Meta;
 
 /* Basic */
-export const Basic = () => {
+export const Basic: Story<ISplitButtonProps> = (args) => {
 	const style = { marginRight: '20px', height: 100 };
 
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<SplitButton style={style}>
-						<SplitButton.Button>Basic</SplitButton.Button>
-						<SplitButton.Button>One</SplitButton.Button>
-						<SplitButton.Button>Two</SplitButton.Button>
-					</SplitButton>
+	return (
+		<section>
+			<SplitButton {...args} style={style}>
+				<SplitButton.Button>Basic</SplitButton.Button>
+				<SplitButton.Button>One</SplitButton.Button>
+				<SplitButton.Button>Two</SplitButton.Button>
+			</SplitButton>
 
-					<SplitButton kind='primary' style={style}>
-						<SplitButton.Button>Primary</SplitButton.Button>
-						<SplitButton.Button>One</SplitButton.Button>
-						<SplitButton.Button>Two</SplitButton.Button>
-					</SplitButton>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+			<SplitButton {...args} kind='primary' style={style}>
+				<SplitButton.Button>Primary</SplitButton.Button>
+				<SplitButton.Button>One</SplitButton.Button>
+				<SplitButton.Button>Two</SplitButton.Button>
+			</SplitButton>
+		</section>
+	);
 };
 
 /* Disabled */
-export const Disabled = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div style={{ height: 100 }}>
-					<SplitButton>
-						<SplitButton.Button isDisabled>Save</SplitButton.Button>
-						<SplitButton.Button isDisabled>
-							This action should be disabled
-						</SplitButton.Button>
-						<SplitButton.Button>This one should be enabled</SplitButton.Button>
-						<SplitButton.Button isDisabled>
-							This should be disabled, too
-						</SplitButton.Button>
-					</SplitButton>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+export const Disabled: Story<ISplitButtonProps> = (args) => {
+	return (
+		<section style={{ height: 100 }}>
+			<SplitButton {...args}>
+				<SplitButton.Button isDisabled>Save</SplitButton.Button>
+				<SplitButton.Button isDisabled>
+					This action should be disabled
+				</SplitButton.Button>
+				<SplitButton.Button>This one should be enabled</SplitButton.Button>
+				<SplitButton.Button isDisabled>
+					This should be disabled, too
+				</SplitButton.Button>
+			</SplitButton>
+		</section>
+	);
 };
 
 /* Up */
-export const Up = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<div style={{ height: 100 }}>
-					<SplitButton direction='up' kind='primary'>
-						<SplitButton.Button>Save</SplitButton.Button>
-						<SplitButton.Button>Action 01</SplitButton.Button>
-						<SplitButton.Button>Here's Another Action</SplitButton.Button>
-						<SplitButton.Button>And Another Action</SplitButton.Button>
-					</SplitButton>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+export const Up: Story<ISplitButtonProps> = (args) => {
+	return (
+		<section style={{ height: 100 }}>
+			<SplitButton {...args} direction='up' kind='primary'>
+				<SplitButton.Button>Save</SplitButton.Button>
+				<SplitButton.Button>Action 01</SplitButton.Button>
+				<SplitButton.Button>Here's Another Action</SplitButton.Button>
+				<SplitButton.Button>And Another Action</SplitButton.Button>
+			</SplitButton>
+		</section>
+	);
 };
 
 /* Sizes */
-export const Sizes = () => {
+export const Sizes: Story<ISplitButtonProps> = (args) => {
 	const style = { marginRight: '20px', height: 100 };
 
-	const Component = createClass({
-		render() {
-			return (
-				<div>
-					<SplitButton size='large' style={style}>
-						<SplitButton.Button>Large</SplitButton.Button>
-						<SplitButton.Button>One</SplitButton.Button>
-						<SplitButton.Button>Two</SplitButton.Button>
-					</SplitButton>
-					<SplitButton size='small' style={style}>
-						<SplitButton.Button>Small</SplitButton.Button>
-						<SplitButton.Button>One</SplitButton.Button>
-						<SplitButton.Button>Two</SplitButton.Button>
-					</SplitButton>
-					<SplitButton size='short' style={style}>
-						<SplitButton.Button>Short</SplitButton.Button>
-						<SplitButton.Button>One</SplitButton.Button>
-						<SplitButton.Button>Two</SplitButton.Button>
-					</SplitButton>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section>
+			<SplitButton {...args} size='large' style={style}>
+				<SplitButton.Button>Large</SplitButton.Button>
+				<SplitButton.Button>One</SplitButton.Button>
+				<SplitButton.Button>Two</SplitButton.Button>
+			</SplitButton>
+			<SplitButton {...args} size='small' style={style}>
+				<SplitButton.Button>Small</SplitButton.Button>
+				<SplitButton.Button>One</SplitButton.Button>
+				<SplitButton.Button>Two</SplitButton.Button>
+			</SplitButton>
+			<SplitButton {...args} size='short' style={style}>
+				<SplitButton.Button>Short</SplitButton.Button>
+				<SplitButton.Button>One</SplitButton.Button>
+				<SplitButton.Button>Two</SplitButton.Button>
+			</SplitButton>
+		</section>
+	);
 };

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -1,11 +1,11 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	filterTypes,
 	getFirst,
-	omitProps,
 	StandardProps,
 } from '../../util/component-types';
 import { buildModernHybridComponent } from '../../util/state-management';
@@ -56,6 +56,7 @@ ButtonChild.propTypes = {
 	onClick: func,
 };
 
+/** SplitButton */
 export interface ISplitButtonProps extends StandardProps {
 	/** Sets the direction the flyout menu will render relative to the SplitButton. */
 	direction: 'up' | 'down';
@@ -203,11 +204,17 @@ class SplitButton extends React.Component<ISplitButtonProps> {
 		return (
 			<DropMenu
 				{...dropMenuProps}
-				{...omitProps(
-					passThroughs,
-					undefined,
-					_.keys(DropMenu.Option.propTypes)
-				)}
+				{...omit(passThroughs, [
+					'DropMenu',
+					'children',
+					'className',
+					'direction',
+					'kind',
+					'size',
+					'type',
+					'initialState',
+					'callbackId',
+				])}
 				direction={direction}
 				className={cx('&', className)}
 				onSelect={this.handleSelect}

--- a/src/components/SplitButton/__snapshots__/SplitButton.spec.tsx.snap
+++ b/src/components/SplitButton/__snapshots__/SplitButton.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SplitButton [common] example testing should match snapshot(s) for Basic 1`] = `
-<div>
+<section>
   <div
     class="lucid-DropMenu lucid-DropMenu-base lucid-SplitButton"
     style="margin-right:20px;height:100px"
@@ -98,11 +98,11 @@ exports[`SplitButton [common] example testing should match snapshot(s) for Basic
       </div>
     </span>
   </div>
-</div>
+</section>
 `;
 
 exports[`SplitButton [common] example testing should match snapshot(s) for Disabled 1`] = `
-<div
+<section
   style="height:100px"
 >
   <div
@@ -153,11 +153,11 @@ exports[`SplitButton [common] example testing should match snapshot(s) for Disab
       </div>
     </span>
   </div>
-</div>
+</section>
 `;
 
 exports[`SplitButton [common] example testing should match snapshot(s) for Sizes 1`] = `
-<div>
+<section>
   <div
     class="lucid-DropMenu lucid-DropMenu-base lucid-SplitButton"
     style="margin-right:20px;height:100px"
@@ -302,11 +302,11 @@ exports[`SplitButton [common] example testing should match snapshot(s) for Sizes
       </div>
     </span>
   </div>
-</div>
+</section>
 `;
 
 exports[`SplitButton [common] example testing should match snapshot(s) for Up 1`] = `
-<div
+<section
   style="height:100px"
 >
   <div
@@ -356,7 +356,7 @@ exports[`SplitButton [common] example testing should match snapshot(s) for Up 1`
       </div>
     </span>
   </div>
-</div>
+</section>
 `;
 
 exports[`SplitButton click handlers primary button should trigger \`handleClick\` 1`] = `


### PR DESCRIPTION
## PR Checklist

Description of changes:
[Add unit tests for omitted props]
[Update stories to SB6]
[Update snapshots]
[Replace omitProps with explicit list of props]

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2581-SplitButton-replace-omitProps/?path=/docs/controls-splitbutton--basic

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
