### PR TITLE
Cxp 2584 sticky section replace omit props

### DIFF
--- a/src/components/StickySection/StickySection.spec.tsx
+++ b/src/components/StickySection/StickySection.spec.tsx
@@ -1,7 +1,8 @@
+import _, { forEach, has } from 'lodash';
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import assert from 'assert';
-import _ from 'lodash';
+
 import { common } from '../../util/generic-tests';
 import { dispatchDOMEvent } from '../../util/dom-helpers';
 import StickySection from './StickySection';
@@ -22,6 +23,52 @@ describe('StickySection', () => {
 	});
 
 	describe('props', () => {
+		describe('root pass throughs', () => {
+			let wrapper: any;
+
+			beforeEach(() => {
+				const props = {
+					lowerBound: 20,
+					topOffset: 200,
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<StickySection {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-StickySection').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' and style are plucked from the pass through object
+				// but still appears becuase each one is also directly added to the root element as a prop
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-StickySection').props();
+				forEach(
+					['lowerBound', 'topOffset', 'initialState', 'callbackId'],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
+			});
+		});
+
 		describe('lowerBound', () => {
 			let wrapper: any;
 			let mountTestdiv: any;

--- a/src/components/StickySection/StickySection.stories.tsx
+++ b/src/components/StickySection/StickySection.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import createClass from 'create-react-class';
-import StickySection from './StickySection';
+import { Meta, Story } from '@storybook/react';
+
+import StickySection, { IStickySectionProps } from './StickySection';
 
 export default {
 	title: 'Helpers/StickySection',
@@ -8,675 +9,632 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (StickySection as any).peek.description,
+				component: StickySection.peek.description,
 			},
 		},
 	},
-};
+} as Meta;
 
 /* With Lower Bound */
-export const WithLowerBound = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						color: 'rgba(128,128,128,.25)',
-						width: 800,
-						marginBottom: 700,
-					}}
-				>
-					Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-					messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray.
-					<StickySection
-						lowerBound={600}
-						style={{ backgroundColor: '#2abbb0', color: 'white' }}
-					>
-						This section sticks to top!
-					</StickySection>
-					Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-					messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray.
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const WithLowerBound: Story<IStickySectionProps> = (args) => {
+	return (
+		<section
+			style={{
+				color: 'rgba(128,128,128,.25)',
+				width: 800,
+				marginBottom: 700,
+			}}
+		>
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray.
+			<StickySection
+				lowerBound={600}
+				style={{ backgroundColor: '#2abbb0', color: 'white' }}
+			>
+				This section sticks to top!
+			</StickySection>
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+		</section>
+	);
 };
-WithLowerBound.storyName = 'WithLowerBound';
 
 /* With Lower Bound And Scroll Viewport Width */
-export const WithLowerBoundAndScrollViewportWidth = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						color: 'rgba(128,128,128,.25)',
-						width: 800,
-						overflow: 'auto',
-					}}
+export const WithLowerBoundAndScrollViewportWidth: Story<
+	IStickySectionProps
+> = (args) => {
+	return (
+		<section
+			style={{
+				color: 'rgba(128,128,128,.25)',
+				width: 800,
+				overflow: 'auto',
+			}}
+		>
+			<section style={{ width: 1000 }}>
+				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+				messenger bag viral migas. Artisan freegan cold-pressed offal,
+				flexitarian shabby chic polaroid banjo four dollar toast four loko
+				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
+				scenester actually cornhole locavore man bun chambray.
+				<StickySection
+					{...args}
+					viewportWidth={800}
+					lowerBound={1838}
+					style={{ backgroundColor: '#2abbb0', color: 'white' }}
 				>
-					<section style={{ width: 1000 }}>
-						Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-						messenger bag viral migas. Artisan freegan cold-pressed offal,
-						flexitarian shabby chic polaroid banjo four dollar toast four loko
-						williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-						scenester actually cornhole locavore man bun chambray.
-						<StickySection
-							viewportWidth={800}
-							lowerBound={1838}
-							style={{ backgroundColor: '#2abbb0', color: 'white' }}
-						>
-							I scroll horizontally to match the content!
-						</StickySection>
-						Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-						messenger bag viral migas. Artisan freegan cold-pressed offal,
-						flexitarian shabby chic polaroid banjo four dollar toast four loko
-						williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-						scenester actually cornhole locavore man bun chambray. Post-ironic
-						health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-						viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-						chic polaroid banjo four dollar toast four loko williamsburg.
-						Taxidermy ramps fap vegan bushwick pug, kickstarter scenester
-						actually cornhole locavore man bun chambray. Post-ironic health goth
-						austin mixtape mlkshk. Cold-pressed ennui messenger bag viral migas.
-						Artisan freegan cold-pressed offal, flexitarian shabby chic polaroid
-						banjo four dollar toast four loko williamsburg. Taxidermy ramps fap
-						vegan bushwick pug, kickstarter scenester actually cornhole locavore
-						man bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray. Post-ironic health goth austin mixtape mlkshk.
-						Cold-pressed ennui messenger bag viral migas. Artisan freegan
-						cold-pressed offal, flexitarian shabby chic polaroid banjo four
-						dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-						bushwick pug, kickstarter scenester actually cornhole locavore man
-						bun chambray.
-					</section>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+					I scroll horizontally to match the content!
+				</StickySection>
+				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+				messenger bag viral migas. Artisan freegan cold-pressed offal,
+				flexitarian shabby chic polaroid banjo four dollar toast four loko
+				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
+				scenester actually cornhole locavore man bun chambray. Post-ironic
+				health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
+				viral migas. Artisan freegan cold-pressed offal, flexitarian shabby chic
+				polaroid banjo four dollar toast four loko williamsburg. Taxidermy ramps
+				fap vegan bushwick pug, kickstarter scenester actually cornhole locavore
+				man bun chambray. Post-ironic health goth austin mixtape mlkshk.
+				Cold-pressed ennui messenger bag viral migas. Artisan freegan
+				cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+				toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+				kickstarter scenester actually cornhole locavore man bun chambray.
+				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+				messenger bag viral migas. Artisan freegan cold-pressed offal,
+				flexitarian shabby chic polaroid banjo four dollar toast four loko
+				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
+				scenester actually cornhole locavore man bun chambray. Post-ironic
+				health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
+				viral migas. Artisan freegan cold-pressed offal, flexitarian shabby chic
+				polaroid banjo four dollar toast four loko williamsburg. Taxidermy ramps
+				fap vegan bushwick pug, kickstarter scenester actually cornhole locavore
+				man bun chambray. Post-ironic health goth austin mixtape mlkshk.
+				Cold-pressed ennui messenger bag viral migas. Artisan freegan
+				cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+				toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+				kickstarter scenester actually cornhole locavore man bun chambray.
+				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+				messenger bag viral migas. Artisan freegan cold-pressed offal,
+				flexitarian shabby chic polaroid banjo four dollar toast four loko
+				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
+				scenester actually cornhole locavore man bun chambray. Post-ironic
+				health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
+				viral migas. Artisan freegan cold-pressed offal, flexitarian shabby chic
+				polaroid banjo four dollar toast four loko williamsburg. Taxidermy ramps
+				fap vegan bushwick pug, kickstarter scenester actually cornhole locavore
+				man bun chambray. Post-ironic health goth austin mixtape mlkshk.
+				Cold-pressed ennui messenger bag viral migas. Artisan freegan
+				cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+				toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+				kickstarter scenester actually cornhole locavore man bun chambray.
+				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+				messenger bag viral migas. Artisan freegan cold-pressed offal,
+				flexitarian shabby chic polaroid banjo four dollar toast four loko
+				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
+				scenester actually cornhole locavore man bun chambray. Post-ironic
+				health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
+				viral migas. Artisan freegan cold-pressed offal, flexitarian shabby chic
+				polaroid banjo four dollar toast four loko williamsburg. Taxidermy ramps
+				fap vegan bushwick pug, kickstarter scenester actually cornhole locavore
+				man bun chambray. Post-ironic health goth austin mixtape mlkshk.
+				Cold-pressed ennui messenger bag viral migas. Artisan freegan
+				cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+				toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+				kickstarter scenester actually cornhole locavore man bun chambray.
+				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+				messenger bag viral migas. Artisan freegan cold-pressed offal,
+				flexitarian shabby chic polaroid banjo four dollar toast four loko
+				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
+				scenester actually cornhole locavore man bun chambray. Post-ironic
+				health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
+				viral migas. Artisan freegan cold-pressed offal, flexitarian shabby chic
+				polaroid banjo four dollar toast four loko williamsburg. Taxidermy ramps
+				fap vegan bushwick pug, kickstarter scenester actually cornhole locavore
+				man bun chambray. Post-ironic health goth austin mixtape mlkshk.
+				Cold-pressed ennui messenger bag viral migas. Artisan freegan
+				cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+				toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+				kickstarter scenester actually cornhole locavore man bun chambray.
+				Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+				messenger bag viral migas. Artisan freegan cold-pressed offal,
+				flexitarian shabby chic polaroid banjo four dollar toast four loko
+				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
+				scenester actually cornhole locavore man bun chambray.
+			</section>
+		</section>
+	);
 };
-WithLowerBoundAndScrollViewportWidth.storyName =
-	'WithLowerBoundAndScrollViewportWidth';
 
 /* Standard */
-export const Standard = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						color: 'rgba(128,128,128,.25)',
-						marginBottom: 700,
-						height: 3000,
-					}}
-				>
-					Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-					messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray.
-					<StickySection style={{ backgroundColor: '#2abbb0', color: 'white' }}>
-						This section has no lower bounds!
-					</StickySection>
-					Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-					messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray.
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const Standard: Story<IStickySectionProps> = (args) => {
+	return (
+		<section
+			style={{
+				color: 'rgba(128,128,128,.25)',
+				marginBottom: 700,
+				height: 3000,
+			}}
+		>
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray.
+			<StickySection
+				{...args}
+				style={{ backgroundColor: '#2abbb0', color: 'white' }}
+			>
+				This section has no lower bounds!
+			</StickySection>
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray.
+		</section>
+	);
 };
 
 /* Top Offset */
-export const TopOffset = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						color: 'rgba(128,128,128,.25)',
-						marginBottom: 700,
-						height: 3000,
-					}}
-				>
-					Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-					messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray.
-					<StickySection
-						topOffset={100}
-						style={{ backgroundColor: '#2abbb0', color: 'white' }}
-					>
-						This section has no lower bounds! but has a topOffset
-					</StickySection>
-					Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
-					messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray. Post-ironic
-					health goth austin mixtape mlkshk. Cold-pressed ennui messenger bag
-					viral migas. Artisan freegan cold-pressed offal, flexitarian shabby
-					chic polaroid banjo four dollar toast four loko williamsburg.
-					Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
-					cornhole locavore man bun chambray. Post-ironic health goth austin
-					mixtape mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan
-					freegan cold-pressed offal, flexitarian shabby chic polaroid banjo
-					four dollar toast four loko williamsburg. Taxidermy ramps fap vegan
-					bushwick pug, kickstarter scenester actually cornhole locavore man bun
-					chambray. Post-ironic health goth austin mixtape mlkshk. Cold-pressed
-					ennui messenger bag viral migas. Artisan freegan cold-pressed offal,
-					flexitarian shabby chic polaroid banjo four dollar toast four loko
-					williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
-					scenester actually cornhole locavore man bun chambray.
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const TopOffset: Story<IStickySectionProps> = (args) => {
+	return (
+		<section
+			style={{
+				color: 'rgba(128,128,128,.25)',
+				marginBottom: 700,
+				height: 3000,
+			}}
+		>
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray.
+			<StickySection
+				{...args}
+				topOffset={100}
+				style={{ backgroundColor: '#2abbb0', color: 'white' }}
+			>
+				This section has no lower bounds! but has a topOffset
+			</StickySection>
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray. Post-ironic health goth austin mixtape
+			mlkshk. Cold-pressed ennui messenger bag viral migas. Artisan freegan
+			cold-pressed offal, flexitarian shabby chic polaroid banjo four dollar
+			toast four loko williamsburg. Taxidermy ramps fap vegan bushwick pug,
+			kickstarter scenester actually cornhole locavore man bun chambray.
+			Post-ironic health goth austin mixtape mlkshk. Cold-pressed ennui
+			messenger bag viral migas. Artisan freegan cold-pressed offal, flexitarian
+			shabby chic polaroid banjo four dollar toast four loko williamsburg.
+			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
+			cornhole locavore man bun chambray.
+		</section>
+	);
 };
-TopOffset.storyName = 'TopOffset';

--- a/src/components/StickySection/StickySection.stories.tsx
+++ b/src/components/StickySection/StickySection.stories.tsx
@@ -31,6 +31,7 @@ export const WithLowerBound: Story<IStickySectionProps> = (args) => {
 			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
 			cornhole locavore man bun chambray.
 			<StickySection
+				{...(args as any)}
 				lowerBound={600}
 				style={{ backgroundColor: '#2abbb0', color: 'white' }}
 			>
@@ -167,7 +168,7 @@ export const WithLowerBoundAndScrollViewportWidth: Story<
 				williamsburg. Taxidermy ramps fap vegan bushwick pug, kickstarter
 				scenester actually cornhole locavore man bun chambray.
 				<StickySection
-					{...args}
+					{...(args as any)}
 					viewportWidth={800}
 					lowerBound={1838}
 					style={{ backgroundColor: '#2abbb0', color: 'white' }}
@@ -270,7 +271,7 @@ export const Standard: Story<IStickySectionProps> = (args) => {
 			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
 			cornhole locavore man bun chambray.
 			<StickySection
-				{...args}
+				{...(args as any)}
 				style={{ backgroundColor: '#2abbb0', color: 'white' }}
 			>
 				This section has no lower bounds!
@@ -462,7 +463,7 @@ export const TopOffset: Story<IStickySectionProps> = (args) => {
 			Taxidermy ramps fap vegan bushwick pug, kickstarter scenester actually
 			cornhole locavore man bun chambray.
 			<StickySection
-				{...args}
+				{...(args as any)}
 				topOffset={100}
 				style={{ backgroundColor: '#2abbb0', color: 'white' }}
 			>

--- a/src/components/StickySection/StickySection.tsx
+++ b/src/components/StickySection/StickySection.tsx
@@ -1,14 +1,15 @@
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+
 import { lucidClassNames } from '../../util/style-helpers';
-import { omitProps, StandardProps } from '../../util/component-types';
+import { StandardProps } from '../../util/component-types';
 import { getAbsoluteBoundingClientRect } from '../../util/dom-helpers';
 
 const cx = lucidClassNames.bind('&-StickySection');
 const { node, number, object, string } = PropTypes;
 
-interface IStickySectionProps
+export interface IStickySectionProps
 	extends StandardProps,
 		React.DetailedHTMLProps<
 			React.HTMLAttributes<HTMLDivElement>,
@@ -186,11 +187,12 @@ class StickySection extends React.Component<
 
 		return (
 			<div
-				{...omitProps<IStickySectionProps>(
-					passThroughs,
-					undefined,
-					_.keys(StickySection.propTypes)
-				)}
+				{...omit(passThroughs, [
+					'lowerBound',
+					'topOffset',
+					'initialState',
+					'callbackId',
+				])}
 				className={cx('&', className)}
 				style={{
 					...(isAboveFold


### PR DESCRIPTION
## PR Checklist

Description of changes for `StickySection`:
Replace omitProps by propTypes with an explicit list
Update Storybook story
Add unit test for omitted props.

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2584-StickySection-replace-omitProps/?path=/docs/helpers-stickysection--with-lower-bound

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [ ] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
