### PR TITLE
Cxp 2578 scroll table fix omit props

### DIFF
--- a/src/components/ScrollTable/ScrollTable.stories.tsx
+++ b/src/components/ScrollTable/ScrollTable.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import createClass from 'create-react-class';
-import ScrollTable from './ScrollTable';
+import { Meta, Story } from '@storybook/react';
+
+import ScrollTable, { IScrollTableProps } from './ScrollTable';
 import Checkbox from '../Checkbox/Checkbox';
 import SuccessIcon from '../Icon/SuccessIcon/SuccessIcon';
 import Button from '../Button/Button';
@@ -11,1793 +12,1761 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (ScrollTable as any).peek.description,
+				component: ScrollTable.peek.description,
 			},
 		},
 	},
-};
+	args: ScrollTable.defaultProps,
+} as Meta;
 
-/* Standard */
-export const Standard = () => {
+/* Basic */
+export const Basic: Story<IScrollTableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = ScrollTable;
 
-	const Component = createClass({
-		render() {
-			return (
-				<ScrollTable>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable isResizable>
-								Sortable and resizable.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up' isResizable>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center' isResizable>
-								align center
-							</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</ScrollTable>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<ScrollTable {...args}>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable isResizable>
+						Sortable and resizable.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up' isResizable>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center' isResizable>
+						align center
+					</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</ScrollTable>
+	);
 };
 
 /* With Border */
-export const WithBorder = () => {
+export const WithBorder: Story<IScrollTableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = ScrollTable;
 
-	const Component = createClass({
-		render() {
-			return (
-				<ScrollTable hasBorder>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable isResizable>
-								Sortable and resizable.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up' isResizable>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center' isResizable>
-								align center
-							</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</ScrollTable>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<ScrollTable {...args} hasBorder>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable isResizable>
+						Sortable and resizable.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up' isResizable>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center' isResizable>
+						align center
+					</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</ScrollTable>
+	);
 };
-WithBorder.storyName = 'WithBorder';
 
 /* Set Width And Height */
-export const SetWidthAndHeight = () => {
+export const SetWidthAndHeight: Story<IScrollTableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = ScrollTable;
 
-	const Component = createClass({
-		render() {
-			return (
-				<ScrollTable
-					hasWordWrap={false}
-					style={{
-						width: 300,
-						height: 300,
-					}}
-				>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable isResizable>
-								Sortable and resizable.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up' isResizable>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center' isResizable>
-								align center
-							</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</ScrollTable>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<ScrollTable
+			{...args}
+			hasWordWrap={false}
+			style={{
+				width: 300,
+				height: 300,
+			}}
+		>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable isResizable>
+						Sortable and resizable.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up' isResizable>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center' isResizable>
+						align center
+					</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</ScrollTable>
+	);
 };
-SetWidthAndHeight.storyName = 'SetWidthAndHeight';
 
 /* Full Width */
-export const FullWidth = () => {
+export const FullWidth: Story<IScrollTableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = ScrollTable;
 
-	const Component = createClass({
-		render() {
-			return (
-				<ScrollTable hasWordWrap={false}>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable isResizable>
-								Sortable and resizable.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up' isResizable>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-							<Th rowSpan={2}>Extra Column</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center' isResizable>
-								align center
-							</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-							<Td>Extra Column</Td>
-						</Tr>
-					</Tbody>
-				</ScrollTable>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<ScrollTable {...args} hasWordWrap={false}>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable isResizable>
+						Sortable and resizable.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up' isResizable>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+					<Th rowSpan={2}>Extra Column</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center' isResizable>
+						align center
+					</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+					<Td>Extra Column</Td>
+				</Tr>
+			</Tbody>
+		</ScrollTable>
+	);
 };
-FullWidth.storyName = 'FullWidth';
 
 /* Set Table Width */
-export const SetTableWidth = () => {
+export const SetTableWidth: Story<IScrollTableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = ScrollTable;
 
-	const Component = createClass({
-		render() {
-			return (
-				<ScrollTable tableWidth={2000}>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable isResizable>
-								Sortable and resizable.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up' isResizable>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center' isResizable>
-								align center
-							</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</ScrollTable>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<ScrollTable {...args} tableWidth={2000}>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable isResizable>
+						Sortable and resizable.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up' isResizable>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center' isResizable>
+						align center
+					</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</ScrollTable>
+	);
 };
-SetTableWidth.storyName = 'SetTableWidth';

--- a/src/components/ScrollTable/ScrollTable.tsx
+++ b/src/components/ScrollTable/ScrollTable.tsx
@@ -1,7 +1,8 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StandardProps, omitProps } from '../../util/component-types';
+
+import { StandardProps } from '../../util/component-types';
 import { lucidClassNames } from '../../util/style-helpers';
 import Table from '../Table/Table';
 
@@ -53,12 +54,15 @@ export const ScrollTable = (props: IScrollTableProps): React.ReactElement => {
 			style={style}
 		>
 			<Table
-				{...omitProps(
-					passThroughs,
-					undefined,
-					_.keys(ScrollTable.propTypes),
-					false
-				)}
+				{...omit(passThroughs, [
+					'children',
+					'className',
+					'style',
+					'tableWidth',
+					'hasWordWrap',
+					'hasBorder',
+					'initialState',
+				])}
 				style={{
 					width: tableWidth,
 				}}

--- a/src/components/ScrollTable/__snapshots__/ScrollTable.spec.tsx.snap
+++ b/src/components/ScrollTable/__snapshots__/ScrollTable.spec.tsx.snap
@@ -1,5 +1,1714 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ScrollTable [common] example testing should match snapshot(s) for Basic 1`] = `
+<div
+  class="lucid-ScrollTable"
+>
+  <table
+    class="lucid-Table lucid-Table-density-extended lucid-Table-has-light-header"
+  >
+    <thead
+      class="lucid-Table-Thead"
+    >
+      <tr
+        class="lucid-Table-Tr"
+      >
+        <th
+          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-is-first-col lucid-Table-align-left"
+          rowspan="2"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              RS
+            </div>
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left"
+          rowspan="2"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              <div
+                class="lucid-Checkbox"
+              >
+                <input
+                  class="lucid-Checkbox-native"
+                  type="checkbox"
+                />
+                <span
+                  class="lucid-Checkbox-visualization-glow"
+                />
+                <span
+                  class="lucid-Checkbox-visualization-container"
+                />
+                <span
+                  class="lucid-Checkbox-visualization-checkmark"
+                >
+                  <span
+                    class="lucid-Checkbox-visualization-checkmark-stem"
+                  />
+                  <span
+                    class="lucid-Checkbox-visualization-checkmark-kick"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left lucid-Table-is-resizable lucid-Table-is-sortable"
+          rowspan="2"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              Sortable and resizable.
+            </div>
+            <div
+              class="lucid-Table-Th-inner-caret"
+            >
+              <svg
+                class="lucid-Icon lucid-Icon-color-primary lucid-ArrowIcon lucid-ArrowIcon-is-up lucid-Table-sort-icon"
+                height="10"
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width="10"
+              >
+                <path
+                  d="M0 8h15.5m-6-6l6 6-6 6"
+                />
+              </svg>
+            </div>
+            <div
+              class="lucid-DragCaptureZone lucid-Table-Th-inner-resize"
+            />
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left"
+          rowspan="2"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              <svg
+                class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+                height="16"
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <circle
+                  class="lucid-SuccessIcon-background"
+                  cx="8"
+                  cy="8"
+                  r="7.5"
+                />
+                <path
+                  class="lucid-SuccessIcon-check"
+                  d="M4.5 8L7 10.5 11.5 6"
+                />
+              </svg>
+            </div>
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left"
+          rowspan="2"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              Button
+            </div>
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left lucid-Table-is-resizable lucid-Table-is-sortable lucid-Table-is-sorted"
+          rowspan="2"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              Sorted Column
+            </div>
+            <div
+              class="lucid-Table-Th-inner-caret"
+            >
+              <svg
+                class="lucid-Icon lucid-Icon-color-primary lucid-ArrowIcon lucid-ArrowIcon-is-up lucid-Table-sort-icon"
+                height="10"
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width="10"
+              >
+                <path
+                  d="M0 8h15.5m-6-6l6 6-6 6"
+                />
+              </svg>
+            </div>
+            <div
+              class="lucid-DragCaptureZone lucid-Table-Th-inner-resize"
+            />
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-first-single lucid-Table-is-last-col lucid-Table-align-center"
+          colspan="3"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              Alignments
+            </div>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="lucid-Table-Tr"
+      >
+        <th
+          class="lucid-Table-Th lucid-Table-is-last-row lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              align left
+            </div>
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-last-row lucid-Table-align-center lucid-Table-is-resizable"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              align center
+            </div>
+            <div
+              class="lucid-DragCaptureZone lucid-Table-Th-inner-resize"
+            />
+          </div>
+        </th>
+        <th
+          class="lucid-Table-Th lucid-Table-is-last-row lucid-Table-is-last-col lucid-Table-align-right lucid-Table-is-sortable lucid-Table-is-sorted"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Table-Th-inner"
+          >
+            <div
+              class="lucid-Table-Th-inner-content"
+            >
+              align right
+            </div>
+            <div
+              class="lucid-Table-Th-inner-caret"
+            >
+              <svg
+                class="lucid-Icon lucid-Icon-color-primary lucid-ArrowIcon lucid-ArrowIcon-is-up lucid-Table-sort-icon"
+                height="10"
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width="10"
+              >
+                <path
+                  d="M0 8h15.5m-6-6l6 6-6 6"
+                />
+              </svg>
+            </div>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="lucid-Table-Tbody"
+    >
+      <tr
+        class="lucid-Table-Tr"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-is-first-col lucid-Table-align-left lucid-Table-has-border-right"
+          rowspan="14"
+        >
+          RS
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left"
+          rowspan="1"
+        >
+          Text
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-small"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-disabled"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          isDisabled
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Text && isActionable
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-small"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-disabled"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          isDisabled && isActionable
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <a
+            href="#"
+          >
+            Link
+          </a>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-small"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-disabled"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <a
+            href="#"
+          >
+            isDisabled Link
+          </a>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <a
+            href="#"
+          >
+            Link && isActionable
+          </a>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-small"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-disabled"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <a
+            href="#"
+          >
+            isDisabled Link && isActionable
+          </a>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-selected"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox lucid-Checkbox-is-selected"
+          >
+            <input
+              checked=""
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          isSelected
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-small"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-disabled lucid-Table-is-selected"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox lucid-Checkbox-is-selected"
+          >
+            <input
+              checked=""
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          isSelected && isDisabled
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-selected"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox lucid-Checkbox-is-selected"
+          >
+            <input
+              checked=""
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          isSelected && isActionable
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-small"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-disabled lucid-Table-is-selected"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox lucid-Checkbox-is-selected"
+          >
+            <input
+              checked=""
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          isSelected && isDisabled && isActionable
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-active"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          isActive
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-small"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+      <tr
+        class="lucid-Table-Tr lucid-Table-is-disabled lucid-Table-is-active"
+      >
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-is-first-single lucid-Table-align-left"
+          rowspan="1"
+        >
+          <div
+            class="lucid-Checkbox"
+          >
+            <input
+              class="lucid-Checkbox-native"
+              type="checkbox"
+            />
+            <span
+              class="lucid-Checkbox-visualization-glow"
+            />
+            <span
+              class="lucid-Checkbox-visualization-container"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark"
+            >
+              <span
+                class="lucid-Checkbox-visualization-checkmark-stem"
+              />
+              <span
+                class="lucid-Checkbox-visualization-checkmark-kick"
+              />
+            </span>
+          </div>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left"
+          rowspan="1"
+        >
+          isActive && isDisabled
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          <svg
+            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
+            height="16"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <circle
+              class="lucid-SuccessIcon-background"
+              cx="8"
+              cy="8"
+              r="7.5"
+            />
+            <path
+              class="lucid-SuccessIcon-check"
+              d="M4.5 8L7 10.5 11.5 6"
+            />
+          </svg>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left"
+          rowspan="1"
+        >
+          <button
+            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
+            disabled=""
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              button
+            </span>
+          </button>
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left"
+          rowspan="1"
+        >
+          Sorted Column
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left lucid-Table-has-border-left"
+          rowspan="1"
+        >
+          align left
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-center"
+          rowspan="1"
+        >
+          align center
+        </td>
+        <td
+          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-is-last-col lucid-Table-align-right"
+          rowspan="1"
+        >
+          align right
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`ScrollTable [common] example testing should match snapshot(s) for FullWidth 1`] = `
 <div
   class="lucid-ScrollTable"
@@ -4403,1715 +6112,6 @@ exports[`ScrollTable [common] example testing should match snapshot(s) for SetWi
 <div
   class="lucid-ScrollTable"
   style="width:300px;height:300px"
->
-  <table
-    class="lucid-Table lucid-Table-density-extended lucid-Table-has-light-header"
-  >
-    <thead
-      class="lucid-Table-Thead"
-    >
-      <tr
-        class="lucid-Table-Tr"
-      >
-        <th
-          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-is-first-col lucid-Table-align-left"
-          rowspan="2"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              RS
-            </div>
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left"
-          rowspan="2"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              <div
-                class="lucid-Checkbox"
-              >
-                <input
-                  class="lucid-Checkbox-native"
-                  type="checkbox"
-                />
-                <span
-                  class="lucid-Checkbox-visualization-glow"
-                />
-                <span
-                  class="lucid-Checkbox-visualization-container"
-                />
-                <span
-                  class="lucid-Checkbox-visualization-checkmark"
-                >
-                  <span
-                    class="lucid-Checkbox-visualization-checkmark-stem"
-                  />
-                  <span
-                    class="lucid-Checkbox-visualization-checkmark-kick"
-                  />
-                </span>
-              </div>
-            </div>
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left lucid-Table-is-resizable lucid-Table-is-sortable"
-          rowspan="2"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              Sortable and resizable.
-            </div>
-            <div
-              class="lucid-Table-Th-inner-caret"
-            >
-              <svg
-                class="lucid-Icon lucid-Icon-color-primary lucid-ArrowIcon lucid-ArrowIcon-is-up lucid-Table-sort-icon"
-                height="10"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width="10"
-              >
-                <path
-                  d="M0 8h15.5m-6-6l6 6-6 6"
-                />
-              </svg>
-            </div>
-            <div
-              class="lucid-DragCaptureZone lucid-Table-Th-inner-resize"
-            />
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left"
-          rowspan="2"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              <svg
-                class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-                height="16"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width="16"
-              >
-                <circle
-                  class="lucid-SuccessIcon-background"
-                  cx="8"
-                  cy="8"
-                  r="7.5"
-                />
-                <path
-                  class="lucid-SuccessIcon-check"
-                  d="M4.5 8L7 10.5 11.5 6"
-                />
-              </svg>
-            </div>
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left"
-          rowspan="2"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              Button
-            </div>
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-align-left lucid-Table-is-resizable lucid-Table-is-sortable lucid-Table-is-sorted"
-          rowspan="2"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              Sorted Column
-            </div>
-            <div
-              class="lucid-Table-Th-inner-caret"
-            >
-              <svg
-                class="lucid-Icon lucid-Icon-color-primary lucid-ArrowIcon lucid-ArrowIcon-is-up lucid-Table-sort-icon"
-                height="10"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width="10"
-              >
-                <path
-                  d="M0 8h15.5m-6-6l6 6-6 6"
-                />
-              </svg>
-            </div>
-            <div
-              class="lucid-DragCaptureZone lucid-Table-Th-inner-resize"
-            />
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-first-row lucid-Table-is-first-single lucid-Table-is-last-col lucid-Table-align-center"
-          colspan="3"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              Alignments
-            </div>
-          </div>
-        </th>
-      </tr>
-      <tr
-        class="lucid-Table-Tr"
-      >
-        <th
-          class="lucid-Table-Th lucid-Table-is-last-row lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              align left
-            </div>
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-last-row lucid-Table-align-center lucid-Table-is-resizable"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              align center
-            </div>
-            <div
-              class="lucid-DragCaptureZone lucid-Table-Th-inner-resize"
-            />
-          </div>
-        </th>
-        <th
-          class="lucid-Table-Th lucid-Table-is-last-row lucid-Table-is-last-col lucid-Table-align-right lucid-Table-is-sortable lucid-Table-is-sorted"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Table-Th-inner"
-          >
-            <div
-              class="lucid-Table-Th-inner-content"
-            >
-              align right
-            </div>
-            <div
-              class="lucid-Table-Th-inner-caret"
-            >
-              <svg
-                class="lucid-Icon lucid-Icon-color-primary lucid-ArrowIcon lucid-ArrowIcon-is-up lucid-Table-sort-icon"
-                height="10"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width="10"
-              >
-                <path
-                  d="M0 8h15.5m-6-6l6 6-6 6"
-                />
-              </svg>
-            </div>
-          </div>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="lucid-Table-Tbody"
-    >
-      <tr
-        class="lucid-Table-Tr"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-is-last-row lucid-Table-is-first-col lucid-Table-align-left lucid-Table-has-border-right"
-          rowspan="14"
-        >
-          RS
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left"
-          rowspan="1"
-        >
-          Text
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-small"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-row lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-disabled"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          isDisabled
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Text && isActionable
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-small"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-disabled"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          isDisabled && isActionable
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <a
-            href="#"
-          >
-            Link
-          </a>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-small"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-disabled"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <a
-            href="#"
-          >
-            isDisabled Link
-          </a>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <a
-            href="#"
-          >
-            Link && isActionable
-          </a>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-small"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-disabled"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <a
-            href="#"
-          >
-            isDisabled Link && isActionable
-          </a>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-selected"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox lucid-Checkbox-is-selected"
-          >
-            <input
-              checked=""
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          isSelected
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-small"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-disabled lucid-Table-is-selected"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox lucid-Checkbox-is-selected"
-          >
-            <input
-              checked=""
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          isSelected && isDisabled
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-selected"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox lucid-Checkbox-is-selected"
-          >
-            <input
-              checked=""
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          isSelected && isActionable
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-small"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-disabled lucid-Table-is-selected"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox lucid-Checkbox-is-selected"
-          >
-            <input
-              checked=""
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          isSelected && isDisabled && isActionable
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-active"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          isActive
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-small"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-      <tr
-        class="lucid-Table-Tr lucid-Table-is-disabled lucid-Table-is-active"
-      >
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-is-first-single lucid-Table-align-left"
-          rowspan="1"
-        >
-          <div
-            class="lucid-Checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left"
-          rowspan="1"
-        >
-          isActive && isDisabled
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left lucid-Table-has-border-right lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          <svg
-            class="lucid-Icon lucid-Icon-color-primary lucid-SuccessIcon"
-            height="16"
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <circle
-              class="lucid-SuccessIcon-background"
-              cx="8"
-              cy="8"
-              r="7.5"
-            />
-            <path
-              class="lucid-SuccessIcon-check"
-              d="M4.5 8L7 10.5 11.5 6"
-            />
-          </svg>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left"
-          rowspan="1"
-        >
-          <button
-            class="lucid-Button lucid-Button-is-disabled lucid-Button-small"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              button
-            </span>
-          </button>
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left"
-          rowspan="1"
-        >
-          Sorted Column
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-left lucid-Table-has-border-left"
-          rowspan="1"
-        >
-          align left
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-align-center"
-          rowspan="1"
-        >
-          align center
-        </td>
-        <td
-          class="lucid-Table-Td lucid-Table-is-last-row lucid-Table-is-last-col lucid-Table-align-right"
-          rowspan="1"
-        >
-          align right
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`ScrollTable [common] example testing should match snapshot(s) for Standard 1`] = `
-<div
-  class="lucid-ScrollTable"
 >
   <table
     class="lucid-Table lucid-Table-density-extended lucid-Table-has-light-header"


### PR DESCRIPTION
## PR Checklist

Description of changes to ScrollTable:
* Add unit tests for omitted props
* Update ScrollTable stories to use controls
* Replace omitProps with explicit list of propTypes
* Update snapshot for ScrollTable

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2578-ScrollTable-fix-omitProps/?path=/docs/table-scrolltable--basic
![Screen Shot 2022-04-19 at 4 03 54 PM](https://user-images.githubusercontent.com/19521671/164115264-fa3eef60-792d-4fc6-9285-b70810c41fe0.png)

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
