### PR TITLE
Cxp 2593 vertical tabs & table fix omit props

### DIFF
--- a/src/components/Table/Table.spec.tsx
+++ b/src/components/Table/Table.spec.tsx
@@ -1,6 +1,8 @@
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import assert from 'assert';
+
 import { common } from '../../util/generic-tests';
 import Table from './Table';
 import ArrowIcon from '../Icon/ArrowIcon/ArrowIcon';
@@ -20,6 +22,59 @@ describe('Table', () => {
 	});
 
 	describe('props', () => {
+		describe('root pass throughs', () => {
+			let wrapper: any;
+
+			beforeEach(() => {
+				const props = {
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<Table {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-Table').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' is plucked from the pass through object
+				// but still appears becuase it is also directly added to the root element as a prop
+				forEach(['className', 'data-testid', 'style'], (prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				});
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-Table').props();
+
+				forEach(
+					[
+						'density',
+						'hasLightHeader',
+						'hasBorder',
+						'hasWordWrap',
+						'hasHover',
+						'initialState',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
+			});
+		});
+
 		describe('density', () => {
 			describe('value `compressed`', () => {
 				it('should apply the `lucid-Table-density-compressed` class name to the rendered table', () => {
@@ -66,6 +121,58 @@ describe('Table', () => {
 					assert.equal(wrapper.find('thead.lucid-Table-Thead').length, 1);
 				});
 			});
+
+			describe('Thead pass through props', () => {
+				let wrapper: any;
+
+				beforeEach(() => {
+					const props = {
+						className: 'wut',
+						style: { marginRight: 10 },
+						initialState: { test: true },
+						callbackId: 1,
+						'data-testid': 10,
+					};
+					wrapper = mount(
+						<Table>
+							<Thead {...props}></Thead>
+						</Table>
+					);
+				});
+
+				afterEach(() => {
+					wrapper.unmount();
+				});
+
+				it('passes through props not defined in `Thead.propTypes` to the <thead> element.', () => {
+					const theadProps = wrapper.find('.lucid-Table-Thead').props();
+
+					expect(
+						wrapper.find('.lucid-Table-Thead').prop(['className'])
+					).toContain('wut');
+					expect(
+						wrapper.find('.lucid-Table-Thead').prop(['style'])
+					).toMatchObject({
+						marginRight: 10,
+					});
+					expect(wrapper.find('.lucid-Table-Thead').prop(['data-testid'])).toBe(
+						10
+					);
+
+					// 'className' is plucked from the pass through object
+					// but still appears becuase it is also directly added to the root element as a prop
+					forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+						expect(has(theadProps, prop)).toBe(true);
+					});
+				});
+				it('omits the props defined in `Thead.propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+					const theadProps = wrapper.find('.lucid-Table-Thead').props();
+
+					forEach(['initialState', 'callbackId'], (prop) => {
+						expect(has(theadProps, prop)).toBe(false);
+					});
+				});
+			});
 		});
 
 		describe('Tbody', () => {
@@ -74,6 +181,59 @@ describe('Table', () => {
 					const wrapper = shallow(<Tbody />);
 
 					assert.equal(wrapper.find('tbody.lucid-Table-Tbody').length, 1);
+				});
+			});
+
+			describe('Tbody pass through props', () => {
+				let wrapper: any;
+
+				beforeEach(() => {
+					const props = {
+						className: 'wut',
+						style: { marginRight: 10 },
+						initialState: { test: true },
+						callbackId: 1,
+						'data-testid': 10,
+					};
+					wrapper = mount(
+						<Table>
+							<Thead></Thead>
+							<Tbody {...props}></Tbody>
+						</Table>
+					);
+				});
+
+				afterEach(() => {
+					wrapper.unmount();
+				});
+
+				it('passes through props not defined in `Tbody.propTypes` to the <tbody> element.', () => {
+					const tbodyProps = wrapper.find('.lucid-Table-Tbody').props();
+
+					expect(
+						wrapper.find('.lucid-Table-Tbody').prop(['className'])
+					).toContain('wut');
+					expect(
+						wrapper.find('.lucid-Table-Tbody').prop(['style'])
+					).toMatchObject({
+						marginRight: 10,
+					});
+					expect(wrapper.find('.lucid-Table-Tbody').prop(['data-testid'])).toBe(
+						10
+					);
+
+					// 'className' is plucked from the pass through object
+					// but still appears becuase it is also directly added to the root element as a prop
+					forEach(['className', 'children', 'data-testid', 'style'], (prop) => {
+						expect(has(tbodyProps, prop)).toBe(true);
+					});
+				});
+				it('omits the props defined in `Tbody.propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+					const tbodyProps = wrapper.find('.lucid-Table-Tbody').props();
+
+					forEach(['initialState', 'callbackId'], (prop) => {
+						expect(has(tbodyProps, prop)).toBe(false);
+					});
 				});
 			});
 		});
@@ -88,6 +248,78 @@ describe('Table', () => {
 			});
 
 			describe('props', () => {
+				describe('Tr pass through props', () => {
+					let wrapper: any;
+
+					beforeEach(() => {
+						const props = {
+							isDisabled: true,
+							isSelected: true,
+							isActive: true,
+							isActionable: true,
+							className: 'wut',
+							style: { marginRight: 10 },
+							initialState: { test: true },
+							callbackId: 1,
+							'data-testid': 10,
+						};
+						wrapper = mount(
+							<Table>
+								<Thead></Thead>
+								<Tbody>
+									<Tr {...props}></Tr>
+								</Tbody>
+							</Table>
+						);
+					});
+
+					afterEach(() => {
+						wrapper.unmount();
+					});
+
+					it('passes through props not defined in `Tr.propTypes` to the <tbody> element.', () => {
+						const trProps = wrapper.find('.lucid-Table-Tr').props();
+
+						expect(
+							wrapper.find('.lucid-Table-Tr').prop(['className'])
+						).toContain('wut');
+						expect(
+							wrapper.find('.lucid-Table-Tr').prop(['style'])
+						).toMatchObject({
+							marginRight: 10,
+						});
+						expect(wrapper.find('.lucid-Table-Tr').prop(['data-testid'])).toBe(
+							10
+						);
+
+						// 'className' is plucked from the pass through object
+						// but still appears becuase it is also directly added to the root element as a prop
+						forEach(
+							['className', 'children', 'data-testid', 'style'],
+							(prop) => {
+								expect(has(trProps, prop)).toBe(true);
+							}
+						);
+					});
+					it('omits the props defined in `Tr.propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+						const trProps = wrapper.find('.lucid-Table-Tr').props();
+
+						forEach(
+							[
+								'isDisabled',
+								'isSelected',
+								'isActive',
+								'initialState',
+								'isActionable',
+								'callbackId',
+							],
+							(prop) => {
+								expect(has(trProps, prop)).toBe(false);
+							}
+						);
+					});
+				});
+
 				describe('isDisabled', () => {
 					it('should apply the class name `lucid-Table-is-disabled`', () => {
 						const wrapper = shallow(<Tr isDisabled />);
@@ -120,6 +352,109 @@ describe('Table', () => {
 					const wrapper = shallow(<Th />);
 
 					assert.equal(wrapper.find('th.lucid-Table-Th').length, 1);
+				});
+			});
+
+			describe('Th pass through props', () => {
+				let wrapper: any;
+
+				beforeEach(() => {
+					const props = {
+						align: 'center' as any,
+						children: <div></div>,
+						hasBorderRight: true,
+						hasBorderLeft: true,
+						isResizable: true,
+						isSortable: true,
+						isSorted: true,
+						onResize: noop,
+						sortDirection: 'right' as any,
+						width: 100,
+						minWidth: 50,
+						isFirstRow: true,
+						isLastRow: false,
+						isFirstCol: true,
+						isLastCol: false,
+						isFirstSingle: true,
+						field: 'test',
+						truncateContent: true,
+						rowSpan: 2,
+						className: 'wut',
+						style: { marginRight: 10 },
+						initialState: { test: true },
+						callbackId: 1,
+						'data-testid': 10,
+					};
+					wrapper = mount(
+						<Table>
+							<Thead>
+								<Tr>
+									<Th {...props}>Lorem</Th>
+								</Tr>
+							</Thead>
+							<Tbody>
+								<Tr></Tr>
+							</Tbody>
+						</Table>
+					);
+				});
+
+				afterEach(() => {
+					wrapper.unmount();
+				});
+
+				it('passes through props not defined in `Th.propTypes` to the <thead> element.', () => {
+					const thProps = wrapper.find('.lucid-Table-Th').props();
+
+					expect(wrapper.find('.lucid-Table-Th').prop(['className'])).toContain(
+						'wut'
+					);
+					expect(wrapper.find('.lucid-Table-Th').prop(['style'])).toMatchObject(
+						{
+							marginRight: 10,
+						}
+					);
+					expect(wrapper.find('.lucid-Table-Th').prop(['data-testid'])).toBe(
+						10
+					);
+
+					// 'className' and 'style' appear becuase they are directly added to the root element as a prop
+					forEach(
+						['className', 'children', 'data-testid', 'style', 'rowSpan'],
+						(prop) => {
+							expect(has(thProps, prop)).toBe(true);
+						}
+					);
+				});
+				it('omits the props defined in `Th.propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+					const thProps = wrapper.find('.lucid-Table-Th').props();
+
+					forEach(
+						[
+							'align',
+							'hasBorderRight',
+							'hasBorderLeft',
+							'isResizable',
+							'isSortable',
+							'isSorted',
+							'onResize',
+							'sortDirection',
+							'width',
+							'minWidth',
+							'isFirstRow',
+							'isLastRow',
+							'isFirstCol',
+							'isLastCol',
+							'isFirstSingle',
+							'field',
+							'truncateContent',
+							'initialState',
+							'callbackId',
+						],
+						(prop) => {
+							expect(has(thProps, prop)).toBe(false);
+						}
+					);
 				});
 			});
 
@@ -267,6 +602,90 @@ describe('Table', () => {
 					const wrapper = shallow(<Td />);
 
 					assert.equal(wrapper.find('td.lucid-Table-Td').length, 1);
+				});
+			});
+
+			describe('Td pass through props', () => {
+				let wrapper: any;
+
+				beforeEach(() => {
+					const props = {
+						align: 'center' as any,
+						hasBorderRight: true,
+						hasBorderLeft: true,
+						isFirstRow: true,
+						isLastRow: true,
+						isFirstCol: true,
+						isLastCol: true,
+						isFirstSingle: true,
+						isEmpty: true,
+						truncateContent: true,
+						rowSpan: 2,
+						className: 'wut',
+						style: { marginRight: 10 },
+						initialState: { test: true },
+						callbackId: 1,
+						'data-testid': 10,
+					};
+					wrapper = mount(
+						<Table>
+							<Thead>Lorem</Thead>
+							<Tbody>
+								<Tr>
+									<Td {...props}>Ipsum</Td>
+								</Tr>
+							</Tbody>
+						</Table>
+					);
+				});
+
+				afterEach(() => {
+					wrapper.unmount();
+				});
+
+				it('passes through props not defined in `Td.propTypes` to the <td> element.', () => {
+					const tdProps = wrapper.find('.lucid-Table-Td').props();
+
+					expect(wrapper.find('.lucid-Table-Td').prop(['className'])).toContain(
+						'wut'
+					);
+					expect(wrapper.find('.lucid-Table-Td').prop(['style'])).toMatchObject(
+						{
+							marginRight: 10,
+						}
+					);
+					expect(wrapper.find('.lucid-Table-Td').prop(['data-testid'])).toBe(
+						10
+					);
+
+					// 'className' is plucked from the pass through object
+					// but still appears becuase it is also directly added to the root element as a prop
+					forEach(['className', 'children', 'data-testid', 'style'], (prop) => {
+						expect(has(tdProps, prop)).toBe(true);
+					});
+				});
+				it('omits the props defined in `Td.propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+					const tdProps = wrapper.find('.lucid-Table-Td').props();
+
+					forEach(
+						[
+							'align',
+							'hasBorderRight',
+							'hasBorderLeft',
+							'isFirstRow',
+							'isLastRow',
+							'isFirstCol',
+							'isLastCol',
+							'isFirstSingle',
+							'isEmpty',
+							'truncateContent',
+							'initialState',
+							'callbackId',
+						],
+						(prop) => {
+							expect(has(tdProps, prop)).toBe(false);
+						}
+					);
 				});
 			});
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import createClass from 'create-react-class';
 import { Meta, Story } from '@storybook/react';
+
 import Table, { ITableProps } from './Table';
 import Checkbox from '../Checkbox/Checkbox';
 import SuccessIcon from '../Icon/SuccessIcon/SuccessIcon';
@@ -16,6 +16,7 @@ export default {
 			},
 		},
 	},
+	args: Table.defaultProps,
 } as Meta;
 
 export const Basic: Story<ITableProps> = (args) => (
@@ -49,1869 +50,1829 @@ export const Basic: Story<ITableProps> = (args) => (
 export const Standard: Story<ITableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = Table;
 
-	const Component = createClass({
-		render() {
-			return (
-				<Table {...args}>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable>
-								Lorem.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up'>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center'>align center</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Row active</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</Table>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<Table {...args}>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable>
+						Lorem.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up'>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center'>align center</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Row active</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</Table>
+	);
 };
 
 /* Gray Header */
 export const GrayHeader: Story<ITableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = Table;
 
-	const Component = createClass({
-		render() {
-			return (
-				<Table {...args} hasLightHeader={false}>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable>
-								Lorem.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up'>
-								Sorted Column
-							</Th>
-							<Th align='left'>align left</Th>
-							<Th align='center'>align center</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</Table>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<Table {...args} hasLightHeader={false}>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable>
+						Lorem.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up'>
+						Sorted Column
+					</Th>
+					<Th align='left'>align left</Th>
+					<Th align='center'>align center</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</Table>
+	);
 };
-GrayHeader.storyName = 'GrayHeader';
 
 /* Compressed */
 export const Compressed: Story<ITableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = Table;
 
-	const Component = createClass({
-		render() {
-			return (
-				<Table {...args} density='compressed'>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable isResizable>
-								Sortable and resizable.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up' isResizable>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center' isResizable>
-								align center
-							</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</Table>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<Table {...args} density='compressed'>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable isResizable>
+						Sortable and resizable.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up' isResizable>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center' isResizable>
+						align center
+					</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</Table>
+	);
 };
 
 /* With Border */
 export const WithBorder: Story<ITableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = Table;
 
-	const Component = createClass({
-		render() {
-			return (
-				<Table {...args} hasBorder>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable>
-								Lorem.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up'>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center'>align center</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isActive && isDisabled</Td>
-							<Td>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left'>align left</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</Table>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<Table {...args} hasBorder>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable>
+						Lorem.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up'>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center'>align center</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isActive && isDisabled</Td>
+					<Td>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left'>align left</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</Table>
+	);
 };
-WithBorder.storyName = 'WithBorder';
 
 /* With Empty Column */
 export const WithEmptyColumn: Story<ITableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = Table;
 
-	const Component = createClass({
-		render() {
-			return (
-				<Table {...args}>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>RS</Th>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable>
-								Empty
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up'>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center'>align center</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td rowSpan={14} hasBorderRight>
-								RS
-							</Td>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isActive isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td isEmpty>No Data</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</Table>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<Table {...args}>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>RS</Th>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable>
+						Empty
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up'>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center'>align center</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td rowSpan={14} hasBorderRight>
+						RS
+					</Td>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isActive isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td isEmpty>No Data</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</Table>
+	);
 };
-WithEmptyColumn.storyName = 'WithEmptyColumn';
 
 /* No Hover */
 export const NoHover: Story<ITableProps> = (args) => {
 	const { Thead, Tbody, Tr, Th, Td } = Table;
 
-	const Component = createClass({
-		render() {
-			return (
-				<Table {...args} hasHover={false}>
-					<Thead>
-						<Tr>
-							<Th rowSpan={2}>
-								<Checkbox />
-							</Th>
-							<Th rowSpan={2} isSortable>
-								Lorem.
-							</Th>
-							<Th rowSpan={2}>
-								<SuccessIcon />
-							</Th>
-							<Th rowSpan={2}>Button</Th>
-							<Th rowSpan={2} isSorted sortDirection='up'>
-								Sorted Column
-							</Th>
-							<Th colSpan={3} align='center'>
-								Alignments
-							</Th>
-						</Tr>
-						<Tr>
-							<Th align='left'>align left</Th>
-							<Th align='center'>align center</Th>
-							<Th align='right' isSortable isSorted>
-								align right
-							</Th>
-						</Tr>
-					</Thead>
-					<Tbody>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>Text && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isActionable isDisabled>
-							<Td>
-								<Checkbox />
-							</Td>
-							<Td>
-								<a href='#'>isDisabled Link && isActionable</a>
-							</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small'>button</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-						<Tr isSelected isDisabled isActionable>
-							<Td>
-								<Checkbox isSelected={true} />
-							</Td>
-							<Td>isSelected && isDisabled && isActionable</Td>
-							<Td hasBorderLeft hasBorderRight>
-								<SuccessIcon />
-							</Td>
-							<Td>
-								<Button size='small' isDisabled={true}>
-									button
-								</Button>
-							</Td>
-							<Td>Sorted Column</Td>
-							<Td align='left' hasBorderLeft>
-								align left
-							</Td>
-							<Td align='center'>align center</Td>
-							<Td align='right'>align right</Td>
-						</Tr>
-					</Tbody>
-				</Table>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<Table {...args} hasHover={false}>
+			<Thead>
+				<Tr>
+					<Th rowSpan={2}>
+						<Checkbox />
+					</Th>
+					<Th rowSpan={2} isSortable>
+						Lorem.
+					</Th>
+					<Th rowSpan={2}>
+						<SuccessIcon />
+					</Th>
+					<Th rowSpan={2}>Button</Th>
+					<Th rowSpan={2} isSorted sortDirection='up'>
+						Sorted Column
+					</Th>
+					<Th colSpan={3} align='center'>
+						Alignments
+					</Th>
+				</Tr>
+				<Tr>
+					<Th align='left'>align left</Th>
+					<Th align='center'>align center</Th>
+					<Th align='right' isSortable isSorted>
+						align right
+					</Th>
+				</Tr>
+			</Thead>
+			<Tbody>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>Text && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isActionable isDisabled>
+					<Td>
+						<Checkbox />
+					</Td>
+					<Td>
+						<a href='#'>isDisabled Link && isActionable</a>
+					</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small'>button</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+				<Tr isSelected isDisabled isActionable>
+					<Td>
+						<Checkbox isSelected={true} />
+					</Td>
+					<Td>isSelected && isDisabled && isActionable</Td>
+					<Td hasBorderLeft hasBorderRight>
+						<SuccessIcon />
+					</Td>
+					<Td>
+						<Button size='small' isDisabled={true}>
+							button
+						</Button>
+					</Td>
+					<Td>Sorted Column</Td>
+					<Td align='left' hasBorderLeft>
+						align left
+					</Td>
+					<Td align='center'>align center</Td>
+					<Td align='right'>align right</Td>
+				</Tr>
+			</Tbody>
+		</Table>
+	);
 };
-NoHover.storyName = 'NoHover';

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,10 +1,9 @@
-import _ from 'lodash';
-import React, { ReactElement } from 'react';
+import _, { omit } from 'lodash';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	filterTypes,
-	omitProps,
 	StandardProps,
 	Overwrite,
 } from '../../util/component-types';
@@ -34,7 +33,12 @@ const Thead = (props: ITheadProps) => {
 
 	return (
 		<thead
-			{...omitProps(passThroughs, undefined, _.keys(Thead.propTypes))}
+			{...omit(passThroughs, [
+				'className',
+				'children',
+				'initialState',
+				'callbackId',
+			] as any)}
 			className={cx('&-Thead', className)}
 		>
 			{renderRowsWithIdentifiedEdges(filterTypes(children, Tr), Th as any)}
@@ -79,7 +83,12 @@ const Tbody = (props: ITBodyProps) => {
 
 	return (
 		<tbody
-			{...omitProps(passThroughs, undefined, _.keys(Tbody.propTypes))}
+			{...omit(passThroughs, [
+				'className',
+				'children',
+				'initialState',
+				'callbackId',
+			])}
 			className={cx('&-Tbody', className)}
 		>
 			{renderRowsWithIdentifiedEdges(filterTypes(children, Tr), Td)}
@@ -144,11 +153,16 @@ const Tr = (props: ITrProps) => {
 
 	return (
 		<tr
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(Tr.propTypes).concat(['isActionable'])
-			)}
+			{...omit(passThroughs, [
+				'children',
+				'className',
+				'isDisabled',
+				'isSelected',
+				'isActive',
+				'isActionable',
+				'initialState',
+				'callbackId',
+			])}
 			className={cx(
 				'&-Tr',
 				{
@@ -606,7 +620,30 @@ export class Th extends React.Component<IThProps, IThState> {
 
 		return (
 			<th
-				{...omitProps(passThroughs, undefined, _.keys(Th.propTypes))}
+				{...omit(passThroughs, [
+					'className',
+					'children',
+					'style',
+					'align',
+					'hasBorderRight',
+					'hasBorderLeft',
+					'isResizable',
+					'isSortable',
+					'isSorted',
+					'onResize',
+					'sortDirection',
+					'width',
+					'minWidth',
+					'isFirstRow',
+					'isLastRow',
+					'isFirstCol',
+					'isLastCol',
+					'isFirstSingle',
+					'field',
+					'truncateContent',
+					'initialState',
+					'callbackId',
+				] as any)}
 				className={cx(
 					'&-Th',
 					{
@@ -726,11 +763,22 @@ const Td = (props: ITdProps): React.ReactElement => {
 
 	return (
 		<td
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(Td.propTypes).concat(['sortDirection'])
-			)}
+			{...omit(passThroughs, [
+				'className',
+				'align',
+				'hasBorderRight',
+				'hasBorderLeft',
+				'isFirstRow',
+				'isLastRow',
+				'isFirstCol',
+				'isLastCol',
+				'isFirstSingle',
+				'isEmpty',
+				'truncateContent',
+				'initialState',
+				'callbackId',
+				'sortDirection',
+			] as any)}
 			className={cx(
 				'&-Td',
 				{
@@ -859,7 +907,15 @@ const Table = (props: ITableProps) => {
 
 	return (
 		<table
-			{...omitProps(passThroughs, undefined, _.keys(Table.propTypes))}
+			{...omit(passThroughs, [
+				'density',
+				'hasLightHeader',
+				'hasBorder',
+				'hasWordWrap',
+				'hasHover',
+				'initialState',
+				'callbackId',
+			])}
 			style={style}
 			className={cx(
 				'&',

--- a/src/components/VerticalTabs/VerticalTabs.spec.tsx
+++ b/src/components/VerticalTabs/VerticalTabs.spec.tsx
@@ -1,3 +1,4 @@
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
@@ -5,6 +6,9 @@ import { shallow } from 'enzyme';
 import { common } from '../../util/generic-tests';
 import { VerticalTabsDumb as VerticalTabs } from './VerticalTabs';
 import { VerticalListMenuDumb as VerticalListMenu } from '../VerticalListMenu/VerticalListMenu';
+
+//👇 Destructure any child components that we will need
+const { Tab, Title } = VerticalTabs;
 
 describe('VerticalTabs', () => {
 	common(VerticalTabs, {
@@ -171,6 +175,58 @@ describe('VerticalTabs', () => {
 				wrapper.find(VerticalListMenu).props().onSelect('stuff');
 				expect(onSelectMock).toBeCalledTimes(1);
 				expect(onSelectMock.mock.calls[0][0]).toEqual('stuff');
+			});
+		});
+
+		describe('root pass throughs', () => {
+			let wrapper: any;
+
+			beforeEach(() => {
+				const props = {
+					Tab: <Tab>One content</Tab>,
+					Title: <Title>One</Title>,
+					selectedIndex: 2,
+					onSelect: noop,
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(<VerticalTabs {...props} />);
+			});
+
+			afterEach(() => {
+				wrapper.unmount();
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-VerticalTabs').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+				// 'className' is plucked from the pass through object
+				// but still appears becuase it is also directly added to the root element as a prop
+				forEach(
+					['className', 'data-testid', 'style', 'children', 'Tab', 'Title'],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-VerticalTabs').props();
+
+				forEach(
+					['selectedIndex', 'onSelect', 'initialState', 'callbackId'],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(false);
+					}
+				);
 			});
 		});
 	});

--- a/src/components/VerticalTabs/VerticalTabs.stories.tsx
+++ b/src/components/VerticalTabs/VerticalTabs.stories.tsx
@@ -1,9 +1,9 @@
 import { map } from 'lodash';
 import React from 'react';
-import { Meta } from '@storybook/react';
+import { Meta, Story } from '@storybook/react';
 
 import * as d3Scale from 'd3-scale';
-import VerticalTabs from './VerticalTabs';
+import VerticalTabs, { IVerticalTabsProps } from './VerticalTabs';
 import Lines from '../Lines/Lines';
 import SuccessIcon from '../Icon/SuccessIcon/SuccessIcon';
 import WarningIcon from '../Icon/WarningIcon/WarningIcon';
@@ -19,6 +19,7 @@ export default {
 			},
 		},
 	},
+	args: VerticalTabs.defaultProps,
 } as Meta;
 
 //👇 Destructure any child components that we will need
@@ -30,10 +31,10 @@ function addKeys(children: any) {
 }
 
 //👇 Create a “template” of how args map to rendering
-const Template: any = (args) => {
+const Template: Story<IVerticalTabsProps> = (args) => {
 	return (
 		<section>
-			<VerticalTabs {...args} />
+			<VerticalTabs {...(args as any)} />
 		</section>
 	);
 };
@@ -78,6 +79,8 @@ TitleAsChild.args = {
 };
 
 /** Complex Title as Child */
+export const ComplexTitleAsChild = Template.bind({});
+
 const dataSet = [
 	{ x: 'OR', y: 1 },
 	{ x: 'CA', y: 0 },
@@ -102,7 +105,6 @@ const titleThree = (
 	</span>
 );
 
-export const ComplexTitleAsChild = Template.bind({});
 ComplexTitleAsChild.args = {
 	children: addKeys([
 		<VerticalTabs.Tab>

--- a/src/components/VerticalTabs/VerticalTabs.tsx
+++ b/src/components/VerticalTabs/VerticalTabs.tsx
@@ -1,11 +1,10 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	findTypes,
 	getFirst,
-	omitProps,
 	Overwrite,
 	StandardProps,
 } from '../../util/component-types';
@@ -154,7 +153,13 @@ class VerticalTabs extends React.Component<
 
 		return (
 			<div
-				{...omitProps(passThroughs, undefined, _.keys(VerticalTabs.propTypes))}
+				{...omit(passThroughs, [
+					'className',
+					'selectedIndex',
+					'onSelect',
+					'initialState',
+					'callbackId',
+				])}
 				className={cx('&', className)}
 			>
 				<VerticalListMenu


### PR DESCRIPTION
## PR Checklist

Description of changes for VerticalTabs and Table components:
* Add unit tests for prop types
* Update Stories with args and Story TS definition
* Replace omitProps with explicit list of props

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2593-VerticalTabs-fix-omitProps/?path=/docs/navigation-verticaltabs--basic
<img width="892" alt="Screen Shot 2022-04-20 at 12 32 46 PM" src="https://user-images.githubusercontent.com/19521671/164308635-4d4f12ad-980c-435f-9ba1-f8feb1953b85.png">

https://docspot.adnxs.net/projects/lucid/CXP-2593-VerticalTabs-fix-omitProps/?path=/docs/table-table--basic
![Screen Shot 2022-04-21 at 10 00 54 AM](https://user-images.githubusercontent.com/19521671/164512991-849a06a8-a910-4818-a851-afb0bd5d8cfc.png)


- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
