### PR TITLE
BUDE-1755: Remove optional chaining due to compile issues

### DIFF
--- a/src/components/TextFieldValidated/TextFieldValidated.tsx
+++ b/src/components/TextFieldValidated/TextFieldValidated.tsx
@@ -116,8 +116,8 @@ class TextFieldValidated extends React.Component<
 			);
 		} else if (this.props.Info) {
 			childProps = [this.props.Info];
-		} else if (this.props.Success) {
-			childProps = [this.props.Success?.message];
+		} else if (this.props.Success && this.props.Success.message) {
+			childProps = [this.props.Success.message];
 		}
 
 		const isSuccess =
@@ -129,7 +129,8 @@ class TextFieldValidated extends React.Component<
 					'-info': !this.props.Error && this.props.Info,
 					'-success':
 						!this.props.Error && !this.props.Info && this.props.Success,
-					'-disappearing': isSuccess && this.props.Success?.disappearing,
+					'-disappearing':
+						isSuccess && this.props.Success && this.props.Success.disappearing,
 				})}
 				style={style}
 				Error={childProps}


### PR DESCRIPTION
## PR Checklist

Description of changes:

Just remove optional chaining that is preventing compilation in some apps

Link(s) to Storybook on docspot:

[link](https://docspot.adnxs.net/projects/lucid/BUDE-1755_2/?path=/docs/controls-textfieldvalidated--basic)

- Manually tested across supported browsers

  - [x] Chrome
  - [x] Firefox
  - [x] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
