### PR TITLE
Cxp 2568 infinite side panel replace omit props

### DIFF
--- a/src/components/InfiniteSlidePanel/InfiniteSlidePanel.spec.tsx
+++ b/src/components/InfiniteSlidePanel/InfiniteSlidePanel.spec.tsx
@@ -1,7 +1,11 @@
-import { shallow } from 'enzyme';
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
+import { shallow } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import InfiniteSlidePanel from './InfiniteSlidePanel';
+import ImageIcon from '../Icon/ImageIcon/ImageIcon';
+import SlidePanel from '../SlidePanel/SlidePanel';
 
 describe('InfiniteSlidePanel', () => {
 	common(InfiniteSlidePanel, {
@@ -10,6 +14,77 @@ describe('InfiniteSlidePanel', () => {
 				children: (slideOffset: any) => <span>{slideOffset}</span>,
 			};
 		},
+	});
+
+	describe('props', () => {
+		describe('root pass throughs', () => {
+			let wrapper: any;
+			const Slide = SlidePanel.Slide;
+
+			beforeEach(() => {
+				const props = {
+					...InfiniteSlidePanel.defaultProps,
+					totalSlides: 11,
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = shallow(
+					<InfiniteSlidePanel {...props}>
+						{(slideOffset) => {
+							<div>{slideOffset}</div>;
+						}}
+					</InfiniteSlidePanel>
+				);
+			});
+
+			afterEach(() => {
+				if (wrapper) {
+					wrapper.unmount();
+				}
+			});
+
+			it('passes through props not defined in `propTypes` to the root element.', () => {
+				const rootProps = wrapper.find('.lucid-InfiniteSlidePanel').props();
+
+				expect(wrapper.first().prop(['className'])).toContain('wut');
+				expect(wrapper.first().prop(['style'])).toMatchObject({
+					marginRight: 10,
+				});
+				expect(wrapper.first().prop(['data-testid'])).toBe(10);
+				expect(wrapper.first().prop(['callbackId'])).toBe(1);
+
+				// 'className', 'offset', 'slidesToShow' and 'onSwipe' are plucked from the pass through object
+				// but still appears becuase each one is also directly added to the root element as a prop
+				// callbackId is not omitted because the root <SlidePanel /> element is not a DOM element
+				forEach(
+					[
+						'isAnimated',
+						'isLooped',
+						'offset',
+						'slidesToShow',
+						'onSwipe',
+						'className',
+						'data-testid',
+						'style',
+						'children',
+						'callbackId',
+					],
+					(prop) => {
+						expect(has(rootProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+				const rootProps = wrapper.find('.lucid-InfiniteSlidePanel').props();
+
+				forEach(['totalSlides', 'Slide', 'initialState'], (prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				});
+			});
+		});
 	});
 
 	describe('required children', () => {

--- a/src/components/InfiniteSlidePanel/InfiniteSlidePanel.stories.tsx
+++ b/src/components/InfiniteSlidePanel/InfiniteSlidePanel.stories.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
-import createClass from 'create-react-class';
-import InfiniteSlidePanel from './InfiniteSlidePanel';
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
+
+import InfiniteSlidePanel, {
+	IInfiniteSlidePanelSlideProps,
+} from './InfiniteSlidePanel';
 import Button from '../Button/Button';
 
 export default {
@@ -9,14 +12,15 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (InfiniteSlidePanel as any).peek.description,
+				component: InfiniteSlidePanel.peek.description,
 			},
 		},
 	},
-};
+	args: InfiniteSlidePanel.defaultProps,
+} as Meta;
 
 /* Dynamic Content */
-export const DynamicContent = () => {
+export const DynamicContent: Story = (args: IInfiniteSlidePanelSlideProps) => {
 	const generateRGB = (n: any) => {
 		const R = Math.floor((Math.sin(n / Math.PI) + 1) * 128);
 		const G = Math.floor((Math.sin((2 * n) / Math.PI) + 1) * 128);
@@ -24,63 +28,47 @@ export const DynamicContent = () => {
 		return `rgb(${R},${G},${B})`;
 	};
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				offset: 0,
-			};
-		},
+	const [offset, setOffset] = useState(0);
 
-		handlePrev() {
-			this.setState({
-				offset: this.state.offset - 1,
-			});
-		},
+	const handlePrev = () => {
+		setOffset(offset - 1);
+	};
 
-		handleNext() {
-			this.setState({
-				offset: this.state.offset + 1,
-			});
-		},
+	const handleNext = () => {
+		setOffset(offset + 1);
+	};
 
-		handleSwipe(slidesSwiped: any) {
-			this.setState({
-				offset: this.state.offset + slidesSwiped,
-			});
-		},
+	const handleSwipe = (slidesSwiped: any) => {
+		setOffset(offset + slidesSwiped);
+	};
 
-		render() {
-			return (
-				<section>
-					<Button onClick={this.handlePrev}>Backward</Button>
-					<Button onClick={this.handleNext}>Forward</Button>
-					Current offset: {this.state.offset}
-					<InfiniteSlidePanel
-						totalSlides={12}
-						slidesToShow={3}
-						offset={this.state.offset}
-						onSwipe={this.handleSwipe}
+	return (
+		<section>
+			<Button onClick={handlePrev}>Backward</Button>
+			<Button onClick={handleNext}>Forward</Button>
+			<span style={{ marginLeft: 10 }}>Current offset: {offset}</span>
+			<InfiniteSlidePanel
+				{...args}
+				totalSlides={12}
+				slidesToShow={3}
+				offset={offset}
+				onSwipe={handleSwipe}
+			>
+				{(slideOffset) => (
+					<div
+						style={{
+							width: '100%',
+							height: '30vh',
+							background: generateRGB(slideOffset),
+							display: 'flex',
+							justifyContent: 'center',
+							alignItems: 'center',
+						}}
 					>
-						{(slideOffset) => (
-							<div
-								style={{
-									width: '100%',
-									height: '30vh',
-									background: generateRGB(slideOffset),
-									display: 'flex',
-									justifyContent: 'center',
-									alignItems: 'center',
-								}}
-							>
-								{slideOffset}
-							</div>
-						)}
-					</InfiniteSlidePanel>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+						{slideOffset}
+					</div>
+				)}
+			</InfiniteSlidePanel>
+		</section>
+	);
 };
-DynamicContent.storyName = 'DynamicContent';

--- a/src/components/InfiniteSlidePanel/InfiniteSlidePanel.tsx
+++ b/src/components/InfiniteSlidePanel/InfiniteSlidePanel.tsx
@@ -1,6 +1,7 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { lucidClassNames } from '../../util/style-helpers';
 import { Overwrite, getFirst, omitProps } from '../../util/component-types';
 import SlidePanel, {
@@ -43,6 +44,7 @@ export interface IInfiniteSlidePanelPropsRaw {
 	 * re-used. */
 	isLooped: boolean;
 
+	/** Child components of SlidePanel */
 	Slide?: React.ReactNode;
 }
 
@@ -104,12 +106,7 @@ export const InfiniteSlidePanel = (
 
 	return (
 		<SlidePanel
-			{...omitProps<IInfiniteSlidePanelProps>(
-				passThroughs,
-				undefined,
-				_.keys(InfiniteSlidePanel.propTypes),
-				false
-			)}
+			{...omit(passThroughs, ['Slide', 'initialState'] as any)}
 			className={cx('&', className)}
 			offset={offset}
 			slidesToShow={slidesToShow}
@@ -186,6 +183,7 @@ InfiniteSlidePanel.propTypes = {
 	*/
 	totalSlides: number,
 
+	/** Child components of SlidePanel */
 	Slide: node,
 };
 

--- a/src/components/InfiniteSlidePanel/__snapshots__/InfiniteSlidePanel.spec.tsx.snap
+++ b/src/components/InfiniteSlidePanel/__snapshots__/InfiniteSlidePanel.spec.tsx.snap
@@ -22,7 +22,11 @@ exports[`InfiniteSlidePanel [common] example testing should match snapshot(s) fo
       Forward
     </span>
   </button>
-  Current offset: 0
+  <span
+    style="margin-left:10px"
+  >
+    Current offset: 0
+  </span>
   <div
     class="lucid-SlidePanel lucid-InfiniteSlidePanel"
   >

--- a/src/components/SplitVertical/SplitVertical.spec.tsx
+++ b/src/components/SplitVertical/SplitVertical.spec.tsx
@@ -106,7 +106,6 @@ describe('SplitVertical', () => {
 						'callbackId',
 					],
 					(prop) => {
-						console.log(prop);
 						expect(has(rootProps, prop)).toBe(false);
 					}
 				);


### PR DESCRIPTION
## PR Checklist

Description of changes to <InfiniteSlidePanel />
* replace omitProps with explicit list of omitted props
* update snapshot
* add a unit test for the pass throughs
* add ts defs and activate SB6 controls for the Story and make it a functional component story

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2568-InfiniteSidePanel-replace-omitProps/?path=/docs/private-infiniteslidepanel--dynamic-content

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
![Screen Shot 2022-04-27 at 2 58 53 PM](https://user-images.githubusercontent.com/19521671/165638158-af681618-b58a-4116-9f09-9ffc987438f9.png)

