### PR TITLE
CXP-3019: SearchableSelect component autofocus to search field on open

### DIFF
--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -187,6 +187,12 @@ class SearchField extends React.Component<
 		value: '',
 	};
 
+	private textFieldElement = React.createRef<TextField>();
+
+	focus = (options?: FocusOptions): void => {
+		this.textFieldElement.current?.focus(options);
+	};
+
 	render(): React.ReactNode {
 		const {
 			props,
@@ -222,7 +228,9 @@ class SearchField extends React.Component<
 			autoComplete,
 		};
 
-		const textFieldElement = <TextField {...textFieldProps} />;
+		const textFieldElement = (
+			<TextField ref={this.textFieldElement} {...textFieldProps} />
+		);
 		const isIconActive = _.isUndefined(isValid)
 			? !_.isEmpty(_.get(textFieldElement, 'props.value'))
 			: isValid;

--- a/src/components/SearchableSelect/SearchableSelect.spec.tsx
+++ b/src/components/SearchableSelect/SearchableSelect.spec.tsx
@@ -417,6 +417,20 @@ describe('SearchableSelect', () => {
 
 				assert.equal(searchFieldWrapper.prop('placeholder'), 'custom');
 			});
+
+			it('should pass send focus to the underlying SearchField element when opened', () => {
+				const wrapper = mount(
+					<SearchableSelect>
+						<SearchField placeholder='custom' />
+						<Option name='OptionA'>option a</Option>
+						<Option name='OptionB'>option b</Option>
+						<Option name='OptionC'>option c</Option>
+					</SearchableSelect>
+				);
+				const control: any = wrapper.find('.lucid-Icon');
+				control.at(0).simulate('click');
+				expect(wrapper.state('isFocusOnSearchFieldRequired')).toBe(true);
+			});
 		});
 
 		describe('Placeholder', () => {

--- a/src/components/SearchableSelect/SearchableSelect.tsx
+++ b/src/components/SearchableSelect/SearchableSelect.tsx
@@ -128,6 +128,7 @@ export interface ISearchableSelectState {
 	flattenedOptionsData: IOptionsData[];
 	ungroupedOptionData: IOptionsData[];
 	optionGroupDataLookup: { [key: number]: IOptionsData[] };
+	isFocusOnSearchFieldRequired: boolean;
 }
 
 const defaultProps = {
@@ -350,6 +351,28 @@ class SearchableSelect extends React.Component<
 		onSearch(searchText, firstVisibleIndex);
 	};
 
+	handleExpand = ({
+		props,
+		event,
+	}: {
+		props: IDropMenuProps;
+		event: React.KeyboardEvent | React.MouseEvent;
+	}): void => {
+		const dropMenuProps = this.props.DropMenu;
+		dropMenuProps.onExpand && dropMenuProps.onExpand({ event, props: props });
+		this.setState({ isFocusOnSearchFieldRequired: true });
+	};
+
+	setSearchField = (e: SearchField) => {
+		if (e && this.state.isFocusOnSearchFieldRequired) {
+			this.setState({ isFocusOnSearchFieldRequired: false });
+			// use setTimeout to prevent scroll from safari
+			setTimeout(() => {
+				e.focus({ preventScroll: true });
+			}, 0);
+		}
+	};
+
 	renderUnderlinedChildren = (childText: string, searchText: string) => {
 		const [pre, match, post] = partitionText(
 			childText,
@@ -517,6 +540,7 @@ class SearchableSelect extends React.Component<
 					isDisabled={isDisabled}
 					onSelect={onSelect}
 					selectedIndices={_.isNumber(selectedIndex) ? [selectedIndex] : []}
+					onExpand={this.handleExpand}
 				>
 					<DropMenu.Control>
 						<div
@@ -570,6 +594,7 @@ class SearchableSelect extends React.Component<
 							autoComplete={searchFieldProps.autoComplete || 'off'}
 							onChange={this.handleSearch}
 							value={searchText}
+							ref={this.setSearchField}
 						/>
 					</DropMenu.Header>
 					{isLoading && (

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -329,9 +329,9 @@ class TextField extends React.Component<
 		}
 	};
 
-	focus = (): void => {
+	focus = (options?: FocusOptions): void => {
 		/* istanbul ignore next */
-		(this.nativeElement.current as HTMLElement).focus();
+		(this.nativeElement.current as HTMLElement).focus(options);
 	};
 
 	UNSAFE_componentWillMount(): void {


### PR DESCRIPTION
## PR Checklist

Description of changes:
 - support autofocus onto TextField when SearchableSelect is opened
 - add/extend existing `focus` methods to support optional `FocusOptions` parameter for `TextField` and `SearchField`  (see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus)
 
Link(s) to Storybook on docspot: https://docspot.adnxs.net/projects/lucid/CXP-3019-autofocus-onto-searchableselect-open/?path=/docs/controls-searchableselect--basic

- Manually tested across supported browsers

  - [X] Chrome
  - [X] Firefox
  - [X] Safari
  - [X] MS-Edge
  
- [x] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [X] Unit tests written (`common` at minimum)
- [X] PR has one of the `semver-` labels
