### PR TITLE
Cxp 2569 line chart replace omit props

### DIFF
--- a/src/components/LineChart/LineChart.spec.tsx
+++ b/src/components/LineChart/LineChart.spec.tsx
@@ -3,13 +3,15 @@
 // author inteded. As a consequence, you may need to re-pin these tests if you
 // change things.
 
+import _, { forEach, has, identity } from 'lodash';
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { common } from '../../util/generic-tests';
 import assert from 'assert';
 
 import LineChart from './LineChart';
 import { EmptyStateWrapper } from '../EmptyStateWrapper/EmptyStateWrapper';
+import * as chartConstants from '../../constants/charts';
 
 const {
 	EmptyStateWrapper: { Title, Body },
@@ -54,6 +56,150 @@ describe('LineChart', () => {
 					.find('LoadingIndicator');
 
 				assert(loadingIndicatorWrapper.prop('isLoading'));
+			});
+		});
+
+		describe('pass throughs', () => {
+			const className = 'wut';
+
+			const data = [
+				{ x: new Date('2015-01-01T00:00:00-08:00'), y: 1 },
+				{ x: new Date('2015-01-02T00:00:00-08:00'), y: 0 },
+				{ x: new Date('2015-01-03T00:00:00-08:00'), y: 3 },
+			];
+
+			const props = {
+				className: 'wut',
+				height: 100,
+				width: 101,
+				margin: { top: 10, right: 11, bottom: 12, left: 13 },
+				data,
+				legend: {
+					x: 'Date',
+					y: 'Impressions',
+				},
+				isLoading: true,
+				hasToolTips: true,
+				hasLegend: true,
+				palette: chartConstants.PALETTE_MONOCHROME_2_5,
+				colorMap: { clicks: '#abc123' },
+				xAxisField: 'xAxisField test',
+				xAxisMin: new Date('2021-01-01T00:00:00-08:00'),
+				xAxisMax: new Date('2022-01-01T00:00:00-08:00'),
+				xAxisFormatter: identity,
+				xAxisTooltipFormatter: identity,
+				xAxisTickCount: 10,
+				xAxisTicks: [
+					new Date('2022-01-01T00:00:00-08:00'),
+					new Date('2022-01-01T00:00:00-08:00'),
+				],
+				xAxisTitle: 'xAxisTitle test',
+				xAxisTitleColor: chartConstants.COLOR_0,
+				xAxisTextOrientation: 'vertical' as any,
+				yAxisFields: ['yAxisFields1', 'yAxisFields2'],
+				yAxisMin: 103,
+				yAxisMax: 104,
+				yAxisFormatter: identity,
+				yAxisIsStacked: true,
+				yAxisHasPoints: true,
+				yAxisTickCount: 105,
+				yAxisTitle: 'yAxisTitle test',
+				yAxisTitleColor: chartConstants.COLOR_2,
+				yAxisTooltipFormatter: identity,
+				yAxisTooltipDataFormatter: identity,
+				yAxisColorOffset: 106,
+				y2AxisFields: ['y2AxisFields_1 test', 'y2AxisFields_2 test'],
+				y2AxisMin: 106,
+				y2AxisMax: 107,
+				y2AxisFormatter: identity,
+				y2AxisTooltipDataFormatter: identity,
+				y2AxisIsStacked: true,
+				y2AxisHasPoints: true,
+				y2AxisTickCount: 108,
+				y2AxisTitle: 'y2AxisTitle test',
+				y2AxisTitleColor: chartConstants.COLOR_3,
+				y2AxisColorOffset: 109,
+				yAxisTextOrientation: 'horizontal' as any,
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+				...{
+					foo: 1,
+					bar: 2,
+				},
+			};
+
+			it('passes through all props not defined in `propTypes` to the native input element.', () => {
+				wrapper = shallow(<LineChart {...props} />);
+
+				const inputProps = wrapper.find('.lucid-LineChart').props();
+
+				// 'className', 'width' and 'height'
+				// all appear becuase they are directly passed on the root element as a prop
+				// It should pass `foo` and `bar` through to the native svg.
+				_.forEach(
+					['foo', 'bar', 'className', 'data-testid', 'height', 'width'],
+					(prop) => {
+						expect(has(inputProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits the component specific props defined in `propTypes` (plus, in addition, `children`, `initialState`, and `callbackId`) from the root element', () => {
+				wrapper = shallow(<LineChart {...props} />);
+
+				const inputProps = wrapper.find('.lucid-LineChart').props();
+
+				forEach(
+					[
+						'margin',
+						'data',
+						'legend',
+						'isLoading',
+						'hasToolTips',
+						'hasLegend',
+						'palette',
+						'colorMap',
+						'xAxisField',
+						'xAxisMin',
+						'xAxisMax',
+						'xAxisFormatter',
+						'xAxisTooltipFormatter',
+						'xAxisTickCount',
+						'xAxisTicks',
+						'xAxisTitle',
+						'xAxisTitleColor',
+						'xAxisTextOrientation',
+						'yAxisFields',
+						'yAxisMin',
+						'yAxisMax',
+						'yAxisFormatter',
+						'yAxisIsStacked',
+						'yAxisHasPoints',
+						'yAxisTickCount',
+						'yAxisTitle',
+						'yAxisTitleColor',
+						'yAxisTooltipFormatter',
+						'yAxisTooltipDataFormatter',
+						'yAxisColorOffset',
+						'y2AxisFields',
+						'y2AxisMin',
+						'y2AxisMax',
+						'y2AxisFormatter',
+						'y2AxisTooltipDataFormatter',
+						'y2AxisIsStacked',
+						'y2AxisHasPoints',
+						'y2AxisTickCount',
+						'y2AxisTitle',
+						'y2AxisTitleColor',
+						'y2AxisColorOffset',
+						'yAxisTextOrientation',
+						'callbackId',
+						'initialState',
+					],
+					(prop) => {
+						expect(has(inputProps, prop)).toBe(false);
+					}
+				);
 			});
 		});
 	});

--- a/src/components/LineChart/LineChart.stories.tsx
+++ b/src/components/LineChart/LineChart.stories.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import createClass from 'create-react-class';
 import _ from 'lodash';
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+
 import Resizer from '../Resizer/Resizer';
 import Button from '../Button/Button';
 import * as chartConstants from '../../constants/charts';
-import LineChart from './LineChart';
+import LineChart, { ILineChartProps } from './LineChart';
 import Legend from '../Legend/Legend';
 import * as formatters from '../../util/formatters';
 
@@ -18,10 +19,11 @@ export default {
 			},
 		},
 	},
-};
+	args: LineChart.defaultProps,
+} as Meta;
 
 /* Basic */
-export const Basic = () => {
+export const Basic: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{ x: new Date('2015-01-01T00:00:00-08:00'), y: 1 },
 		{ x: new Date('2015-01-02T00:00:00-08:00'), y: 0 },
@@ -33,21 +35,15 @@ export const Basic = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart data={data} width={800} />
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart {...args} data={data} width={800} />
+		</section>
+	);
 };
 
 /* Responsive */
-export const Responsive = () => {
+export const Responsive: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{ x: new Date('2015-01-01T00:00:00-08:00'), y: 1 },
 		{ x: new Date('2015-01-02T00:00:00-08:00'), y: 2 },
@@ -59,25 +55,19 @@ export const Responsive = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<Resizer>
-						{(width /*, height */) => (
-							<LineChart width={width} height={width * 0.3} data={data} />
-						)}
-					</Resizer>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<Resizer>
+				{(width /*, height */) => (
+					<LineChart {...args} width={width} height={width * 0.3} data={data} />
+				)}
+			</Resizer>
+		</section>
+	);
 };
 
 /* Multi */
-export const Multi = () => {
+export const Multi: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{
 			x: new Date('2015-01-01T00:00:00-08:00'),
@@ -259,26 +249,21 @@ export const Multi = () => {
 		paddingTop: '8rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						yAxisFields={['apples', 'oranges', 'pears']}
-						yAxisTitle='Fruit Count'
-						width={800}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				yAxisFields={['apples', 'oranges', 'pears']}
+				yAxisTitle='Fruit Count'
+				width={800}
+			/>
+		</section>
+	);
 };
 
 /* Multi With Legend */
-export const MultiWithLegend = () => {
+export const MultiWithLegend: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{
 			x: new Date('2015-01-01T00:00:00-08:00'),
@@ -312,42 +297,36 @@ export const MultiWithLegend = () => {
 		paddingTop: '8rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						yAxisFields={yAxisFields}
-						yAxisTitle='Fruit Count'
-						palette={palette}
-						width={800}
-					/>
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				yAxisFields={yAxisFields}
+				yAxisTitle='Fruit Count'
+				palette={palette}
+				width={800}
+			/>
 
-					<Legend style={{ verticalAlign: 'top' }}>
-						{_.map(yAxisFields, (field, i) => (
-							<Legend.Item
-								key={field}
-								hasPoint
-								hasLine
-								color={palette[i % palette.length]}
-								pointKind={i}
-							>
-								{field}
-							</Legend.Item>
-						))}
-					</Legend>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+			<Legend style={{ verticalAlign: 'top' }}>
+				{_.map(yAxisFields, (field, i) => (
+					<Legend.Item
+						key={field}
+						hasPoint
+						hasLine
+						color={palette[i % palette.length]}
+						pointKind={i}
+					>
+						{field}
+					</Legend.Item>
+				))}
+			</Legend>
+		</section>
+	);
 };
-MultiWithLegend.storyName = 'MultiWithLegend';
 
 /* Stacked */
-export const Stacked = () => {
+export const Stacked: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{
 			x: new Date('2015-01-01T00:00:00-08:00'),
@@ -409,34 +388,29 @@ export const Stacked = () => {
 		paddingTop: '11rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						yAxisFields={[
-							'apples',
-							'oranges',
-							'pears',
-							'bananas',
-							'kiwis',
-							'cherries',
-						]}
-						yAxisIsStacked={true}
-						yAxisTitle='Fruit Count'
-						width={800}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				yAxisFields={[
+					'apples',
+					'oranges',
+					'pears',
+					'bananas',
+					'kiwis',
+					'cherries',
+				]}
+				yAxisIsStacked={true}
+				yAxisTitle='Fruit Count'
+				width={800}
+			/>
+		</section>
+	);
 };
 
 /* Dual Axis */
-export const DualAxis = () => {
+export const DualAxis: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{ x: new Date('2015-01-01T00:00:00-08:00'), bananas: 2, cherries: 8 },
 		{ x: new Date('2015-03-02T00:00:00-08:00'), bananas: 2, cherries: 5 },
@@ -448,38 +422,32 @@ export const DualAxis = () => {
 		paddingTop: '5rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						margin={{
-							right: 80,
-						}}
-						width={800}
-						colorMap={{
-							bananas: chartConstants.COLOR_4,
-							cherries: chartConstants.COLOR_2,
-						}}
-						yAxisFields={['bananas']}
-						yAxisTitle='Number of Bananas'
-						yAxisTitleColor={chartConstants.COLOR_4}
-						y2AxisFields={['cherries']}
-						y2AxisTitle='Number of Cherries'
-						y2AxisTitleColor={chartConstants.COLOR_2}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				margin={{
+					right: 80,
+				}}
+				width={800}
+				colorMap={{
+					bananas: chartConstants.COLOR_4,
+					cherries: chartConstants.COLOR_2,
+				}}
+				yAxisFields={['bananas']}
+				yAxisTitle='Number of Bananas'
+				yAxisTitleColor={chartConstants.COLOR_4}
+				y2AxisFields={['cherries']}
+				y2AxisTitle='Number of Cherries'
+				y2AxisTitleColor={chartConstants.COLOR_2}
+			/>
+		</section>
+	);
 };
-DualAxis.storyName = 'DualAxis';
 
 /* All The Things */
-export const AllTheThings = () => {
+export const AllTheThings: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{
 			date: new Date('2015-01-01T00:00:00-08:00'),
@@ -515,49 +483,45 @@ export const AllTheThings = () => {
 		paddingTop: '5rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						margin={{
-							right: 80,
-						}}
-						width={800}
-						data={data}
-						colorMap={{
-							blueberries: chartConstants.COLOR_0,
-							oranges: chartConstants.COLOR_1,
-						}}
-						xAxisField='date'
-						xAxisFormatter={xFormatter}
-						xAxisMin={new Date('2014-12-31T00:00-08:00')}
-						xAxisMax={new Date('2015-01-07T00:00-08:00')}
-						xAxisTickCount={5}
-						xAxisTitle='Date'
-						yAxisFields={['blueberries']}
-						yAxisFormatter={yFormatter}
-						yAxisTickCount={5}
-						yAxisTitle='Number of Blueberries'
-						yAxisTitleColor={chartConstants.COLOR_0}
-						y2AxisFields={['oranges']}
-						y2AxisFormatter={yFormatter}
-						y2AxisTickCount={5}
-						y2AxisTitle='Number of Oranges'
-						y2AxisHasPoints={false}
-						y2AxisTitleColor={chartConstants.COLOR_1}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				margin={{
+					right: 80,
+				}}
+				width={800}
+				data={data}
+				colorMap={{
+					blueberries: chartConstants.COLOR_0,
+					oranges: chartConstants.COLOR_1,
+				}}
+				xAxisField='date'
+				xAxisFormatter={xFormatter}
+				xAxisMin={new Date('2014-12-31T00:00-08:00')}
+				xAxisMax={new Date('2015-01-07T00:00-08:00')}
+				xAxisTickCount={5}
+				xAxisTitle='Date'
+				yAxisFields={['blueberries']}
+				yAxisFormatter={yFormatter}
+				yAxisTickCount={5}
+				yAxisTitle='Number of Blueberries'
+				yAxisTitleColor={chartConstants.COLOR_0}
+				y2AxisFields={['oranges']}
+				y2AxisFormatter={yFormatter}
+				y2AxisTickCount={5}
+				y2AxisTitle='Number of Oranges'
+				y2AxisHasPoints={false}
+				y2AxisTitleColor={chartConstants.COLOR_1}
+			/>
+		</section>
+	);
 };
-AllTheThings.storyName = 'AllTheThings';
 
 /* Stacked Single Series With Formatters */
-export const StackedSingleSeriesWithFormatters = () => {
+export const StackedSingleSeriesWithFormatters: Story<ILineChartProps> = (
+	args: any
+) => {
 	const data = [
 		{ x: new Date('2015-01-01T00:00:00-08:00'), y: 1.55 },
 		{ x: new Date('2015-01-02T00:00:00-08:00'), y: 2.67 },
@@ -569,29 +533,24 @@ export const StackedSingleSeriesWithFormatters = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						yAxisIsStacked
-						yAxisFormatter={(yValue) => `$ ${yValue}`}
-						yAxisTooltipFormatter={(yField, yValueFormatted) => yValueFormatted}
-						data={data}
-						width={800}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				yAxisIsStacked
+				yAxisFormatter={(yValue) => `$ ${yValue}`}
+				yAxisTooltipFormatter={(yField, yValueFormatted) => yValueFormatted}
+				data={data}
+				width={800}
+			/>
+		</section>
+	);
 };
-StackedSingleSeriesWithFormatters.storyName =
-	'StackedSingleSeriesWithFormatters';
 
 /* Stacked Monochrome No Shapes */
-export const StackedMonochromeNoShapes = () => {
+export const StackedMonochromeNoShapes: Story<ILineChartProps> = (
+	args: any
+) => {
 	const data = [
 		{
 			x: new Date('2015-01-01T00:00:00-08:00'),
@@ -647,30 +606,24 @@ export const StackedMonochromeNoShapes = () => {
 		paddingTop: '10rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						width={800}
-						yAxisFields={['apples', 'oranges', 'pears', 'bananas', 'kiwis']}
-						yAxisIsStacked={true}
-						yAxisHasPoints={false}
-						yAxisTitle='Fruit Count'
-						palette={chartConstants.PALETTE_MONOCHROME_0_5}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				width={800}
+				yAxisFields={['apples', 'oranges', 'pears', 'bananas', 'kiwis']}
+				yAxisIsStacked={true}
+				yAxisHasPoints={false}
+				yAxisTitle='Fruit Count'
+				palette={chartConstants.PALETTE_MONOCHROME_0_5}
+			/>
+		</section>
+	);
 };
-StackedMonochromeNoShapes.storyName = 'StackedMonochromeNoShapes';
 
 /* Abbreviated Numbers */
-export const AbbreviatedNumbers = () => {
+export const AbbreviatedNumbers: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{ x: new Date('2015-01-07T00:00:00-08:00'), blueberries: 1030872156 },
 		{ x: new Date('2015-01-08T00:00:00-08:00'), blueberries: 4002156 },
@@ -683,28 +636,22 @@ export const AbbreviatedNumbers = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						width={800}
-						yAxisFields={['blueberries']}
-						yAxisFormatter={formatters.formatAbbreviatedNumber}
-						yAxisTooltipDataFormatter={formatters.formatThousands}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				width={800}
+				yAxisFields={['blueberries']}
+				yAxisFormatter={formatters.formatAbbreviatedNumber}
+				yAxisTooltipDataFormatter={formatters.formatThousands}
+			/>
+		</section>
+	);
 };
-AbbreviatedNumbers.storyName = 'AbbreviatedNumbers';
 
 /* Color Offset */
-export const ColorOffset = () => {
+export const ColorOffset: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{ x: new Date('2015-01-01T00:00:00-08:00'), apples: 184, pears: 117 },
 		{ x: new Date('2015-01-02T00:00:00-08:00'), apples: 191, pears: 118 },
@@ -727,122 +674,94 @@ export const ColorOffset = () => {
 		paddingTop: '5rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						margin={{
-							right: 80,
-						}}
-						width={800}
-						hasLegend
-						yAxisFields={['apples']}
-						yAxisColorOffset={3}
-						y2AxisFields={['pears']}
-						y2AxisColorOffset={4}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				margin={{
+					right: 80,
+				}}
+				width={800}
+				hasLegend
+				yAxisFields={['apples']}
+				yAxisColorOffset={3}
+				y2AxisFields={['pears']}
+				y2AxisColorOffset={4}
+			/>
+		</section>
+	);
 };
-ColorOffset.storyName = 'ColorOffset';
 
 /* Empty */
-export const Empty = () => {
-	const Component = createClass({
-		render() {
-			return <LineChart data={[]} yAxisFields={['blueberries']} width={800} />;
-		},
-	});
-
-	return <Component />;
+export const Empty: Story<ILineChartProps> = (args: any) => {
+	return (
+		<LineChart {...args} data={[]} yAxisFields={['blueberries']} width={800} />
+	);
 };
 
 /* Empty With Custom Title And Body */
-export const EmptyWithCustomTitleAndBody = () => {
+export const EmptyWithCustomTitleAndBody: Story<ILineChartProps> = (
+	args: any
+) => {
 	const {
 		EmptyStateWrapper,
 		EmptyStateWrapper: { Title, Body },
 	} = LineChart;
 
-	const Component = createClass({
-		render() {
-			return (
-				<LineChart data={[]} yAxisFields={['blueberries']} width={800}>
-					<EmptyStateWrapper>
-						<Title>Something went wrong.</Title>
-						<Body
-							style={{
-								fontSize: '12px',
-							}}
-						>
-							Echo park poutine esse tempor squid do. Lo-fi ramps XOXO
-							chicharrones laboris, portland fugiat locavore. Fap four dollar
-							toast keytar, cronut kogi fingerstache distillery microdosing
-							everyday carry austin DIY dreamcatcher. Distillery flexitarian
-							meditation laboris roof party. Cred raclette gastropub tilde
-							PBR&B. Shoreditch poke adipisicing, reprehenderit lumbersexual
-							succulents mustache officia franzen vinyl nostrud af. Hashtag
-							bitters organic, before they sold out butcher cronut sapiente.
-						</Body>
-					</EmptyStateWrapper>
-				</LineChart>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<LineChart {...args} data={[]} yAxisFields={['blueberries']} width={800}>
+			<EmptyStateWrapper>
+				<Title>Something went wrong.</Title>
+				<Body
+					style={{
+						fontSize: '12px',
+					}}
+				>
+					Echo park poutine esse tempor squid do. Lo-fi ramps XOXO chicharrones
+					laboris, portland fugiat locavore. Fap four dollar toast keytar,
+					cronut kogi fingerstache distillery microdosing everyday carry austin
+					DIY dreamcatcher. Distillery flexitarian meditation laboris roof
+					party. Cred raclette gastropub tilde PBR&B. Shoreditch poke
+					adipisicing, reprehenderit lumbersexual succulents mustache officia
+					franzen vinyl nostrud af. Hashtag bitters organic, before they sold
+					out butcher cronut sapiente.
+				</Body>
+			</EmptyStateWrapper>
+		</LineChart>
+	);
 };
-EmptyWithCustomTitleAndBody.storyName = 'EmptyWithCustomTitleAndBody';
 
 /* Empty With Button */
-export const EmptyWithButton = () => {
+export const EmptyWithButton: Story<ILineChartProps> = (args: any) => {
 	const {
 		EmptyStateWrapper,
 		EmptyStateWrapper: { Title, Body },
 	} = LineChart;
 
-	const Component = createClass({
-		render() {
-			return (
-				<LineChart data={[]} yAxisFields={['blueberries']} width={800}>
-					<EmptyStateWrapper>
-						<Title>Something went wrong.</Title>
-						<Body
-							style={{
-								fontSize: '12px',
-							}}
-						>
-							<Button>Action</Button>
-						</Body>
-					</EmptyStateWrapper>
-				</LineChart>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<LineChart {...args} data={[]} yAxisFields={['blueberries']} width={800}>
+			<EmptyStateWrapper>
+				<Title>Something went wrong.</Title>
+				<Body
+					style={{
+						fontSize: '12px',
+					}}
+				>
+					<Button>Action</Button>
+				</Body>
+			</EmptyStateWrapper>
+		</LineChart>
+	);
 };
-EmptyWithButton.storyName = 'EmptyWithButton';
 
 /* Loading */
-export const Loading = () => {
-	const Component = createClass({
-		render() {
-			return <LineChart data={[]} width={800} isLoading />;
-		},
-	});
-
-	return <Component />;
+export const Loading: Story<ILineChartProps> = (args: any) => {
+	return <LineChart {...args} data={[]} width={800} isLoading />;
 };
 
 /* Fine Grained Ticks */
-export const FineGrainedTicks = () => {
+export const FineGrainedTicks: Story<ILineChartProps> = (args: any) => {
 	const data = [
 		{ x: new Date('2018-01-01T00:00:00-0800'), y: 1 },
 		{ x: new Date('2018-01-02T00:00:00-0800'), y: 2 },
@@ -853,21 +772,15 @@ export const FineGrainedTicks = () => {
 		paddingTop: '5rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<LineChart
-						data={data}
-						width={800}
-						xAxisTicks={_.map(data, 'x')}
-						xAxisFormatter={(date) => date.toLocaleDateString()}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section style={style}>
+			<LineChart
+				{...args}
+				data={data}
+				width={800}
+				xAxisTicks={_.map(data, 'x')}
+				xAxisFormatter={(date) => date.toLocaleDateString()}
+			/>
+		</section>
+	);
 };
-FineGrainedTicks.storyName = 'FineGrainedTicks';

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -1,16 +1,11 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as d3Scale from 'd3-scale';
 import * as d3TimeFormat from 'd3-time-format';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	StandardProps,
-	getFirst,
-	omitProps,
-	Overwrite,
-} from '../../util/component-types';
+import { StandardProps, getFirst, Overwrite } from '../../util/component-types';
 import {
 	minByFields,
 	maxByFields,
@@ -292,6 +287,57 @@ export interface ILineChartPropsRaw extends StandardProps {
 	yAxisTextOrientation: 'vertical' | 'horizontal' | 'diagonal';
 }
 
+/** TODO: Remove the nonPassThroughs when the component is converted to a functional component */
+const nonPassThroughs = [
+	'className',
+	'height',
+	'width',
+	'margin',
+	'data',
+	'legend',
+	'isLoading',
+	'hasToolTips',
+	'hasLegend',
+	'palette',
+	'colorMap',
+	'xAxisField',
+	'xAxisMin',
+	'xAxisMax',
+	'xAxisFormatter',
+	'xAxisTooltipFormatter',
+	'xAxisTickCount',
+	'xAxisTicks',
+	'xAxisTitle',
+	'xAxisTitleColor',
+	'xAxisTextOrientation',
+	'yAxisFields',
+	'yAxisMin',
+	'yAxisMax',
+	'yAxisFormatter',
+	'yAxisIsStacked',
+	'yAxisHasPoints',
+	'yAxisTickCount',
+	'yAxisTitle',
+	'yAxisTitleColor',
+	'yAxisTooltipFormatter',
+	'yAxisTooltipDataFormatter',
+	'yAxisColorOffset',
+	'y2AxisFields',
+	'y2AxisMin',
+	'y2AxisMax',
+	'y2AxisFormatter',
+	'y2AxisTooltipDataFormatter',
+	'y2AxisIsStacked',
+	'y2AxisHasPoints',
+	'y2AxisTickCount',
+	'y2AxisTitle',
+	'y2AxisTitleColor',
+	'y2AxisColorOffset',
+	'yAxisTextOrientation',
+	'callbackId',
+	'initialState',
+];
+
 export type ILineChartProps = Overwrite<
 	React.SVGProps<SVGGElement>,
 	ILineChartPropsRaw
@@ -357,6 +403,7 @@ class LineChart extends React.Component<ILineChartProps, ILineChartState, {}> {
 				]
 		*/
 		data: arrayOf(object),
+
 		/**
 			An object with human readable names for fields that will be used for
 			legends and tooltips. E.g:
@@ -1014,7 +1061,7 @@ class LineChart extends React.Component<ILineChartProps, ILineChartState, {}> {
 				>
 					{emptyStateWrapperChildren}
 					<svg
-						{...omitProps(passThroughs, undefined, _.keys(LineChart.propTypes))}
+						{...(omit(passThroughs, nonPassThroughs) as any)}
 						className={svgClasses}
 						width={width}
 						height={height}
@@ -1046,7 +1093,7 @@ class LineChart extends React.Component<ILineChartProps, ILineChartState, {}> {
 
 		return (
 			<svg
-				{...omitProps(passThroughs, undefined, _.keys(LineChart.propTypes))}
+				{...(omit(passThroughs, nonPassThroughs) as any)}
 				className={svgClasses}
 				width={width}
 				height={height}

--- a/src/components/LineChart/__snapshots__/LineChart.spec.tsx.snap
+++ b/src/components/LineChart/__snapshots__/LineChart.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LineChart [common] example testing should match snapshot(s) for AbbreviatedNumbers 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -442,11 +442,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for Abbrevi
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for AllTheThings 1`] = `
-<div
+<section
   style="padding-top:5rem"
 >
   <svg
@@ -989,11 +989,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for AllTheT
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for Basic 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -1543,11 +1543,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for Basic 1
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for ColorOffset 1`] = `
-<div
+<section
   style="padding-top:5rem"
 >
   <svg
@@ -2510,11 +2510,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for ColorOf
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for DualAxis 1`] = `
-<div
+<section
   style="padding-top:5rem"
 >
   <svg
@@ -3175,7 +3175,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for DualAxi
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for Empty 1`] = `
@@ -3369,7 +3369,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for EmptyWi
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for FineGrainedTicks 1`] = `
-<div
+<section
   style="padding-top:5rem"
 >
   <svg
@@ -3838,7 +3838,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for FineGra
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for Loading 1`] = `
@@ -3923,7 +3923,7 @@ exports[`LineChart [common] example testing should match snapshot(s) for Loading
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for Multi 1`] = `
-<div
+<section
   style="padding-top:8rem"
 >
   <svg
@@ -4933,11 +4933,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for Multi 1
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for MultiWithLegend 1`] = `
-<div
+<section
   style="padding-top:8rem"
 >
   <svg
@@ -5656,11 +5656,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for MultiWi
       pears
     </li>
   </ul>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for Responsive 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <div
@@ -6138,11 +6138,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for Respons
       </svg>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for Stacked 1`] = `
-<div
+<section
   style="padding-top:11rem"
 >
   <svg
@@ -6953,11 +6953,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for Stacked
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for StackedMonochromeNoShapes 1`] = `
-<div
+<section
   style="padding-top:10rem"
 >
   <svg
@@ -7517,11 +7517,11 @@ exports[`LineChart [common] example testing should match snapshot(s) for Stacked
       />
     </g>
   </svg>
-</div>
+</section>
 `;
 
 exports[`LineChart [common] example testing should match snapshot(s) for StackedSingleSeriesWithFormatters 1`] = `
-<div
+<section
   style="padding-top:4rem"
 >
   <svg
@@ -8090,5 +8090,5 @@ exports[`LineChart [common] example testing should match snapshot(s) for Stacked
       />
     </g>
   </svg>
-</div>
+</section>
 `;

--- a/src/components/SplitVertical/SplitVertical.spec.tsx
+++ b/src/components/SplitVertical/SplitVertical.spec.tsx
@@ -106,7 +106,6 @@ describe('SplitVertical', () => {
 						'callbackId',
 					],
 					(prop) => {
-						console.log(prop);
 						expect(has(rootProps, prop)).toBe(false);
 					}
 				);


### PR DESCRIPTION
## PR Checklist

Description of changes to `LineChart`:
* Add unit test for pass throughs
* Add controls and type defs to Stories
* Replace omitProps method with list of props
* update snapshot

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2569-LineChart-replace-omitProps/?path=/docs/visualizations-linechart--basic
<img width="871" alt="Screen Shot 2022-04-29 at 3 57 24 PM" src="https://user-images.githubusercontent.com/19521671/166078568-bc72ccea-db9e-48a5-b185-cf62fb893725.png">

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
