### PR TITLE
Update the default values for the side panel

### DIFF
--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -213,9 +213,9 @@ class SidePanel extends React.Component<ISidePanelProps, ISidePanelState, {}> {
 		position: 'right',
 		preventBodyScroll: false,
 		topOffset: 0,
-		width: 240,
-		minWidth: -Infinity,
-		maxWidth: Infinity,
+		width: 500,
+		minWidth: 500,
+		maxWidth: 1200,
 	};
 
 	static Header = SidePanelHeader;

--- a/src/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/src/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -121,7 +121,7 @@ exports[`SidePanel Header should match snapshot 1`] = `
     style={
       Object {
         "marginTop": 0,
-        "width": 240,
+        "width": 500,
       }
     }
   >
@@ -208,7 +208,7 @@ exports[`SidePanel isAnimated should match snapshot and apply the appropriate cl
     style={
       Object {
         "marginTop": 0,
-        "width": 240,
+        "width": 500,
       }
     }
   >
@@ -261,7 +261,7 @@ exports[`SidePanel isExpanded should match snapshot and apply the appropriate cl
     style={
       Object {
         "marginTop": 0,
-        "width": 240,
+        "width": 500,
       }
     }
   >
@@ -314,7 +314,7 @@ exports[`SidePanel isResizeDisabled should match snapshot 1`] = `
     style={
       Object {
         "marginTop": 0,
-        "width": 240,
+        "width": 500,
       }
     }
   >
@@ -348,7 +348,7 @@ exports[`SidePanel position should match snapshot and apply the appropriate clas
     style={
       Object {
         "marginTop": 0,
-        "width": 240,
+        "width": 500,
       }
     }
   >
@@ -401,7 +401,7 @@ exports[`SidePanel position should match snapshot and apply the appropriate clas
     style={
       Object {
         "marginTop": 0,
-        "width": 240,
+        "width": 500,
       }
     }
   >


### PR DESCRIPTION
## PR Checklist

**Description of changes:**
Currently our SidePanel component has the following default props:

Width: 240px 
minWidth: -Infinity
maxWidth: Infinity
If teams don't update these values it can create instances where data layouts within the SidePanel fall apart. 

**Update the defaults to the following:**

Width: 500px
midWidth: 500px
maxWidth: 90% (Can we do percentages for this?)
Product teams should still be able to update these props to suite their particular content layout needs.

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-3031-update-default-props-sidepanel

- Manually tested across supported browsers

  - [x ] Chrome
  - [x ] Firefox
  - [ ] Safari

- [x ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [ ] Unit tests written (`common` at minimum)
- [x ] PR has one of the `semver-` labels
