### PR TITLE
Cxp 2585 Submarine fix omit props

### DIFF
--- a/src/components/Submarine/Submarine.spec.tsx
+++ b/src/components/Submarine/Submarine.spec.tsx
@@ -1,3 +1,4 @@
+import _, { forEach, has } from 'lodash';
 import React from 'react';
 import { shallow } from 'enzyme';
 import assert from 'assert';
@@ -67,6 +68,135 @@ describe('Submarine', () => {
 				wrapper.find('.lucid-Submarine > .lucid-Submarine-Primary').length,
 				1
 			);
+		});
+	});
+
+	describe('root pass throughs', () => {
+		let wrapper: any;
+		let barWrapper: any;
+
+		beforeEach(() => {
+			const props = {
+				...Submarine.defaultProps,
+				Title: 'test Title',
+				children: (
+					<Submarine.Bar
+						className='foo bar'
+						style={{ marginLeft: 10 }}
+						Title='test Bar Title'
+						callbackId={2}
+						data-testid={11}
+					/>
+				),
+				Primary: 'test Primary',
+				className: 'wut',
+				style: { marginRight: 10 },
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+			};
+			wrapper = shallow(<Submarine {...props} />);
+			barWrapper = wrapper.find('.lucid-Submarine > .lucid-Submarine-Bar');
+		});
+
+		afterEach(() => {
+			if (wrapper) {
+				wrapper.unmount();
+			}
+		});
+
+		it('passes through props not defined in `propTypes` to the root element.', () => {
+			const rootProps = wrapper.find('.lucid-Submarine').props();
+
+			expect(wrapper.first().prop(['className'])).toContain('wut');
+			expect(wrapper.first().prop(['style'])).toMatchObject({
+				marginRight: 10,
+			});
+			expect(wrapper.first().prop(['data-testid'])).toBe(10);
+			expect(wrapper.first().prop(['callbackId'])).toBe(1);
+
+			// 'className', 'isAnimated', 'isExpanded', 'onResizing' and 'onResize' are plucked from the pass through object
+			// but still appears becuase each one is also directly added to the root element as a prop
+			forEach(
+				[
+					'className',
+					'style',
+					'isAnimated',
+					'isExpanded',
+					'onResizing',
+					'onResize',
+					'data-testid',
+					'style',
+					'children',
+					'callbackId',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				}
+			);
+		});
+		it('omits the props defined in `propTypes` (plus, in addition, `initialState`) from the root element', () => {
+			const rootProps = wrapper.find('.lucid-Submarine').props();
+
+			forEach(
+				[
+					'height',
+					'isHidden',
+					'isTitleShownCollapsed',
+					'position',
+					'isResizeDisabled',
+					'Title',
+					'Bar',
+					'Primary',
+					'onToggle',
+					'initialState',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
+		});
+
+		it('passes through props not defined in `Bar.propTypes` to the BarPane element.', () => {
+			const barProps = wrapper.find('.lucid-Submarine-Bar').props();
+
+			expect(
+				wrapper.find('.lucid-Submarine-Bar').prop(['className'])
+			).toContain('foo bar');
+			expect(
+				wrapper.find('.lucid-Submarine-Bar').prop(['style'])
+			).toMatchObject({
+				marginLeft: 10,
+			});
+			expect(wrapper.find('.lucid-Submarine-Bar').prop(['data-testid'])).toBe(
+				11
+			);
+			expect(wrapper.find('.lucid-Submarine-Bar').prop(['callbackId'])).toBe(2);
+
+			// 'className' and 'height' are plucked from the pass through object
+			// but still appears becuase each one is also directly added to the BarPane element as a prop
+			forEach(
+				[
+					'className',
+					'style',
+					'height',
+					'children',
+					'isPrimary',
+					'data-testid',
+					'children',
+					'callbackId',
+				],
+				(prop) => {
+					expect(has(barProps, prop)).toBe(true);
+				}
+			);
+		});
+
+		it('omits the props defined in `Bar.propTypes` from the BarPane element', () => {
+			const barProps = wrapper.find('.lucid-Submarine-Bar').props();
+			forEach(['Title', 'initialState'], (prop) => {
+				expect(has(barProps, prop)).toBe(false);
+			});
 		});
 	});
 

--- a/src/components/Submarine/Submarine.stories.tsx
+++ b/src/components/Submarine/Submarine.stories.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import createClass from 'create-react-class';
-import Submarine from './Submarine';
+import { Meta, Story } from '@storybook/react';
+
+import Submarine, { ISubmarineProps } from './Submarine';
 
 export default {
 	title: 'Layout/Submarine',
@@ -8,543 +10,441 @@ export default {
 	parameters: {
 		docs: {
 			description: {
-				component: (Submarine as any).peek.description,
+				component: Submarine.peek.description,
 			},
 		},
 	},
-};
+	args: Submarine.defaultProps,
+} as Meta;
 
-/* Default Submarine */
-export const DefaultSubmarine = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 300,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine>
-						<Submarine.Bar>
-							Minim 90's paleo retro, fugiat aliqua hashtag enim photo booth
-							listicle next level. Consectetur fap proident magna culpa. Art
-							party meh ad, four loko slow-carb venmo distillery wolf cornhole
-							nisi.
-						</Submarine.Bar>
-						<Submarine.Primary>
-							Twee iPhone intelligentsia, schlitz normcore cold-pressed hella
-							sapiente meh adipisicing sustainable kogi sed. Letterpress plaid
-							aute, brunch chillwave anim mlkshk. Farm-to-table austin
-							post-ironic, man bun gluten-free nesciunt sartorial tacos tousled
-							kickstarter shabby chic migas. Kombucha flannel before they sold
-							out elit voluptate pinterest chambray, odio stumptown street art.
-							Kitsch humblebrag actually, cillum kale chips hashtag shoreditch
-							pariatur waistcoat pop-up consequat leggings try-hard. Marfa
-							crucifix seitan health goth portland. Cliche ennui vero, whatever
-							swag kogi ugh fixie wayfarers before they sold out irure culpa
-							marfa mlkshk bushwick.
-						</Submarine.Primary>
-					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+/* Basic */
+export const Basic: Story<ISubmarineProps> = (args) => {
+	return (
+		<section
+			style={{
+				height: 300,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args}>
+				<Submarine.Bar>
+					Minim 90's paleo retro, fugiat aliqua hashtag enim photo booth
+					listicle next level. Consectetur fap proident magna culpa. Art party
+					meh ad, four loko slow-carb venmo distillery wolf cornhole nisi.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					Twee iPhone intelligentsia, schlitz normcore cold-pressed hella
+					sapiente meh adipisicing sustainable kogi sed. Letterpress plaid aute,
+					brunch chillwave anim mlkshk. Farm-to-table austin post-ironic, man
+					bun gluten-free nesciunt sartorial tacos tousled kickstarter shabby
+					chic migas. Kombucha flannel before they sold out elit voluptate
+					pinterest chambray, odio stumptown street art. Kitsch humblebrag
+					actually, cillum kale chips hashtag shoreditch pariatur waistcoat
+					pop-up consequat leggings try-hard. Marfa crucifix seitan health goth
+					portland. Cliche ennui vero, whatever swag kogi ugh fixie wayfarers
+					before they sold out irure culpa marfa mlkshk bushwick.
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
 
 /* Hidden Bar */
-export const HiddenBar = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				isHidden: true,
-			};
-		},
+export const HiddenBar: Story<ISubmarineProps> = (args) => {
+	const [isHidden, setIsHidden] = useState(true);
 
-		handleToggleIsHidden() {
-			this.setState({
-				isHidden: !this.state.isHidden,
-			});
-		},
+	const handleToggleIsHidden = () => {
+		setIsHidden(!isHidden);
+	};
 
-		render() {
-			return (
-				<section>
-					<button onClick={this.handleToggleIsHidden}>toggle `isHidden`</button>
+	return (
+		<section>
+			<button onClick={handleToggleIsHidden}>toggle `isHidden`</button>
 
-					<section
-						style={{
-							height: 300,
-							background: 'lightgray',
-							outline: '1px solid lightgray',
-						}}
-					>
-						<Submarine isHidden={this.state.isHidden}>
-							<Submarine.Title>
-								This can be totally hidden from view
-							</Submarine.Title>
+			<section
+				style={{
+					height: 300,
+					background: 'lightgray',
+					outline: '1px solid lightgray',
+				}}
+			>
+				<Submarine {...args} isHidden={isHidden}>
+					<Submarine.Title>
+						This can be totally hidden from view
+					</Submarine.Title>
 
-							<Submarine.Bar>
-								Slow-carb meditation four loko, kickstarter umami tilde craft
-								beer kombucha deep v plaid yr cardigan gastropub ennui
-								snackwave. Vape health goth selvage twee lumbersexual, tattooed
-								iceland cred street art slow-carb craft beer pinterest banjo
-								typewriter pop-up. Echo park bicycle rights put a bird on it,
-								sriracha blue bottle ethical pinterest readymade messenger bag.
-								Tousled slow-carb occupy messenger bag readymade, leggings
-								celiac cloud bread tofu. Wayfarers chia jianbing, twee yuccie
-								seitan meggings food truck meh neutra bushwick mlkshk four loko.
-								Franzen unicorn tofu lumbersexual waistcoat. Taxidermy
-								gluten-free yuccie vinyl waistcoat.
-							</Submarine.Bar>
+					<Submarine.Bar>
+						Slow-carb meditation four loko, kickstarter umami tilde craft beer
+						kombucha deep v plaid yr cardigan gastropub ennui snackwave. Vape
+						health goth selvage twee lumbersexual, tattooed iceland cred street
+						art slow-carb craft beer pinterest banjo typewriter pop-up. Echo
+						park bicycle rights put a bird on it, sriracha blue bottle ethical
+						pinterest readymade messenger bag. Tousled slow-carb occupy
+						messenger bag readymade, leggings celiac cloud bread tofu. Wayfarers
+						chia jianbing, twee yuccie seitan meggings food truck meh neutra
+						bushwick mlkshk four loko. Franzen unicorn tofu lumbersexual
+						waistcoat. Taxidermy gluten-free yuccie vinyl waistcoat.
+					</Submarine.Bar>
 
-							<Submarine.Primary>
-								Pickled pinterest hot chicken taxidermy edison bulb. Butcher
-								austin listicle fingerstache unicorn flexitarian. Tumblr cred
-								quinoa normcore, mumblecore cardigan cold-pressed dreamcatcher
-								craft beer ad direct trade vero accusamus cray. Roof party chia
-								shabby chic synth.
-							</Submarine.Primary>
-						</Submarine>
-					</section>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+					<Submarine.Primary>
+						Pickled pinterest hot chicken taxidermy edison bulb. Butcher austin
+						listicle fingerstache unicorn flexitarian. Tumblr cred quinoa
+						normcore, mumblecore cardigan cold-pressed dreamcatcher craft beer
+						ad direct trade vero accusamus cray. Roof party chia shabby chic
+						synth.
+					</Submarine.Primary>
+				</Submarine>
+			</section>
+		</section>
+	);
 };
-HiddenBar.storyName = 'HiddenBar';
 
-/* 11 Title Shown Collapsed */
-export const TitleShownCollapsed = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 300,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine isTitleShownCollapsed={true}>
-						<Submarine.Title>
-							Submarine Title Stays While Collapsed!
-						</Submarine.Title>
-						<Submarine.Bar>
-							Minim 90's paleo retro, fugiat aliqua hashtag enim photo booth
-							listicle next level. Consectetur proident magna culpa. Art party
-							meh ad, four loko slow-carb venmo distillery wolf cornhole nisi.
-							Truffaut meditation cray small batch, schlitz master cleanse
-							cliche taxidermy labore gochujang bitters. Synth fixie banh mi
-							bushwick shoreditch cold-pressed.
-						</Submarine.Bar>
-						<Submarine.Primary>
-							Helvetica narwhal irony, hoodie leggings occaecat tattooed
-							authentic cred. Tumblr cred quinoa normcore, mumblecore cardigan
-							cold-pressed dreamcatcher craft beer ad direct trade vero
-							accusamus cray. Roof party chia shabby chic synth. Pariatur
-							organic before they sold out everyday carry food truck. Labore
-							four loko nihil, narwhal actually infolk mustache jean shorts. Meh
-							kickstarter chicharrones williamsburg bushwick yr, PBR&B fap.
-							Lo-fi leggings magna yuccie, tattooed accusamus blog literally
-							gochujang listicle cliche humblebrag swag kombucha tousled.
-						</Submarine.Primary>
-					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+/* Title Shown Collapsed */
+export const TitleShownCollapsed: Story<ISubmarineProps> = (args) => {
+	return (
+		<section
+			style={{
+				height: 300,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args} isTitleShownCollapsed={true}>
+				<Submarine.Title>
+					Submarine Title Stays While Collapsed!
+				</Submarine.Title>
+				<Submarine.Bar>
+					Minim 90's paleo retro, fugiat aliqua hashtag enim photo booth
+					listicle next level. Consectetur proident magna culpa. Art party meh
+					ad, four loko slow-carb venmo distillery wolf cornhole nisi. Truffaut
+					meditation cray small batch, schlitz master cleanse cliche taxidermy
+					labore gochujang bitters. Synth fixie banh mi bushwick shoreditch
+					cold-pressed.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					Helvetica narwhal irony, hoodie leggings occaecat tattooed authentic
+					cred. Tumblr cred quinoa normcore, mumblecore cardigan cold-pressed
+					dreamcatcher craft beer ad direct trade vero accusamus cray. Roof
+					party chia shabby chic synth. Pariatur organic before they sold out
+					everyday carry food truck. Labore four loko nihil, narwhal actually
+					infolk mustache jean shorts. Meh kickstarter chicharrones williamsburg
+					bushwick yr, PBR&B fap. Lo-fi leggings magna yuccie, tattooed
+					accusamus blog literally gochujang listicle cliche humblebrag swag
+					kombucha tousled.
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
-TitleShownCollapsed.storyName = '11TitleShownCollapsed';
 
 /* Disable Resize */
-export const DisableResize = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 300,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine isResizeDisabled={true}>
-						<Submarine.Bar>
-							Cold-pressed aesthetic biodiesel twee, heirloom vice iPhone
-							austin. Truffaut wolf offal roof party, neutra yr drinking vinegar
-							bitters single-origin coffee austin mlkshk mixtape semiotics blog.
-							Pickled squid asymmetrical locavore before they sold out whatever.
-						</Submarine.Bar>
-						<Submarine.Primary>
-							Chartreuse keffiyeh meggings church-key, gochujang 90's messenger
-							bag. Chillwave poutine cronut whatever occupy, squid vice organic.
-							Tilde kinfolk whatever VHS. Swag gentrify put a bird on it,
-							pour-over jean shorts knausgaard cray twee single-origin coffee
-							lo-fi church-key cronut. Pabst tousled selfies try-hard. Sartorial
-							cred ethical, food truck leggings next level sustainable
-							flexitarian chillwave knausgaard pitchfork. Direct trade poutine
-							photo booth mustache, cliche semiotics skateboard 90's. Meggings
-							actually distillery small batch pickled quinoa. Migas williamsburg
-							polaroid trust fund. Slow-carb truffaut chia, single-origin coffee
-							meggings cornhole four loko chambray put a bird on it art party
-							semiotics. Food truck mumblecore VHS photo booth, brunch direct
-							trade flexitarian before they sold out truffaut squid cred
-							everyday carry salvia neutra. Lo-fi chartreuse semiotics, paleo
-							butcher knausgaard direct trade gentrify post-ironic. XOXO craft
-							beer affogato YOLO, raw denim umami irony pabst echo park
-							humblebrag ugh plaid. Master cleanse tilde tattooed, bushwick
-							seitan selfies four dollar toast hashtag trust fund sartorial
-							cliche.
-						</Submarine.Primary>
-					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const DisableResize: Story<ISubmarineProps> = (args) => {
+	return (
+		<section
+			style={{
+				height: 300,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args} isResizeDisabled={true}>
+				<Submarine.Bar>
+					Cold-pressed aesthetic biodiesel twee, heirloom vice iPhone austin.
+					Truffaut wolf offal roof party, neutra yr drinking vinegar bitters
+					single-origin coffee austin mlkshk mixtape semiotics blog. Pickled
+					squid asymmetrical locavore before they sold out whatever.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					Chartreuse keffiyeh meggings church-key, gochujang 90's messenger bag.
+					Chillwave poutine cronut whatever occupy, squid vice organic. Tilde
+					kinfolk whatever VHS. Swag gentrify put a bird on it, pour-over jean
+					shorts knausgaard cray twee single-origin coffee lo-fi church-key
+					cronut. Pabst tousled selfies try-hard. Sartorial cred ethical, food
+					truck leggings next level sustainable flexitarian chillwave knausgaard
+					pitchfork. Direct trade poutine photo booth mustache, cliche semiotics
+					skateboard 90's. Meggings actually distillery small batch pickled
+					quinoa. Migas williamsburg polaroid trust fund. Slow-carb truffaut
+					chia, single-origin coffee meggings cornhole four loko chambray put a
+					bird on it art party semiotics. Food truck mumblecore VHS photo booth,
+					brunch direct trade flexitarian before they sold out truffaut squid
+					cred everyday carry salvia neutra. Lo-fi chartreuse semiotics, paleo
+					butcher knausgaard direct trade gentrify post-ironic. XOXO craft beer
+					affogato YOLO, raw denim umami irony pabst echo park humblebrag ugh
+					plaid. Master cleanse tilde tattooed, bushwick seitan selfies four
+					dollar toast hashtag trust fund sartorial cliche.
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
-DisableResize.storyName = 'DisableResize';
 
 /* Initial Collapsed */
-export const InitialCollapsed = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 300,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine initialState={{ isExpanded: false }}>
-						<Submarine.Bar>
-							Try-hard cornhole ea artisan, laborum wolf eiusmod chillwave
-							irure. Lomo chicharrones taxidermy narwhal. Cronut deep v PBR&B
-							photo booth tilde. Asymmetrical waistcoat williamsburg 3 wolf
-							moon, poutine magna dreamcatcher disrupt eiusmod thundercats
-							farm-to-table lumbersexual nisi mlkshk tote bag.
-						</Submarine.Bar>
-						<Submarine.Primary>
-							Celiac ad skateboard twee PBR&B. XOXO freegan pitchfork, waistcoat
-							listicle flexitarian mollit adipisicing. Delectus freegan et
-							sartorial, velit occupy exercitation fingerstache +1 ramps.
-							Exercitation pitchfork kale chips, eu everyday carry nostrud
-							aesthetic etsy health goth DIY nisi fingerstache wolf neutra
-							velit. Migas helvetica odio taxidermy. Truffaut meditation cray
-							small batch, schlitz master cleanse cliche taxidermy labore
-							gochujang bitters. Synth fixie banh mi bushwick shoreditch
-							cold-pressed.
-						</Submarine.Primary>
-					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const InitialCollapsed: Story<ISubmarineProps> = (args) => {
+	return (
+		<section
+			style={{
+				height: 300,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args} initialState={{ isExpanded: false }}>
+				<Submarine.Bar>
+					Try-hard cornhole ea artisan, laborum wolf eiusmod chillwave irure.
+					Lomo chicharrones taxidermy narwhal. Cronut deep v PBR&B photo booth
+					tilde. Asymmetrical waistcoat williamsburg 3 wolf moon, poutine magna
+					dreamcatcher disrupt eiusmod thundercats farm-to-table lumbersexual
+					nisi mlkshk tote bag.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					Celiac ad skateboard twee PBR&B. XOXO freegan pitchfork, waistcoat
+					listicle flexitarian mollit adipisicing. Delectus freegan et
+					sartorial, velit occupy exercitation fingerstache +1 ramps.
+					Exercitation pitchfork kale chips, eu everyday carry nostrud aesthetic
+					etsy health goth DIY nisi fingerstache wolf neutra velit. Migas
+					helvetica odio taxidermy. Truffaut meditation cray small batch,
+					schlitz master cleanse cliche taxidermy labore gochujang bitters.
+					Synth fixie banh mi bushwick shoreditch cold-pressed.
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
-InitialCollapsed.storyName = 'InitialCollapsed';
 
 /* Position Top */
-export const PositionTop = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 300,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine position='top'>
-						<Submarine.Bar>
-							Paleo art party disrupt, consequat kogi fashion axe tofu trust
-							fund raw denim readymade. Seitan banjo salvia organic ethical.
-							Next level pork belly sustainable tumblr nostrud.
-						</Submarine.Bar>
-						<Submarine.Primary>
-							Do nesciunt lumbersexual excepteur adipisicing tacos green juice
-							readymade semiotics, pinterest tofu VHS. Paleo dreamcatcher
-							mollit, hoodie four dollar toast typewriter kitsch magna aliquip
-							ethical sunt tattooed. Four dollar toast stumptown umami gastropub
-							heirloom flexitarian. Nihil williamsburg incididunt whatever.
-							Godard commodo bespoke tofu. Selvage polaroid echo park hella,
-							beard flexitarian roof party dolor. Consequat kickstarter ea, sint
-							minim selfies wolf cupidatat everyday carry.
-						</Submarine.Primary>
-					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const PositionTop = (args) => {
+	return (
+		<section
+			style={{
+				height: 300,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args} position='top'>
+				<Submarine.Bar>
+					Paleo art party disrupt, consequat kogi fashion axe tofu trust fund
+					raw denim readymade. Seitan banjo salvia organic ethical. Next level
+					pork belly sustainable tumblr nostrud.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					Do nesciunt lumbersexual excepteur adipisicing tacos green juice
+					readymade semiotics, pinterest tofu VHS. Paleo dreamcatcher mollit,
+					hoodie four dollar toast typewriter kitsch magna aliquip ethical sunt
+					tattooed. Four dollar toast stumptown umami gastropub heirloom
+					flexitarian. Nihil williamsburg incididunt whatever. Godard commodo
+					bespoke tofu. Selvage polaroid echo park hella, beard flexitarian roof
+					party dolor. Consequat kickstarter ea, sint minim selfies wolf
+					cupidatat everyday carry.
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
-PositionTop.storyName = 'PositionTop';
 
 /* Custom Title */
-export const CustomTitle = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 300,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine>
-						<Submarine.Title>
-							Submarine Title <button>Edit</button>
-						</Submarine.Title>
-						<Submarine.Bar>
-							You can also set the <code>title</code> or <code>Title</code> prop
-							on <code>{'<Submarine>'}</code> or{' '}
-							<code>{'<Submarine.Bar>'}</code>.
-						</Submarine.Bar>
-						<Submarine.Primary>
-							Helvetica narwhal irony, hoodie leggings occaecat tattooed
-							authentic cred. Tumblr cred quinoa normcore, mumblecore cardigan
-							cold-pressed dreamcatcher craft beer ad direct trade vero
-							accusamus cray. Roof party chia shabby chic synth. Pariatur
-							organic before they sold out everyday carry food truck. Labore
-							four loko nihil, narwhal actually kinfolk mustache jean shorts.
-							Meh kickstarter chicharrones williamsburg bushwick yr, PBR&B fap.
-							Lo-fi leggings magna yuccie, tattooed accusamus blog literally
-							gochujang listicle cliche humblebrag swag kombucha tousled.
-						</Submarine.Primary>
-					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const CustomTitle: Story<ISubmarineProps> = (args) => {
+	return (
+		<section
+			style={{
+				height: 300,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args}>
+				<Submarine.Title>Submarine Title</Submarine.Title>
+				<Submarine.Bar>
+					You can also set the <code>title</code> or <code>Title</code> prop on{' '}
+					<code>{'<Submarine>'}</code> or <code>{'<Submarine.Bar>'}</code>.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					Helvetica narwhal irony, hoodie leggings occaecat tattooed authentic
+					cred. Tumblr cred quinoa normcore, mumblecore cardigan cold-pressed
+					dreamcatcher craft beer ad direct trade vero accusamus cray. Roof
+					party chia shabby chic synth. Pariatur organic before they sold out
+					everyday carry food truck. Labore four loko nihil, narwhal actually
+					kinfolk mustache jean shorts. Meh kickstarter chicharrones
+					williamsburg bushwick yr, PBR&B fap. Lo-fi leggings magna yuccie,
+					tattooed accusamus blog literally gochujang listicle cliche humblebrag
+					swag kombucha tousled.
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
-CustomTitle.storyName = 'CustomTitle';
 
 /* Custom Height */
-export const CustomHeight = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 300,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine height={100}>
-						<Submarine.Bar>
-							Meditation photo booth actually chicharrones sed consectetur
-							voluptate stumptown. Food truck nihil ut mixtape, ex deep v
-							polaroid aesthetic. Duis street art stumptown nihil, aliquip vero
-							VHS heirloom waistcoat adipisicing post-ironic lo-fi biodiesel.
-						</Submarine.Bar>
-						<Submarine.Primary>
-							Trust fund vegan godard beard, portland humblebrag placeat neutra
-							chambray retro ugh kitsch flannel sapiente mustache. Cred placeat
-							helvetica cray, do before they sold out tilde. Deserunt everyday
-							carry brooklyn kombucha yr fanny pack banh mi, eiusmod
-							intelligentsia tempor tacos. Waistcoat neutra kale chips, keffiyeh
-							ex nulla gochujang crucifix duis typewriter hashtag reprehenderit.
-							Ad nihil mixtape 8-bit, photo booth anim post-ironic vegan qui put
-							a bird on it crucifix. Waistcoat chartreuse ethical, adipisicing
-							jean shorts direct trade PBR&B humblebrag pariatur nulla mollit
-							stumptown listicle. Flannel williamsburg vice flexitarian bespoke
-							elit.
-						</Submarine.Primary>
-					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+export const CustomHeight: Story<ISubmarineProps> = (args) => {
+	return (
+		<section
+			style={{
+				height: 300,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args} height={100}>
+				<Submarine.Bar>
+					Meditation photo booth actually chicharrones sed consectetur voluptate
+					stumptown. Food truck nihil ut mixtape, ex deep v polaroid aesthetic.
+					Duis street art stumptown nihil, aliquip vero VHS heirloom waistcoat
+					adipisicing post-ironic lo-fi biodiesel.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					Trust fund vegan godard beard, portland humblebrag placeat neutra
+					chambray retro ugh kitsch flannel sapiente mustache. Cred placeat
+					helvetica cray, do before they sold out tilde. Deserunt everyday carry
+					brooklyn kombucha yr fanny pack banh mi, eiusmod intelligentsia tempor
+					tacos. Waistcoat neutra kale chips, keffiyeh ex nulla gochujang
+					crucifix duis typewriter hashtag reprehenderit. Ad nihil mixtape
+					8-bit, photo booth anim post-ironic vegan qui put a bird on it
+					crucifix. Waistcoat chartreuse ethical, adipisicing jean shorts direct
+					trade PBR&B humblebrag pariatur nulla mollit stumptown listicle.
+					Flannel williamsburg vice flexitarian bespoke elit.
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
-CustomHeight.storyName = 'CustomHeight';
 
 /* Control Expand */
-export const ControlExpand = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				isExpanded: false,
-			};
-		},
+export const ControlExpand: Story<ISubmarineProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(false);
 
-		handleToggle() {
-			this.setState({ isExpanded: !this.state.isExpanded });
-		},
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
-		render() {
-			return (
-				<section>
-					<button onClick={this.handleToggle}>toggle</button>
+	return (
+		<section>
+			<button onClick={handleToggle}>toggle</button>
 
-					<section
-						style={{
-							height: 300,
-							background: 'lightgray',
-							outline: '1px solid lightgray',
-						}}
-					>
-						<Submarine
-							isExpanded={this.state.isExpanded}
-							onToggle={this.handleToggle}
-						>
-							<Submarine.Bar>
-								Paleo williamsburg retro, mumblecore deserunt typewriter magna
-								raw denim taxidermy. Quinoa incididunt hoodie, ea synth four
-								loko everyday carry lomo vice humblebrag forage assumenda ad
-								small batch reprehenderit.
-							</Submarine.Bar>
-							<Submarine.Primary>
-								Migas esse paleo nesciunt, mollit velit franzen tempor YOLO
-								iPhone thundercats. Keytar tilde raw denim shabby chic quinoa
-								typewriter. Shabby chic tousled labore jean shorts, veniam XOXO
-								mustache. Marfa dreamcatcher hammock cupidatat kitsch, selvage
-								cornhole dolor. Odio salvia slow-carb hammock XOXO, nulla
-								normcore jean shorts magna master cleanse tote bag ea. Pitchfork
-								marfa tote bag shoreditch, retro selvage tempor 90's kogi
-								adipisicing asymmetrical tousled. Pork belly asymmetrical
-								nesciunt, keytar jean shorts mlkshk scenester sriracha man bun
-								placeat tacos post-ironic officia art party.
-							</Submarine.Primary>
-						</Submarine>
-					</section>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+			<section
+				style={{
+					height: 300,
+					background: 'lightgray',
+					outline: '1px solid lightgray',
+				}}
+			>
+				<Submarine {...args} isExpanded={isExpanded} onToggle={handleToggle}>
+					<Submarine.Bar>
+						Paleo williamsburg retro, mumblecore deserunt typewriter magna raw
+						denim taxidermy. Quinoa incididunt hoodie, ea synth four loko
+						everyday carry lomo vice humblebrag forage assumenda ad small batch
+						reprehenderit.
+					</Submarine.Bar>
+					<Submarine.Primary>
+						Migas esse paleo nesciunt, mollit velit franzen tempor YOLO iPhone
+						thundercats. Keytar tilde raw denim shabby chic quinoa typewriter.
+						Shabby chic tousled labore jean shorts, veniam XOXO mustache. Marfa
+						dreamcatcher hammock cupidatat kitsch, selvage cornhole dolor. Odio
+						salvia slow-carb hammock XOXO, nulla normcore jean shorts magna
+						master cleanse tote bag ea. Pitchfork marfa tote bag shoreditch,
+						retro selvage tempor 90's kogi adipisicing asymmetrical tousled.
+						Pork belly asymmetrical nesciunt, keytar jean shorts mlkshk
+						scenester sriracha man bun placeat tacos post-ironic officia art
+						party.
+					</Submarine.Primary>
+				</Submarine>
+			</section>
+		</section>
+	);
 };
-ControlExpand.storyName = 'ControlExpand';
 
 /* Handle Toggle And Resize */
-export const HandleToggleAndResize = () => {
-	const Component = createClass({
-		getInitialState() {
-			return {
-				resizeHeight: null,
-				isExpanded: true,
-			};
-		},
+export const HandleToggleAndResize: Story<ISubmarineProps> = (args) => {
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [resizeHeight, setResizeHeight] = useState(null);
 
-		handleToggle() {
-			this.setState({ isExpanded: !this.state.isExpanded });
-		},
+	const handleToggle = () => {
+		setIsExpanded(!isExpanded);
+	};
 
-		handleResizing(height: any) {
-			this.setState({ resizeHeight: height });
-		},
+	const handleResizing = (height: any) => {
+		setResizeHeight(height);
+	};
 
-		handleResize(height: any) {
-			this.setState({ resizeHeight: height });
-		},
+	const handleResize = (height: any) => {
+		setResizeHeight(height);
+	};
 
-		render() {
-			return (
-				<section>
-					<p>isExpanded: {`${this.state.isExpanded}`}</p>
-					<p>resizeHeight: {`${this.state.resizeHeight}`}</p>
+	return (
+		<section>
+			<p>isExpanded: {`${isExpanded}`}</p>
+			<p>resizeHeight: {`${resizeHeight}`}</p>
 
-					<section
-						style={{
-							height: 300,
-							background: 'lightgray',
-							outline: '1px solid lightgray',
-						}}
-					>
-						<Submarine
-							onResizing={this.handleResizing}
-							onResize={this.handleResize}
-							onToggle={this.handleToggle}
-						>
-							<Submarine.Bar>
-								Non cliche minim normcore ullamco, iPhone etsy banh mi
-								farm-to-table mumblecore stumptown asymmetrical wolf pour-over
-								odio.
-							</Submarine.Bar>
-							<Submarine.Primary>
-								You probably haven't heard of them fingerstache art party
-								messenger bag, 3 wolf moon cold-pressed helvetica nesciunt id
-								anim. Leggings labore dolor, cliche letterpress normcore banh mi
-								aliquip ramps crucifix DIY. Occupy est DIY delectus kitsch, raw
-								denim marfa literally poutine. Anim viral chia, keffiyeh ramps
-								gastropub +1 wolf fixie austin church-key. Hammock placeat tote
-								bag craft beer. Offal plaid PBR&B, art party lo-fi ea poutine
-								kitsch ad. Duis flannel semiotics church-key YOLO.
-							</Submarine.Primary>
-						</Submarine>
-					</section>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+			<section
+				style={{
+					height: 300,
+					background: 'lightgray',
+					outline: '1px solid lightgray',
+				}}
+			>
+				<Submarine
+					{...args}
+					onResizing={handleResizing}
+					onResize={handleResize}
+					onToggle={handleToggle}
+				>
+					<Submarine.Bar>
+						Non cliche minim normcore ullamco, iPhone etsy banh mi farm-to-table
+						mumblecore stumptown asymmetrical wolf pour-over odio.
+					</Submarine.Bar>
+					<Submarine.Primary>
+						You probably haven't heard of them fingerstache art party messenger
+						bag, 3 wolf moon cold-pressed helvetica nesciunt id anim. Leggings
+						labore dolor, cliche letterpress normcore banh mi aliquip ramps
+						crucifix DIY. Occupy est DIY delectus kitsch, raw denim marfa
+						literally poutine. Anim viral chia, keffiyeh ramps gastropub +1 wolf
+						fixie austin church-key. Hammock placeat tote bag craft beer. Offal
+						plaid PBR&B, art party lo-fi ea poutine kitsch ad. Duis flannel
+						semiotics church-key YOLO.
+					</Submarine.Primary>
+				</Submarine>
+			</section>
+		</section>
+	);
 };
-HandleToggleAndResize.storyName = 'HandleToggleAndResize';
 
 /* Nested Submarines */
-export const NestedSubmarines = () => {
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						height: 600,
-						background: 'lightgray',
-						outline: '1px solid lightgray',
-					}}
-				>
-					<Submarine position='top'>
+export const NestedSubmarines: Story<ISubmarineProps> = (args) => {
+	return (
+		<section
+			style={{
+				height: 600,
+				background: 'lightgray',
+				outline: '1px solid lightgray',
+			}}
+		>
+			<Submarine {...args} position='top'>
+				<Submarine.Bar>
+					Bitters shabby chic tacos, sapiente drinking vinegar readymade
+					gochujang typewriter. Gluten-free cred sartorial pop-up commodo.
+				</Submarine.Bar>
+				<Submarine.Primary>
+					<Submarine position='bottom'>
 						<Submarine.Bar>
-							Bitters shabby chic tacos, sapiente drinking vinegar readymade
-							gochujang typewriter. Gluten-free cred sartorial pop-up commodo.
+							Id mumblecore blue bottle vegan, fingerstache commodo health goth
+							man bun bitters. Ad ennui authentic, offal humblebrag paleo minim
+							vero hammock kickstarter reprehenderit gastropub.
 						</Submarine.Bar>
 						<Submarine.Primary>
-							<Submarine position='bottom'>
-								<Submarine.Bar>
-									Id mumblecore blue bottle vegan, fingerstache commodo health
-									goth man bun bitters. Ad ennui authentic, offal humblebrag
-									paleo minim vero hammock kickstarter reprehenderit gastropub.
-								</Submarine.Bar>
-								<Submarine.Primary>
-									Dreamcatcher jean shorts veniam paleo humblebrag, nihil venmo
-									consequat. Tempor kickstarter fingerstache veniam austin,
-									assumenda lomo eu YOLO small batch 3 wolf moon. Chia offal
-									cliche, thundercats try-hard before they sold out tofu freegan
-									ethical scenester polaroid quis next level jean shorts. Sed
-									hoodie ullamco, XOXO laboris yuccie farm-to-table narwhal jean
-									shorts odio affogato irure. Marfa echo park mixtape pinterest
-									accusamus, ullamco normcore deep v hammock. Odio cronut
-									authentic id sunt, knausgaard YOLO. Roof party mollit
-									kickstarter sustainable sriracha.
-								</Submarine.Primary>
-							</Submarine>
+							Dreamcatcher jean shorts veniam paleo humblebrag, nihil venmo
+							consequat. Tempor kickstarter fingerstache veniam austin,
+							assumenda lomo eu YOLO small batch 3 wolf moon. Chia offal cliche,
+							thundercats try-hard before they sold out tofu freegan ethical
+							scenester polaroid quis next level jean shorts. Sed hoodie
+							ullamco, XOXO laboris yuccie farm-to-table narwhal jean shorts
+							odio affogato irure. Marfa echo park mixtape pinterest accusamus,
+							ullamco normcore deep v hammock. Odio cronut authentic id sunt,
+							knausgaard YOLO. Roof party mollit kickstarter sustainable
+							sriracha.
 						</Submarine.Primary>
 					</Submarine>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+				</Submarine.Primary>
+			</Submarine>
+		</section>
+	);
 };
-NestedSubmarines.storyName = 'NestedSubmarines';

--- a/src/components/Submarine/Submarine.tsx
+++ b/src/components/Submarine/Submarine.tsx
@@ -5,7 +5,6 @@ import { lucidClassNames } from '../../util/style-helpers';
 import {
 	filterTypes,
 	findTypes,
-	omitProps,
 	StandardProps,
 } from '../../util/component-types';
 import { buildModernHybridComponent } from '../../util/state-management';

--- a/src/components/Submarine/Submarine.tsx
+++ b/src/components/Submarine/Submarine.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
@@ -24,37 +24,33 @@ const cx = lucidClassNames.bind('&-Submarine');
 
 const { any, bool, func, node, number, string, oneOf, oneOfType } = PropTypes;
 
+/** Primary */
 export interface ISubmarinePrimaryProps extends StandardProps {}
-
-export interface ISumbarineTitleProps extends StandardProps {}
-
-export interface ISubmarineBarProps extends StandardProps {
-	Title?: ISumbarineTitleProps | string;
-}
 
 const Primary = (_props: ISubmarinePrimaryProps): null => null;
 Primary.peek = {
-	description: `
-		Primary content rendered beside the Submarine.
-	`,
+	description: `Primary content rendered beside the Submarine.`,
 };
 Primary.displayName = 'SplitHorizontal.Primary';
 Primary.propName = 'Primary';
 
+/** Title */
+export interface ISumbarineTitleProps extends StandardProps {}
+
 const Title = (_props: ISumbarineTitleProps): null => null;
 Title.peek = {
-	description: `
-		Submarine title;
-	`,
+	description: `Submarine title.`,
 };
 Title.displayName = 'Submarine.Title';
 Title.propName = 'Title';
 
+/** Bar */
+export interface ISubmarineBarProps extends StandardProps {
+	Title?: ISumbarineTitleProps | string;
+}
 const Bar = (_props: ISubmarineBarProps): null => null;
 Bar.peek = {
-	description: `
-		Submarine bar;
-	`,
+	description: `Submarine bar.`,
 };
 Bar.displayName = 'Submarine.Bar';
 Bar.propName = 'Bar';
@@ -65,6 +61,7 @@ Bar.propTypes = {
 	Title: any,
 };
 
+/** Submarine */
 const defaultProps = {
 	isExpanded: true,
 	isAnimated: true,
@@ -107,7 +104,7 @@ export interface ISubmarineProps extends StandardProps {
 	/** Set the title of the Submarine. */
 	Primary?: React.ReactNode;
 
-	/** Set the title of the Submarine. */
+	/** Set the content and title of the Submarine Bar. */
 	Bar?: React.ReactNode;
 
 	/** Called when the user is currently resizing the Submarine. */
@@ -205,7 +202,7 @@ class Submarine extends React.Component<ISubmarineProps, ISubmarineState> {
 		Title: any,
 
 		/**
-			Set the submarine bar content.
+			Set the Submarine Bar content.
 		*/
 		Bar: any,
 
@@ -282,11 +279,13 @@ class Submarine extends React.Component<ISubmarineProps, ISubmarineState> {
 			'props',
 			{}
 		); // props from first Primary
+
 		const barProps = _.get(
 			_.first(filterTypes(children, Submarine.Bar)),
 			'props',
 			{}
 		); // props from first Bar
+
 		const titleProps = _.get(
 			findTypes(barProps, Submarine.Title).concat(
 				findTypes(this.props, Submarine.Title)
@@ -309,11 +308,25 @@ class Submarine extends React.Component<ISubmarineProps, ISubmarineState> {
 
 		return (
 			<SplitHorizontal
-				{...omitProps(
+				{...omit(
 					passThroughs,
-					undefined,
-					_.keys(Submarine.propTypes),
-					false
+					[
+						'className',
+						'children',
+						'height',
+						'isExpanded',
+						'isHidden',
+						'isTitleShownCollapsed',
+						'isAnimated',
+						'position',
+						'isResizeDisabled',
+						'Title',
+						'Bar',
+						'Primary',
+						'onResizing',
+						'onResize',
+						'onToggle',
+					].concat('initialState')
 				)}
 				className={cx(
 					'&',
@@ -331,12 +344,7 @@ class Submarine extends React.Component<ISubmarineProps, ISubmarineState> {
 				onResize={this.handleResize}
 			>
 				<BarPane
-					{...omitProps(
-						barProps,
-						undefined,
-						_.keys(Submarine.Bar.propTypes),
-						false
-					)}
+					{...omit(barProps, ['Title'].concat('initialState'))}
 					className={cx('&-Bar', barProps.className)}
 					height={height}
 				>

--- a/src/components/Submarine/__snapshots__/Submarine.spec.tsx.snap
+++ b/src/components/Submarine/__snapshots__/Submarine.spec.tsx.snap
@@ -1,5 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Submarine [common] example testing should match snapshot(s) for Basic 1`] = `
+<section
+  style="height:300px;background:lightgray;outline:1px solid lightgray"
+>
+  <div
+    class="lucid-SplitHorizontal lucid-SplitHorizontal-is-expanded lucid-SplitHorizontal-is-animated lucid-Submarine lucid-Submarine-is-position-bottom"
+    style="flex:1;overflow:hidden"
+  >
+    <div
+      class="lucid-SplitHorizontal-inner"
+      style="height:100%;display:flex;flex-direction:column;transform:translateY(0px)"
+    >
+      <div
+        class="lucid-SplitHorizontal-TopPane lucid-Submarine-Primary"
+        style="flex-grow:1;flex-shrink:1;flex-basis:0%;margin-top:0;overflow:auto"
+      >
+        Twee iPhone intelligentsia, schlitz normcore cold-pressed hella sapiente meh adipisicing sustainable kogi sed. Letterpress plaid aute, brunch chillwave anim mlkshk. Farm-to-table austin post-ironic, man bun gluten-free nesciunt sartorial tacos tousled kickstarter shabby chic migas. Kombucha flannel before they sold out elit voluptate pinterest chambray, odio stumptown street art. Kitsch humblebrag actually, cillum kale chips hashtag shoreditch pariatur waistcoat pop-up consequat leggings try-hard. Marfa crucifix seitan health goth portland. Cliche ennui vero, whatever swag kogi ugh fixie wayfarers before they sold out irure culpa marfa mlkshk bushwick.
+      </div>
+      <div
+        class="lucid-DragCaptureZone lucid-SplitHorizontal-Divider lucid-Submarine-Divider"
+        style="height:6px;box-sizing:border-box"
+      >
+        <svg
+          class="lucid-Icon lucid-Icon-color-primary lucid-GripperHorizontalIcon lucid-Submarine-Divider-gripper"
+          height="2"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 16 2"
+          width="16"
+        >
+          <path
+            d="M.5 0v2M4 0v2M8 0v2M12 0v2M15.5 0v2"
+          />
+        </svg>
+      </div>
+      <div
+        class="lucid-SplitHorizontal-BottomPane lucid-SplitHorizontal-is-secondary lucid-Submarine-Bar"
+        style="flex-grow:0;flex-shrink:0;flex-basis:250px;overflow:auto"
+      >
+        <div
+          class="lucid-Submarine-Bar-overlay"
+        />
+        <div
+          class="lucid-Submarine-Bar-header"
+        >
+          <div
+            class="lucid-Submarine-Bar-Title"
+          />
+          <button
+            class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Submarine-expander"
+            type="button"
+          >
+            <span
+              class="lucid-Button-content"
+            >
+              <svg
+                class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
+                height="16"
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M.5 4.5l7.5 7 7.5-7"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="lucid-Submarine-Bar-content"
+        >
+          Minim 90's paleo retro, fugiat aliqua hashtag enim photo booth listicle next level. Consectetur fap proident magna culpa. Art party meh ad, four loko slow-carb venmo distillery wolf cornhole nisi.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
 exports[`Submarine [common] example testing should match snapshot(s) for ControlExpand 1`] = `
 <section>
   <button>
@@ -210,10 +289,7 @@ exports[`Submarine [common] example testing should match snapshot(s) for CustomT
           <div
             class="lucid-Submarine-Bar-Title"
           >
-            Submarine Title 
-            <button>
-              Edit
-            </button>
+            Submarine Title
           </div>
           <button
             class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Submarine-expander"
@@ -256,85 +332,6 @@ exports[`Submarine [common] example testing should match snapshot(s) for CustomT
             &lt;Submarine.Bar&gt;
           </code>
           .
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-`;
-
-exports[`Submarine [common] example testing should match snapshot(s) for DefaultSubmarine 1`] = `
-<section
-  style="height:300px;background:lightgray;outline:1px solid lightgray"
->
-  <div
-    class="lucid-SplitHorizontal lucid-SplitHorizontal-is-expanded lucid-SplitHorizontal-is-animated lucid-Submarine lucid-Submarine-is-position-bottom"
-    style="flex:1;overflow:hidden"
-  >
-    <div
-      class="lucid-SplitHorizontal-inner"
-      style="height:100%;display:flex;flex-direction:column;transform:translateY(0px)"
-    >
-      <div
-        class="lucid-SplitHorizontal-TopPane lucid-Submarine-Primary"
-        style="flex-grow:1;flex-shrink:1;flex-basis:0%;margin-top:0;overflow:auto"
-      >
-        Twee iPhone intelligentsia, schlitz normcore cold-pressed hella sapiente meh adipisicing sustainable kogi sed. Letterpress plaid aute, brunch chillwave anim mlkshk. Farm-to-table austin post-ironic, man bun gluten-free nesciunt sartorial tacos tousled kickstarter shabby chic migas. Kombucha flannel before they sold out elit voluptate pinterest chambray, odio stumptown street art. Kitsch humblebrag actually, cillum kale chips hashtag shoreditch pariatur waistcoat pop-up consequat leggings try-hard. Marfa crucifix seitan health goth portland. Cliche ennui vero, whatever swag kogi ugh fixie wayfarers before they sold out irure culpa marfa mlkshk bushwick.
-      </div>
-      <div
-        class="lucid-DragCaptureZone lucid-SplitHorizontal-Divider lucid-Submarine-Divider"
-        style="height:6px;box-sizing:border-box"
-      >
-        <svg
-          class="lucid-Icon lucid-Icon-color-primary lucid-GripperHorizontalIcon lucid-Submarine-Divider-gripper"
-          height="2"
-          preserveAspectRatio="xMidYMid meet"
-          viewBox="0 0 16 2"
-          width="16"
-        >
-          <path
-            d="M.5 0v2M4 0v2M8 0v2M12 0v2M15.5 0v2"
-          />
-        </svg>
-      </div>
-      <div
-        class="lucid-SplitHorizontal-BottomPane lucid-SplitHorizontal-is-secondary lucid-Submarine-Bar"
-        style="flex-grow:0;flex-shrink:0;flex-basis:250px;overflow:auto"
-      >
-        <div
-          class="lucid-Submarine-Bar-overlay"
-        />
-        <div
-          class="lucid-Submarine-Bar-header"
-        >
-          <div
-            class="lucid-Submarine-Bar-Title"
-          />
-          <button
-            class="lucid-Button lucid-Button-invisible lucid-Button-has-only-icon lucid-Submarine-expander"
-            type="button"
-          >
-            <span
-              class="lucid-Button-content"
-            >
-              <svg
-                class="lucid-Icon lucid-Icon-color-primary lucid-ChevronIcon lucid-ChevronIcon-is-down"
-                height="16"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width="16"
-              >
-                <path
-                  d="M.5 4.5l7.5 7 7.5-7"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          class="lucid-Submarine-Bar-content"
-        >
-          Minim 90's paleo retro, fugiat aliqua hashtag enim photo booth listicle next level. Consectetur fap proident magna culpa. Art party meh ad, four loko slow-carb venmo distillery wolf cornhole nisi.
         </div>
       </div>
     </div>
@@ -424,7 +421,7 @@ exports[`Submarine [common] example testing should match snapshot(s) for Disable
 exports[`Submarine [common] example testing should match snapshot(s) for HandleToggleAndResize 1`] = `
 <section>
   <p>
-    isExpanded: true
+    isExpanded: false
   </p>
   <p>
     resizeHeight: null

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -90,7 +90,9 @@ export interface ICreateClassComponentClass<P>
 	propName?: string | string[];
 }
 
-// creates a React component
+/**
+ * creates a React component
+ */
 export function createClass<P, S = {}>(
 	spec: ICreateClassComponentSpec<P, S>
 ): ICreateClassComponentClass<P> {
@@ -153,7 +155,9 @@ export function createClass<P, S = {}>(
 	return newClass;
 }
 
-// return all elements matching the specified types
+/**
+ * Return all elements matching the specified types
+ */
 export function filterTypes<P>(
 	children: React.ReactNode,
 	types?: TypesType<P>
@@ -168,7 +172,9 @@ export function filterTypes<P>(
 	) as React.ReactElement[];
 }
 
-// return all elements found in props and children of the specified types
+/**
+ * Return all elements found in props and children of the specified types
+ */
 export function findTypes<P extends { children?: React.ReactNode }>(
 	props: P,
 	types?: TypesType<P>
@@ -230,7 +236,9 @@ export function findTypes<P extends { children?: React.ReactNode }>(
 // 	return elementsFromProps.concat(filterTypes<P2>(props.children, types));
 // }
 
-// return all elements not matching the specified types
+/**
+ * Return all elements not matching the specified types
+ */
 export function rejectTypes<P>(
 	children: React.ReactNode,
 	types: TypesType<P> | Array<TypesType<P>>
@@ -244,7 +252,9 @@ export function rejectTypes<P>(
 	);
 }
 
-// return an array of elements (of the given type) for each of the values
+/**
+ * Return an array of elements (of the given type) for each of the values
+ */
 export function createElements<P>(
 	type: ICreateClassComponentClass<P>,
 	values: Array<React.ReactElement<P> | P> = []
@@ -272,7 +282,9 @@ export function createElements<P>(
 	);
 }
 
-// return the first element found in props and children of the specificed type(s)
+/**
+ * Return the first element found in props and children of the specificed type(s)
+ */
 export function getFirst<P>(
 	props: P,
 	types: TypesType<P> | undefined,


### PR DESCRIPTION
## PR Checklist

Description of changes to `<Submarine />`:

* Upgrade to functional StoryBook Stories with type defs
* Add intelliSense to component-type functions
* Add unit tests for pass throughs
* Replace omitProps with explicit list of props
*Update snapshot

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-2585-Submarine-fix-omitProps/?path=/docs/layout-submarine--basic
<img width="378" alt="Screen Shot 2022-05-12 at 3 23 58 PM" src="https://user-images.githubusercontent.com/19521671/168161728-0a81e2f3-8bb3-462c-96c2-9efa4099470c.png">

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
