### PR TITLE
Cxp 2583 split vertical remove omit props

### DIFF
--- a/src/components/LoadingMessage/LoadingMessage.spec.tsx
+++ b/src/components/LoadingMessage/LoadingMessage.spec.tsx
@@ -168,8 +168,6 @@ describe('LoadingMessage', () => {
 		it('omits the props defined in `propTypes` from the root element, plus, in addition, `initialState`.', () => {
 			const rootProps = wrapper.find('.lucid-LoadingMessage').props();
 
-			console.log('rootProps', rootProps);
-			console.log(wrapper.debug());
 			// initialState and callbackId are always both omitted
 			forEach(
 				['Icon', 'Title', 'Body', 'initialState', 'callbackId'],

--- a/src/components/LoadingMessage/LoadingMessage.spec.tsx
+++ b/src/components/LoadingMessage/LoadingMessage.spec.tsx
@@ -165,7 +165,7 @@ describe('LoadingMessage', () => {
 			expect(wrapper.first().prop(['data-testid'])).toBe(10);
 		});
 
-		it('omits the props defined in `propTypes` from the root element, plus, in addition, `initialState`.', () => {
+		it('omits the props defined in `propTypes` from the root element, plus, in addition, `initialState and callbackId`.', () => {
 			const rootProps = wrapper.find('.lucid-LoadingMessage').props();
 
 			// initialState and callbackId are always both omitted

--- a/src/components/Resizer/Resizer.stories.tsx
+++ b/src/components/Resizer/Resizer.stories.tsx
@@ -31,7 +31,7 @@ export const Basic: Story<IResizerProps> = (args) => {
 /* With Flex */
 export const WithFlex: Story<IResizerProps> = (args) => {
 	return (
-		<div
+		<section
 			style={{
 				display: 'flex',
 			}}
@@ -62,6 +62,6 @@ export const WithFlex: Story<IResizerProps> = (args) => {
 					</div>
 				)}
 			</Resizer>
-		</div>
+		</section>
 	);
 };

--- a/src/components/Resizer/Resizer.tsx
+++ b/src/components/Resizer/Resizer.tsx
@@ -1,8 +1,8 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
-import { omitProps, StandardProps } from '../../util/component-types';
+import { StandardProps } from '../../util/component-types';
 import elementResizeDetectorMaker from 'element-resize-detector';
 
 const cx = lucidClassNames.bind('&-Resizer');
@@ -86,7 +86,10 @@ class Resizer extends React.Component<IResizerProps, IResizerState, {}> {
 
 		return (
 			<div
-				{...omitProps(passThroughs, undefined, _.keys(Resizer.propTypes))}
+				{...omit(
+					passThroughs,
+					['className', 'children'].concat(['initialState', 'callbackId'])
+				)}
 				className={cx('&', className)}
 				ref={this._element}
 			>

--- a/src/components/Resizer/__snapshots__/Resizer.spec.tsx.snap
+++ b/src/components/Resizer/__snapshots__/Resizer.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`Resizer [common] example testing should match snapshot(s) for Basic 1`]
 `;
 
 exports[`Resizer [common] example testing should match snapshot(s) for WithFlex 1`] = `
-<div
+<section
   style="display:flex"
 >
   <div>
@@ -44,5 +44,5 @@ exports[`Resizer [common] example testing should match snapshot(s) for WithFlex 
       </div>
     </div>
   </div>
-</div>
+</section>
 `;

--- a/src/components/SplitVertical/SplitVertical.spec.tsx
+++ b/src/components/SplitVertical/SplitVertical.spec.tsx
@@ -49,13 +49,31 @@ describe('SplitVertical', () => {
 		});
 	});
 
-	describe('props', () => {
+	describe('pass throughs', () => {
 		describe('root pass throughs', () => {
 			let wrapper: any;
 
 			beforeEach(() => {
 				const props = {
 					...SplitVertical.defaultProps,
+					children: [
+						<SplitVertical.RightPane
+							className='test right pane'
+							style={{ marginLeft: 10 }}
+							callbackId={2}
+							data-testid={11}
+							width={234}
+							isPrimary={true}
+						/>,
+						<SplitVertical.LeftPane
+							className='test left pane'
+							style={{ marginLeft: 20 }}
+							callbackId={3}
+							data-testid={12}
+							width={567}
+							isPrimary={false}
+						/>,
+					],
 					collapseShift: 1,
 					isResizeable: false,
 					className: 'wut',
@@ -64,7 +82,7 @@ describe('SplitVertical', () => {
 					callbackId: 1,
 					'data-testid': 10,
 				};
-				wrapper = shallow(<SplitVertical {...props} />);
+				wrapper = mount(<SplitVertical {...props} />);
 			});
 
 			afterEach(() => {
@@ -110,8 +128,181 @@ describe('SplitVertical', () => {
 					}
 				);
 			});
+			it('passes through and omits the correct props for the `SplitVertical.LeftPane`.', () => {
+				const leftPaneProps = wrapper
+					.find('.lucid-SplitVertical-LeftPane')
+					.props();
+
+				// included props
+				forEach(['className', 'style', 'data-testid', 'children'], (prop) => {
+					expect(has(leftPaneProps, prop)).toBe(true);
+				});
+
+				// excluded props
+				forEach(
+					['isPrimary', 'width', 'callbackId', 'initialState'],
+					(prop) => {
+						expect(has(leftPaneProps, prop)).toBe(false);
+					}
+				);
+			});
+			it('passes through and omits the correct props for the `SplitVertical.RightPane`.', () => {
+				const rightPaneProps = wrapper
+					.find('.lucid-SplitVertical-RightPane')
+					.props();
+
+				// included props
+				forEach(['className', 'style', 'data-testid', 'children'], (prop) => {
+					expect(has(rightPaneProps, prop)).toBe(true);
+				});
+
+				// excluded props
+				forEach(
+					['isPrimary', 'width', 'initialState', 'callbackId'],
+					(prop) => {
+						expect(has(rightPaneProps, prop)).toBe(false);
+					}
+				);
+			});
 		});
 
+		describe('DragCaptureZone pass throughs: dividerProps', () => {
+			let wrapper: any;
+
+			beforeEach(() => {
+				const props = {
+					...SplitVertical.defaultProps,
+					children: (
+						<SplitVertical.Divider
+							className='test Divider'
+							style={{ marginLeft: 10 }}
+							callbackId={2}
+							data-testid={11}
+						/>
+					),
+					collapseShift: 1,
+					isResizeable: true, // renders the resizable Divider
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = mount(<SplitVertical {...props} />);
+			});
+
+			afterEach(() => {
+				if (wrapper) {
+					wrapper.unmount();
+				}
+			});
+
+			it('passes through and omits the correct props for the resizable `SplitVerticalDivider` child element.', () => {
+				const dividerProps = wrapper
+					.find('DragCaptureZone.lucid-SplitVertical-Divider')
+					.props();
+
+				expect(
+					wrapper
+						.find('DragCaptureZone.lucid-SplitVertical-Divider')
+						.prop(['className'])
+				).toContain('test Divider');
+				expect(
+					wrapper
+						.find('DragCaptureZone.lucid-SplitVertical-Divider')
+						.prop(['style'])
+				).toMatchObject({
+					marginLeft: 10,
+				});
+				expect(
+					wrapper
+						.find('DragCaptureZone.lucid-SplitVertical-Divider')
+						.prop(['data-testid'])
+				).toBe(11);
+				expect(
+					wrapper
+						.find('DragCaptureZone.lucid-SplitVertical-Divider')
+						.prop(['callbackId'])
+				).toBe(2);
+
+				// callbackId is passed through becuase the divider is a custom React element
+				forEach(
+					['className', 'data-testid', 'style', 'children', 'callbackId'],
+					(prop) => {
+						expect(has(dividerProps, prop)).toBe(true);
+					}
+				);
+
+				// note initial state is explicitly omitted in the code,
+				// and it also is not permitted as a prop on `SplitVertical.Divider`
+				forEach(['initialState'], (prop) => {
+					expect(has(dividerProps, prop)).toBe(false);
+				});
+			});
+		});
+
+		describe('Not resizeable dividerProps', () => {
+			let wrapper: any;
+
+			beforeEach(() => {
+				const props = {
+					...SplitVertical.defaultProps,
+					children: (
+						<SplitVertical.Divider
+							className='test Divider'
+							style={{ marginLeft: 10 }}
+							callbackId={2}
+							data-testid={11}
+						/>
+					),
+					collapseShift: 1,
+					isResizeable: false, // renders the not resizeable Divider
+					className: 'wut',
+					style: { marginRight: 10 },
+					initialState: { test: true },
+					callbackId: 1,
+					'data-testid': 10,
+				};
+				wrapper = mount(<SplitVertical {...props} />);
+			});
+
+			afterEach(() => {
+				if (wrapper) {
+					wrapper.unmount();
+				}
+			});
+
+			it('passes through and omits the correct props for the resizable `SplitVerticalDivider` child element.', () => {
+				const dividerProps = wrapper
+					.find('div.lucid-SplitVertical-Divider')
+					.props();
+
+				expect(
+					wrapper.find('div.lucid-SplitVertical-Divider').prop(['className'])
+				).toContain('test Divider');
+				expect(
+					wrapper.find('div.lucid-SplitVertical-Divider').prop(['style'])
+				).toMatchObject({
+					marginLeft: 10,
+				});
+				expect(
+					wrapper.find('div.lucid-SplitVertical-Divider').prop(['data-testid'])
+				).toBe(11);
+
+				// included props
+				forEach(['className', 'data-testid', 'style', 'children'], (prop) => {
+					expect(has(dividerProps, prop)).toBe(true);
+				});
+
+				// excluded props
+				forEach(['initialState', 'callbackId'], (prop) => {
+					expect(has(dividerProps, prop)).toBe(false);
+				});
+			});
+		});
+	});
+
+	describe('props', () => {
 		describe('isExpanded', () => {
 			let mountWrapper: any;
 

--- a/src/components/SplitVertical/SplitVertical.stories.tsx
+++ b/src/components/SplitVertical/SplitVertical.stories.tsx
@@ -64,7 +64,7 @@ export const AnimatedCollapse: Story<ISplitVerticalProps> = (args) => {
 		<section>
 			<button onClick={handleToggle}>toggle</button>
 
-			<SplitVertical isAnimated isExpanded={isExpanded}>
+			<SplitVertical {...(args as any)} isAnimated isExpanded={isExpanded}>
 				<SplitVertical.LeftPane>
 					<p>
 						Poutine ea ramps cold-pressed, vinyl bespoke sint keffiyeh tumblr

--- a/src/components/SplitVertical/SplitVertical.tsx
+++ b/src/components/SplitVertical/SplitVertical.tsx
@@ -2,11 +2,7 @@ import _, { omit } from 'lodash';
 import React, { RefObject } from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	filterTypes,
-	omitProps,
-	StandardProps,
-} from '../../util/component-types';
+import { filterTypes, StandardProps } from '../../util/component-types';
 import DragCaptureZone from '../DragCaptureZone/DragCaptureZone';
 import { Motion, spring } from 'react-motion';
 import { QUICK_SLIDE_MOTION } from '../../constants/motion-spring';
@@ -15,9 +11,11 @@ const cx = lucidClassNames.bind('&-SplitVertical');
 
 const { any, bool, func, node, number, string, oneOfType } = PropTypes;
 
+/** SplitVertical Right Pane */
 export interface ISplitVerticalRightPaneProps extends StandardProps {
 	/** Set width of this pane. */
 	width?: number | string;
+
 	/** Define this pane as the primary content pane. When the split is
 		collapsed, this pane becomes full width. */
 	isPrimary: boolean;
@@ -35,10 +33,12 @@ SplitVerticalRightPane.propTypes = {
 		Any valid React children.
 	*/
 	children: node,
+
 	/**
 		Set width of this pane.
 	*/
 	width: oneOfType([number, string]),
+
 	/**
 		Define this pane as the primary content pane. When the split is
 		collapsed, this pane becomes full width.
@@ -49,6 +49,7 @@ SplitVerticalRightPane.defaultProps = {
 	isPrimary: false,
 };
 
+/** SplitVertical Left Pane */
 export interface ISplitVerticalLeftPaneProps extends StandardProps {
 	/** Set width of this pane. */
 	width?: number | string;
@@ -56,13 +57,12 @@ export interface ISplitVerticalLeftPaneProps extends StandardProps {
 		collapsed, this pane becomes full width. */
 	isPrimary: boolean;
 }
-const SplitVerticalLeftPane = (_props: ISplitVerticalLeftPaneProps): null =>
-	null;
+export const SplitVerticalLeftPane = (
+	_props: ISplitVerticalLeftPaneProps
+): null => null;
 SplitVerticalLeftPane.displayName = 'SplitVertical.LeftPane';
 SplitVerticalLeftPane.peek = {
-	description: `
-		Left pane of the split.
-	`,
+	description: `Left pane of the split.`,
 };
 SplitVerticalLeftPane.propName = 'LeftPane';
 SplitVerticalLeftPane.propTypes = {
@@ -84,6 +84,7 @@ SplitVerticalLeftPane.defaultProps = {
 	isPrimary: false,
 };
 
+/** SplitVertical Divider */
 const SplitVerticalDivider = (_props: StandardProps): null => null;
 SplitVerticalDivider.displayName = 'SplitVertical.Divider';
 SplitVerticalDivider.peek = {
@@ -97,6 +98,7 @@ SplitVerticalDivider.propTypes = {
 	children: node,
 };
 
+/** SplitVertical */
 export interface ISplitVerticalProps
 	extends StandardProps,
 		React.DetailedHTMLProps<
@@ -165,9 +167,9 @@ class SplitVertical extends React.Component<
 		className: any,
 
 		/**
-			Direct children must be types {Splitvertical.Leftpane,
-			Splitvertical.Divider, Splitvertical.RightPane}.  All content is composed
-			as children of these respective elements.
+			Direct children must be types {SplitVertical.Leftpane,
+			SplitVertical.Divider, SplitVertical.RightPane}.  
+			All content is composed as children of these respective elements.
 		*/
 		children: node,
 
@@ -203,8 +205,20 @@ class SplitVertical extends React.Component<
 		*/
 		collapseShift: number,
 
+		/**
+			Direct child of SplitVertical
+		 */
 		RightPane: node,
+
+		/**
+			Direct child of SplitVertical
+		 */
 		LeftPane: node,
+
+		/**
+		 	Direct child of SplitVertical.
+		 	Rendered when `isResizeable` is true.
+		 */
 		Divider: node,
 	};
 
@@ -538,10 +552,12 @@ class SplitVertical extends React.Component<
 							}}
 						>
 							<div
-								{...omitProps(
+								{...omit(
 									leftPaneProps,
-									undefined,
-									_.keys(SplitVerticalLeftPane.propTypes)
+									['children', 'isPrimary', 'width'].concat([
+										'initialState',
+										'callbackId',
+									])
 								)}
 								className={cx(
 									'&-LeftPane',
@@ -570,12 +586,7 @@ class SplitVertical extends React.Component<
 							</div>
 							{isResizeable ? (
 								<DragCaptureZone
-									{...omitProps(
-										dividerProps,
-										undefined,
-										_.keys(SplitVerticalDivider.propTypes),
-										false
-									)}
+									{...omit(dividerProps, ['children'].concat('initialState'))}
 									className={cx(
 										'&-Divider',
 										'&-Divider-is-resizeable',
@@ -594,10 +605,9 @@ class SplitVertical extends React.Component<
 								</DragCaptureZone>
 							) : (
 								<div
-									{...omitProps(
+									{...omit(
 										dividerProps,
-										undefined,
-										_.keys(SplitVerticalDivider.propTypes)
+										['children'].concat('initialState', 'callbackId')
 									)}
 									className={cx('&-Divider', dividerProps.className)}
 								>
@@ -605,10 +615,12 @@ class SplitVertical extends React.Component<
 								</div>
 							)}
 							<div
-								{...omitProps(
+								{...omit(
 									rightPaneProps,
-									undefined,
-									_.keys(SplitVerticalRightPane.propTypes)
+									['children', 'isPrimary', 'width'].concat([
+										'initialState',
+										'callbackId',
+									])
 								)}
 								className={cx(
 									'&-RightPane',


### PR DESCRIPTION
## PR Checklist

Description of changes for SplitVertical
<img width="1347" alt="Screen Shot 2022-05-13 at 3 56 06 PM" src="https://user-images.githubusercontent.com/19521671/168388533-1ed99e37-3f68-4697-8d7c-9f79f84439d3.png">

* add unit tests for pass throughs
* replace omitProps with explicit list of omitted props
* clean up a few Storybook story syntax problems
* update the snapshot

Link(s) to Storybook on docspot:

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
