### PR TITLE
Cxp 3059 switch labeled omit props

### DIFF
--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -2,11 +2,7 @@ import _, { omit } from 'lodash';
 import React, { createRef } from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	omitProps,
-	StandardProps,
-	Overwrite,
-} from '../../util/component-types';
+import { StandardProps, Overwrite } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-Switch');
 const { bool, func, object, string } = PropTypes;
@@ -109,7 +105,17 @@ export const Switch = (props: ISwitchProps): React.ReactElement => {
 		>
 			<input
 				onChange={_.noop}
-				{...omit(passThroughs, ['initialState', 'callbackId', 'children'])}
+				{...omit(
+					passThroughs,
+					[
+						'className',
+						'isDisabled',
+						'isSelected',
+						'onSelect',
+						'style',
+						'isIncludeExclude',
+					].concat(['initialState', 'callbackId', 'children'])
+				)}
 				checked={isSelected}
 				className={cx('&-native')}
 				disabled={isDisabled}
@@ -130,37 +136,37 @@ Switch.peek = {
 
 Switch.propTypes = {
 	/**
-			Appended to the component-specific class names set on the root element.
-		*/
+		Appended to the component-specific class names set on the root element.
+	*/
 	className: string,
 
 	/**
-			Indicates whether the component should appear and act disabled by having
-			a "greyed out" palette and ignoring user interactions.
-		*/
+		Indicates whether the component should appear and act disabled by having
+		a "greyed out" palette and ignoring user interactions.
+	*/
 	isDisabled: bool,
 
 	/**
-			Indicates that the component is in the "selected" state when true and in
-			the "unselected" state when false.
-		*/
+		Indicates that the component is in the "selected" state when true and in
+		the "unselected" state when false.
+	*/
 	isSelected: bool,
 
 	/**
-			Called when the user clicks on the component or when they press the space
-			key while the component is in focus.  Signature:
-			\`(isSelected, { event, props }) => {}\`
-		*/
+		Called when the user clicks on the component or when they press the space
+		key while the component is in focus.  Signature:
+		\`(isSelected, { event, props }) => {}\`
+	*/
 	onSelect: func,
 
 	/**
-			Passed through to the root element.
-		*/
+		Passed through to the root element.
+	*/
 	style: object,
 
 	/**
-			Offers a red/green styling to the switch.
-		*/
+		Offers a red/green styling to the switch.
+	*/
 	isIncludeExclude: bool,
 };
 

--- a/src/components/SwitchLabeled/SwitchLabeled.spec.tsx
+++ b/src/components/SwitchLabeled/SwitchLabeled.spec.tsx
@@ -1,11 +1,10 @@
-import _ from 'lodash';
+import _, { forEach, has } from 'lodash';
 import assert from 'assert';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 import { mount, shallow } from 'enzyme';
 
 import { common } from '../../util/generic-tests';
-
 import SwitchLabeled from './SwitchLabeled';
 import Switch from '../Switch/Switch';
 
@@ -83,31 +82,71 @@ describe('SwitchLabeled', () => {
 		});
 
 		describe('pass throughs', () => {
-			it('passes through all props not defined in `propTypes` to its `Switch` instance.', () => {
-				const extraProps = {
-					foo: 1,
-					bar: 2,
-					baz: 3,
-					qux: 4,
-					quux: 5,
-				};
+			let wrapper: any;
 
-				const wrapper = shallow(
+			const extraProps = {
+				foo: 1,
+				bar: 2,
+				baz: 3,
+				qux: 4,
+				quux: 5,
+				Label: 'test default',
+				className: 'wut',
+				style: { marginRight: 10 },
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+			};
+
+			beforeEach(() => {
+				wrapper = shallow(
 					<SwitchLabeled
-						className='wut'
 						isDisabled={true}
 						isSelected={true}
-						style={{ fontWeight: 'bold' }}
 						onSelect={_.noop}
 						{...extraProps}
 					/>
 				);
+			});
+
+			afterEach(() => {
+				if (wrapper) {
+					wrapper.unmount();
+				}
+			});
+
+			it('passes through all props not defined in `propTypes` to its `Switch` instance.', () => {
 				const switchProps = wrapper.find(Switch).props();
 
-				// It should pass `foo`, `bar`, `baz`, `qux`, and `quux` through
+				// It should pass `foo`, `bar`, `baz`, `qux`, and `quux`
+				// and `className`, and 'data-testid' through
 				// to the `Switch` instance.
-				_.forEach(['foo', 'bar', 'baz', 'qux', 'quux'], (prop) => {
-					assert(_.has(switchProps, prop));
+				forEach(
+					[
+						'foo',
+						'bar',
+						'baz',
+						'qux',
+						'quux',
+						'isDisabled',
+						'isSelected',
+						'onSelect',
+						'className',
+						'callbackId',
+						'data-testid',
+					],
+					(prop) => {
+						expect(has(switchProps, prop)).toBe(true);
+					}
+				);
+			});
+			it('omits all props defined in `propTypes from its `Switch` instance', () => {
+				const switchProps = wrapper.find(Switch).props();
+
+				// It should omit `Label', 'children', and 'initialState'
+				// from the `Switch` instance.
+				forEach(['Label', 'style', 'initialState'], (prop) => {
+					expect(has(switchProps, prop)).toBe(false);
 				});
 			});
 		});

--- a/src/components/SwitchLabeled/SwitchLabeled.stories.tsx
+++ b/src/components/SwitchLabeled/SwitchLabeled.stories.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Meta, Story } from '@storybook/react';
-import createClass from 'create-react-class';
+
 import SwitchLabeled, { ISwitchLabeledProps } from './SwitchLabeled';
 
 export default {
@@ -14,93 +14,101 @@ export default {
 			},
 		},
 	},
+	args: SwitchLabeled.defaultProps,
 } as Meta;
 
-export const Basic: Story<ISwitchLabeledProps> = (args) => (
-	<SwitchLabeled {...args} Label='Default' />
-);
+export const Basic: Story<ISwitchLabeledProps> = (args) => {
+	const [isSelected, setIsSelected] = useState(false);
 
-/* Interactive Default */
-export const InteractiveDefault: Story<ISwitchLabeledProps> = (args) => {
+	const handleSelected = () => {
+		setIsSelected(!isSelected);
+	};
+
+	return (
+		<SwitchLabeled
+			{...args}
+			Label='Default'
+			onSelect={handleSelected}
+			isSelected={isSelected}
+		/>
+	);
+};
+
+/* Interactive */
+export const Interactive: Story<ISwitchLabeledProps> = (args) => {
 	const style = {
 		marginBottom: '3px',
 	};
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				airplaneMode: false,
-				bluetooth: false,
-				cellularData: false,
-			};
-		},
-
-		handleSelectedAirplaneMode(isSelected: any) {
-			this.setState({
-				airplaneMode: isSelected,
-			});
-		},
-
-		handleSelectedBluetooth(isSelected: any) {
-			this.setState({
-				bluetooth: isSelected,
-			});
-		},
-
-		handleSelectedCellularData(isSelected: any) {
-			this.setState({
-				cellularData: isSelected,
-			});
-		},
-
-		render() {
-			return (
-				<section>
-					<p>
-						<em>
-							(Use the styles on the parent container of{' '}
-							<code>SwitchLabeled</code> components to ensure only the switches
-							and their labels are clickable)
-						</em>
-					</p>
-					<span
-						style={{
-							display: 'inline-flex',
-							flexDirection: 'column',
-							alignItems: 'flex-start',
-						}}
-					>
-						<SwitchLabeled
-							{...args}
-							isSelected={this.state.airplaneMode === true}
-							onSelect={this.handleSelectedAirplaneMode}
-							style={style}
-						>
-							<SwitchLabeled.Label>Airplane Mode</SwitchLabeled.Label>
-						</SwitchLabeled>
-						<SwitchLabeled
-							{...args}
-							isSelected={this.state.bluetooth === true}
-							onSelect={this.handleSelectedBluetooth}
-							style={style}
-						>
-							<SwitchLabeled.Label>Bluetooth</SwitchLabeled.Label>
-						</SwitchLabeled>
-						<SwitchLabeled
-							{...args}
-							isSelected={this.state.cellularData === true}
-							onSelect={this.handleSelectedCellularData}
-							style={style}
-						>
-							<SwitchLabeled.Label>Cellular Data</SwitchLabeled.Label>
-						</SwitchLabeled>
-					</span>
-				</section>
-			);
-		},
+	const [state, setState] = useState({
+		airplaneMode: false,
+		bluetooth: false,
+		cellularData: false,
 	});
 
-	return <Component />;
+	const handleSelectedAirplaneMode = (isSelected: any) => {
+		setState({
+			...state,
+			airplaneMode: isSelected,
+		});
+	};
+
+	const handleSelectedBluetooth = (isSelected: any) => {
+		setState({
+			...state,
+			bluetooth: isSelected,
+		});
+	};
+
+	const handleSelectedCellularData = (isSelected: any) => {
+		setState({
+			...state,
+			cellularData: isSelected,
+		});
+	};
+
+	return (
+		<section>
+			<p>
+				<em>
+					(Use the styles on the parent container of <code>SwitchLabeled</code>{' '}
+					components to ensure only the switches and their labels are clickable)
+				</em>
+			</p>
+			<span
+				style={{
+					display: 'inline-flex',
+					flexDirection: 'column',
+					alignItems: 'flex-start',
+				}}
+			>
+				<SwitchLabeled
+					{...args}
+					isSelected={state.airplaneMode === true}
+					onSelect={handleSelectedAirplaneMode}
+					style={style}
+				>
+					<SwitchLabeled.Label>Airplane Mode</SwitchLabeled.Label>
+				</SwitchLabeled>
+				<SwitchLabeled
+					{...args}
+					isSelected={state.bluetooth === true}
+					onSelect={handleSelectedBluetooth}
+					style={style}
+				>
+					<SwitchLabeled.Label>Bluetooth</SwitchLabeled.Label>
+				</SwitchLabeled>
+				<SwitchLabeled
+					{...args}
+					isSelected={state.cellularData === true}
+					onSelect={handleSelectedCellularData}
+					style={style}
+				>
+					<SwitchLabeled.Label>Cellular Data</SwitchLabeled.Label>
+				</SwitchLabeled>
+			</span>
+		</section>
+	);
 };
 
 /* Interactive With Changing Labels */
@@ -111,97 +119,91 @@ export const InteractiveWithChangingLabels: Story<ISwitchLabeledProps> = (
 		marginBottom: '3px',
 	};
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				airplaneMode: true,
-				bluetooth: true,
-				cellularData: true,
-				spam: true,
-			};
-		},
-
-		handleSelectedAirplaneMode(isSelected: any) {
-			this.setState({
-				airplaneMode: isSelected,
-			});
-		},
-
-		handleSelectedBluetooth(isSelected: any) {
-			this.setState({
-				bluetooth: isSelected,
-			});
-		},
-
-		handleSelectedCellularData(isSelected: any) {
-			this.setState({
-				cellularData: isSelected,
-			});
-		},
-
-		handleSelectedSpam(isSelected: any) {
-			this.setState({
-				spam: isSelected,
-			});
-		},
-
-		render() {
-			const spamSwitchLabel = this.state.spam
-				? 'Yes! I would like to receive updates, special offers, and other information from Xandr and its subsidiaries.'
-				: 'No! Please keep your wicked, dirty spam all to yourselves!';
-
-			return (
-				<section>
-					<span
-						style={{
-							display: 'inline-flex',
-							flexDirection: 'column',
-							alignItems: 'flex-start',
-						}}
-					>
-						<SwitchLabeled
-							{...args}
-							isSelected={this.state.airplaneMode === true}
-							Label={`Airplane Mode ${
-								this.state.airplaneMode === true ? 'Activated' : 'Deactivated'
-							}`}
-							onSelect={this.handleSelectedAirplaneMode}
-							style={style}
-						/>
-						<SwitchLabeled
-							{...args}
-							isSelected={this.state.bluetooth === true}
-							Label={`Bluetooth ${
-								this.state.bluetooth === true ? 'Enabled' : 'Disabled'
-							}`}
-							onSelect={this.handleSelectedBluetooth}
-							style={style}
-						/>
-						<SwitchLabeled
-							{...args}
-							isSelected={this.state.cellularData === true}
-							Label={`${
-								this.state.cellularData ? 'Use' : 'Do Not Use'
-							} Cellular Data`}
-							onSelect={this.handleSelectedCellularData}
-							style={style}
-						/>
-					</span>
-					<br />
-					<SwitchLabeled
-						{...args}
-						isSelected={this.state.spam === true}
-						onSelect={this.handleSelectedSpam}
-						style={style}
-					>
-						<SwitchLabeled.Label>{spamSwitchLabel}</SwitchLabeled.Label>
-					</SwitchLabeled>
-				</section>
-			);
-		},
+	const [state, setState] = useState({
+		airplaneMode: false,
+		bluetooth: false,
+		cellularData: false,
+		spam: false,
 	});
 
-	return <Component />;
+	const handleSelectedAirplaneMode = (isSelected: any) => {
+		setState({
+			...state,
+			airplaneMode: isSelected,
+		});
+	};
+
+	const handleSelectedBluetooth = (isSelected: any) => {
+		setState({
+			...state,
+			bluetooth: isSelected,
+		});
+	};
+
+	const handleSelectedCellularData = (isSelected: any) => {
+		setState({
+			...state,
+			cellularData: isSelected,
+		});
+	};
+
+	const handleSelectedSpam = (isSelected: any) => {
+		setState({
+			...state,
+			spam: isSelected,
+		});
+	};
+
+	const spamSwitchLabel = state.spam
+		? 'Yes! I would like to receive updates, special offers, and other information from Xandr and its subsidiaries.'
+		: 'No! Please keep your messages to yourself!';
+
+	return (
+		<section>
+			<span
+				style={{
+					display: 'inline-flex',
+					flexDirection: 'column',
+					alignItems: 'flex-start',
+				}}
+			>
+				<SwitchLabeled
+					{...args}
+					isSelected={state.airplaneMode === true}
+					Label={`Airplane Mode ${
+						state.airplaneMode === true ? 'Activated' : 'Deactivated'
+					}`}
+					onSelect={handleSelectedAirplaneMode}
+					style={style}
+				/>
+				<SwitchLabeled
+					{...args}
+					isSelected={state.bluetooth === true}
+					Label={`Bluetooth ${
+						state.bluetooth === true ? 'Enabled' : 'Disabled'
+					}`}
+					onSelect={handleSelectedBluetooth}
+					style={style}
+				/>
+				<SwitchLabeled
+					{...args}
+					isSelected={state.cellularData === true}
+					Label={`${state.cellularData ? 'Use' : 'Do Not Use'} Cellular Data`}
+					onSelect={handleSelectedCellularData}
+					style={style}
+				/>
+			</span>
+			<br />
+			<SwitchLabeled
+				{...args}
+				isSelected={state.spam === true}
+				onSelect={handleSelectedSpam}
+				style={style}
+			>
+				<SwitchLabeled.Label>{spamSwitchLabel}</SwitchLabeled.Label>
+			</SwitchLabeled>
+		</section>
+	);
 };
 
 /* Label As Prop */
@@ -210,50 +212,44 @@ export const LabelAsProp: Story<ISwitchLabeledProps> = (args) => {
 		marginRight: '5px',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<section>
-					<section
-						style={{
-							display: 'inline-flex',
-							flexDirection: 'column',
-							alignItems: 'flex-start',
-						}}
-					>
-						<SwitchLabeled {...args} Label='Just text' style={style} />
-						<SwitchLabeled
-							{...args}
-							Label={<span>HTML element</span>}
-							style={style}
-						/>
-						<SwitchLabeled
-							{...args}
-							Label={[
-								'Text in an array',
-								'Only the first value in the array is used',
-								'The rest of these should be ignored',
-							]}
-							style={style}
-						/>
-						<SwitchLabeled
-							{...args}
-							Label={[
-								<span key='1'>HTML element in an array</span>,
-								<span key='2'>
-									Again only the first value in the array is used
-								</span>,
-								<span key='3'>The rest should not be rendered</span>,
-							]}
-							style={style}
-						/>
-					</section>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<section>
+			<section
+				style={{
+					display: 'inline-flex',
+					flexDirection: 'column',
+					alignItems: 'flex-start',
+				}}
+			>
+				<SwitchLabeled {...args} Label='Just text' style={style} />
+				<SwitchLabeled
+					{...args}
+					Label={<span>HTML element</span>}
+					style={style}
+				/>
+				<SwitchLabeled
+					{...args}
+					Label={[
+						'Text in an array',
+						'Only the first value in the array is used',
+						'The rest of these should be ignored',
+					]}
+					style={style}
+				/>
+				<SwitchLabeled
+					{...args}
+					Label={[
+						<span key='1'>HTML element in an array</span>,
+						<span key='2'>
+							Again only the first value in the array is used
+						</span>,
+						<span key='3'>The rest should not be rendered</span>,
+					]}
+					style={style}
+				/>
+			</section>
+		</section>
+	);
 };
 
 /* States */
@@ -263,40 +259,34 @@ export const States: Story<ISwitchLabeledProps> = (args) => {
 		marginRight: '13px',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<section
-					style={{
-						display: 'inline-flex',
-						flexDirection: 'column',
-						alignItems: 'flex-start',
-					}}
+	return (
+		<section
+			style={{
+				display: 'inline-flex',
+				flexDirection: 'column',
+				alignItems: 'flex-start',
+			}}
+		>
+			<SwitchLabeled {...args} style={style}>
+				<SwitchLabeled.Label>(default props)</SwitchLabeled.Label>
+			</SwitchLabeled>
+
+			<section>
+				<SwitchLabeled {...args} isSelected={true} style={style}>
+					<SwitchLabeled.Label>Selected</SwitchLabeled.Label>
+				</SwitchLabeled>
+				<SwitchLabeled {...args} isDisabled={true} style={style}>
+					<SwitchLabeled.Label>Disabled</SwitchLabeled.Label>
+				</SwitchLabeled>
+				<SwitchLabeled
+					{...args}
+					isDisabled={true}
+					isSelected={true}
+					style={style}
 				>
-					<SwitchLabeled {...args} style={style}>
-						<SwitchLabeled.Label>(default props)</SwitchLabeled.Label>
-					</SwitchLabeled>
-
-					<section>
-						<SwitchLabeled {...args} isSelected={true} style={style}>
-							<SwitchLabeled.Label>Selected</SwitchLabeled.Label>
-						</SwitchLabeled>
-						<SwitchLabeled {...args} isDisabled={true} style={style}>
-							<SwitchLabeled.Label>Disabled</SwitchLabeled.Label>
-						</SwitchLabeled>
-						<SwitchLabeled
-							{...args}
-							isDisabled={true}
-							isSelected={true}
-							style={style}
-						>
-							<SwitchLabeled.Label>Disabled & selected</SwitchLabeled.Label>
-						</SwitchLabeled>
-					</section>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+					<SwitchLabeled.Label>Disabled & selected</SwitchLabeled.Label>
+				</SwitchLabeled>
+			</section>
+		</section>
+	);
 };

--- a/src/components/SwitchLabeled/SwitchLabeled.tsx
+++ b/src/components/SwitchLabeled/SwitchLabeled.tsx
@@ -1,9 +1,10 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
+
 import { lucidClassNames } from '../../util/style-helpers';
-import { getFirst, omitProps, StandardProps } from '../../util/component-types';
+import { getFirst, StandardProps } from '../../util/component-types';
 import Switch from '../Switch/Switch';
 import { useState } from 'react';
 import { useEffect } from 'react';
@@ -70,11 +71,17 @@ const SwitchLabeled = (props: ISwitchLabeledProps) => {
 				isDisabled={isDisabled}
 				isSelected={isSelected}
 				onSelect={onSelect}
-				{...omitProps(
+				{...omit(
 					passThroughs,
-					undefined,
-					_.keys(SwitchLabeled.propTypes),
-					false
+					[
+						'className',
+						'style',
+						'Label',
+						'isDisabled',
+						'isSelected',
+						'onSelect',
+						'isIncludeExclude',
+					].concat('initialState')
 				)}
 			/>
 			{labelChildProps && (
@@ -112,9 +119,7 @@ const Label = () => {
 Label.displayName = 'SwitchLabeled.Label';
 
 Label.peek = {
-	description: `
-		Label to be shown alongside the switch.
-	`,
+	description: `Label to be shown alongside the \`Switch\`.`,
 };
 
 Label.propName = 'Label';

--- a/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.tsx.snap
+++ b/src/components/SwitchLabeled/__snapshots__/SwitchLabeled.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for Bas
 </label>
 `;
 
-exports[`SwitchLabeled [common] example testing should match snapshot(s) for InteractiveDefault 1`] = `
+exports[`SwitchLabeled [common] example testing should match snapshot(s) for Interactive 1`] = `
 <section>
   <p>
     <em>
@@ -126,14 +126,13 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for Int
     style="display:inline-flex;flex-direction:column;align-items:flex-start"
   >
     <label
-      class="lucid-SwitchLabeled lucid-SwitchLabeled-is-selected"
+      class="lucid-SwitchLabeled"
       style="margin-bottom:3px"
     >
       <span
-        class="lucid-Switch lucid-Switch-is-selected"
+        class="lucid-Switch"
       >
         <input
-          checked=""
           class="lucid-Switch-native"
           type="checkbox"
         />
@@ -148,18 +147,17 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for Int
         class="lucid-SwitchLabeled-text"
         style="position:relative"
       >
-        Airplane Mode Activated
+        Airplane Mode Deactivated
       </span>
     </label>
     <label
-      class="lucid-SwitchLabeled lucid-SwitchLabeled-is-selected"
+      class="lucid-SwitchLabeled"
       style="margin-bottom:3px"
     >
       <span
-        class="lucid-Switch lucid-Switch-is-selected"
+        class="lucid-Switch"
       >
         <input
-          checked=""
           class="lucid-Switch-native"
           type="checkbox"
         />
@@ -174,18 +172,17 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for Int
         class="lucid-SwitchLabeled-text"
         style="position:relative"
       >
-        Bluetooth Enabled
+        Bluetooth Disabled
       </span>
     </label>
     <label
-      class="lucid-SwitchLabeled lucid-SwitchLabeled-is-selected"
+      class="lucid-SwitchLabeled"
       style="margin-bottom:3px"
     >
       <span
-        class="lucid-Switch lucid-Switch-is-selected"
+        class="lucid-Switch"
       >
         <input
-          checked=""
           class="lucid-Switch-native"
           type="checkbox"
         />
@@ -200,20 +197,19 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for Int
         class="lucid-SwitchLabeled-text"
         style="position:relative"
       >
-        Use Cellular Data
+        Do Not Use Cellular Data
       </span>
     </label>
   </span>
   <br />
   <label
-    class="lucid-SwitchLabeled lucid-SwitchLabeled-is-selected"
+    class="lucid-SwitchLabeled"
     style="margin-bottom:3px"
   >
     <span
-      class="lucid-Switch lucid-Switch-is-selected"
+      class="lucid-Switch"
     >
       <input
-        checked=""
         class="lucid-Switch-native"
         type="checkbox"
       />
@@ -228,7 +224,7 @@ exports[`SwitchLabeled [common] example testing should match snapshot(s) for Int
       class="lucid-SwitchLabeled-text"
       style="position:relative"
     >
-      Yes! I would like to receive updates, special offers, and other information from Xandr and its subsidiaries.
+      No! Please keep your messages to yourself!
     </span>
   </label>
 </section>


### PR DESCRIPTION
## PR Checklist

Description of changes to SwitchLabeled:
* Convert stories to SB6 functional stories
* Add unit tests for pass throughs
* Remove omitProps method that uses propType
* Update snapshots

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-3059-SwitchLabeled-omit-props/?path=/docs/controls-switchlabeled--basic
<img width="1399" alt="Screen Shot 2022-05-16 at 4 27 42 PM" src="https://user-images.githubusercontent.com/19521671/168685556-3f72d9d7-38f3-46c6-b3cb-840142e1abeb.png">

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
![Uploading Screen Shot 2022-05-16 at 4.27.42 PM.png…]()
