### PR TITLE
Cxp 3057 searchable multi select omit props

### DIFF
--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.spec.tsx
@@ -1,6 +1,7 @@
-import * as _ from 'lodash';
+import _, { forEach, has } from 'lodash';
 import React from 'react';
 import { shallow } from 'enzyme';
+
 import { common } from '../../util/generic-tests';
 import { SearchableMultiSelectDumb as SearchableMultiSelect } from './SearchableMultiSelect';
 import { DropMenuDumb as DropMenu } from '../DropMenu/DropMenu';
@@ -381,6 +382,78 @@ describe('SearchableMultiSelect', () => {
 					</SearchableMultiSelect>
 				)
 			).toMatchSnapshot();
+		});
+	});
+
+	describe('pass throughs', () => {
+		let wrapper: any;
+
+		beforeEach(() => {
+			const props = {
+				className: 'wut',
+				style: { marginRight: 10 },
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+			};
+
+			wrapper = shallow(<SearchableMultiSelect {...props} />);
+		});
+
+		afterEach(() => {
+			wrapper.unmount();
+		});
+
+		it('passes through props not defined in `propTypes` to the root element.', () => {
+			const rootProps = wrapper.find('.lucid-SearchableMultiSelect').props();
+
+			expect(wrapper.first().prop(['className'])).toContain('wut');
+			expect(wrapper.first().prop(['style'])).toMatchObject({
+				marginRight: 10,
+			});
+			expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+			// Note: 'className' is plucked from the pass through object
+			// but still appears becuase it is also directly passed to the root element as a prop.
+			forEach(['className', 'style', 'data-testid', 'children'], (prop) => {
+				expect(has(rootProps, prop)).toBe(true);
+			});
+		});
+		it('omits the props defined in `propTypes` from the root element, plus, in addition, `initialState` and `callbackId`.', () => {
+			const rootProps = wrapper.find('.lucid-SearchableMultiSelect').props();
+
+			// initialState and callbackId are always both omitted
+			forEach(
+				[
+					'isDisabled',
+					'isLoading',
+					'maxMenuHeight',
+					'onSearch',
+					'onSelect',
+					'onRemoveAll',
+					'optionFilter',
+					'searchText',
+					'selectedIndices',
+					'DropMenu',
+					'Option',
+					'responsiveMode',
+					'hasRemoveAll',
+					'hasSelections',
+					'hasSelectAll',
+					'selectAllText',
+					'Error',
+					'FixedOption',
+					'NullOption',
+					'OptionGroup',
+					'SearchField',
+					'Label',
+					'initialState',
+					'callbackId',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
 		});
 	});
 });

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.stories.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import createClass from 'create-react-class';
 import _, { map } from 'lodash';
 import { Meta, Story } from '@storybook/react';
@@ -30,6 +30,7 @@ export default {
 			},
 		},
 	},
+	args: SearchableMultiSelect.defaultProps,
 } as Meta;
 
 //👇 Destructure any child components that we will need
@@ -42,20 +43,7 @@ function addKeys(children: any) {
 
 /* Basic */
 export const Basic: Story<ISearchableMultiSelectProps> = (args) => {
-	return (
-		<Resizer>
-			{(width) => {
-				const responsiveMode = width >= 400 ? 'large' : 'small';
-
-				return (
-					<SearchableMultiSelect
-						{...args}
-						responsiveMode={responsiveMode}
-					></SearchableMultiSelect>
-				);
-			}}
-		</Resizer>
-	);
+	return <SearchableMultiSelect {...args}></SearchableMultiSelect>;
 };
 Basic.args = {
 	children: addKeys([
@@ -325,87 +313,81 @@ Asynchronous.args = {
 export const GroupedOptions: Story<ISearchableMultiSelectProps> = (args) => {
 	const { Option, OptionGroup } = SearchableMultiSelect;
 
-	const Component = createClass({
-		render() {
-			return (
-				<SearchableMultiSelect
-					{...args}
-					hasSelectAll
-					initialState={{
-						selectedIndices: [0, 1, 2, 3, 11, 12, 48, 49],
-					}}
-				>
-					<OptionGroup>
-						Northeast
-						<Option>Connecticut</Option>
-						<Option>Delaware</Option>
-						<Option>Maine</Option>
-						<Option>Maryland</Option>
-						<Option>Massachusetts</Option>
-						<Option>New Hampshire</Option>
-						<Option>New Jersey</Option>
-						<Option>New York</Option>
-						<Option>Pennsylvania</Option>
-						<Option>Rhode Island</Option>
-						<Option>Vermont</Option>
-					</OptionGroup>
-					<OptionGroup>
-						Southeast
-						<Option>Alabama</Option>
-						<Option>Arkansas</Option>
-						<Option>Florida</Option>
-						<Option>Georgia</Option>
-						<Option>Kentucky</Option>
-						<Option>Louisiana</Option>
-						<Option>Mississippi</Option>
-						<Option>North Carolina</Option>
-						<Option>South Carolina</Option>
-						<Option>Tennessee</Option>
-						<Option>Virginia</Option>
-						<Option>West Virginia</Option>
-					</OptionGroup>
-					<OptionGroup>
-						Midwest
-						<Option>Illinois</Option>
-						<Option>Indiana</Option>
-						<Option>Iowa</Option>
-						<Option>Kansas</Option>
-						<Option>Michigan</Option>
-						<Option>Minnesota</Option>
-						<Option>Missouri</Option>
-						<Option>Nebraska</Option>
-						<Option>North Dakota</Option>
-						<Option>Ohio</Option>
-						<Option>South Dakota</Option>
-						<Option>Wisconsin</Option>
-					</OptionGroup>
-					<OptionGroup>
-						Southwest
-						<Option>Arizona</Option>
-						<Option>New Mexico</Option>
-						<Option>Oklahoma</Option>
-						<Option>Texas</Option>
-					</OptionGroup>
-					<OptionGroup>
-						West
-						<Option>California</Option>
-						<Option>Colorado</Option>
-						<Option>Idaho</Option>
-						<Option>Montana</Option>
-						<Option>Nevada</Option>
-						<Option>Oregon</Option>
-						<Option>Utah</Option>
-						<Option>Washington</Option>
-						<Option>Wyoming</Option>
-					</OptionGroup>
-					<Option>Alaska</Option>
-					<Option>Hawaii</Option>
-				</SearchableMultiSelect>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<SearchableMultiSelect
+			{...args}
+			hasSelectAll
+			initialState={{
+				selectedIndices: [0, 1, 2, 3, 11, 12, 48, 49],
+			}}
+		>
+			<OptionGroup>
+				Northeast
+				<Option>Connecticut</Option>
+				<Option>Delaware</Option>
+				<Option>Maine</Option>
+				<Option>Maryland</Option>
+				<Option>Massachusetts</Option>
+				<Option>New Hampshire</Option>
+				<Option>New Jersey</Option>
+				<Option>New York</Option>
+				<Option>Pennsylvania</Option>
+				<Option>Rhode Island</Option>
+				<Option>Vermont</Option>
+			</OptionGroup>
+			<OptionGroup>
+				Southeast
+				<Option>Alabama</Option>
+				<Option>Arkansas</Option>
+				<Option>Florida</Option>
+				<Option>Georgia</Option>
+				<Option>Kentucky</Option>
+				<Option>Louisiana</Option>
+				<Option>Mississippi</Option>
+				<Option>North Carolina</Option>
+				<Option>South Carolina</Option>
+				<Option>Tennessee</Option>
+				<Option>Virginia</Option>
+				<Option>West Virginia</Option>
+			</OptionGroup>
+			<OptionGroup>
+				Midwest
+				<Option>Illinois</Option>
+				<Option>Indiana</Option>
+				<Option>Iowa</Option>
+				<Option>Kansas</Option>
+				<Option>Michigan</Option>
+				<Option>Minnesota</Option>
+				<Option>Missouri</Option>
+				<Option>Nebraska</Option>
+				<Option>North Dakota</Option>
+				<Option>Ohio</Option>
+				<Option>South Dakota</Option>
+				<Option>Wisconsin</Option>
+			</OptionGroup>
+			<OptionGroup>
+				Southwest
+				<Option>Arizona</Option>
+				<Option>New Mexico</Option>
+				<Option>Oklahoma</Option>
+				<Option>Texas</Option>
+			</OptionGroup>
+			<OptionGroup>
+				West
+				<Option>California</Option>
+				<Option>Colorado</Option>
+				<Option>Idaho</Option>
+				<Option>Montana</Option>
+				<Option>Nevada</Option>
+				<Option>Oregon</Option>
+				<Option>Utah</Option>
+				<Option>Washington</Option>
+				<Option>Wyoming</Option>
+			</OptionGroup>
+			<Option>Alaska</Option>
+			<Option>Hawaii</Option>
+		</SearchableMultiSelect>
+	);
 };
 
 /* Custom Selection Label */
@@ -414,144 +396,132 @@ export const CustomSelectionLabel: Story<ISearchableMultiSelectProps> = (
 ) => {
 	const { Option, SelectionLabel } = SearchableMultiSelect;
 
-	const Component = createClass({
-		render() {
-			return (
-				<SearchableMultiSelect {...args}>
-					<SelectionLabel>Selected States</SelectionLabel>
-					<Option>Alabama</Option>
-					<Option>Alaska</Option>
-					<Option>Arizona</Option>
-					<Option>Arkansas</Option>
-					<Option>California</Option>
-					<Option>Colorado</Option>
-					<Option>Connecticut</Option>
-					<Option>Delaware</Option>
-					<Option>Florida</Option>
-					<Option>Georgia</Option>
-					<Option>Hawaii</Option>
-					<Option>Idaho</Option>
-					<Option>Illinois</Option>
-					<Option>Indiana</Option>
-					<Option>Iowa</Option>
-					<Option>Kansas</Option>
-					<Option>Kentucky</Option>
-					<Option>Louisiana</Option>
-					<Option>Maine</Option>
-					<Option>Maryland</Option>
-					<Option>Massachusetts</Option>
-					<Option>Michigan</Option>
-					<Option>Minnesota</Option>
-					<Option>Mississippi</Option>
-					<Option>Missouri</Option>
-					<Option>Montana Nebraska</Option>
-					<Option>Nevada</Option>
-					<Option>New Hampshire</Option>
-					<Option>New Jersey</Option>
-					<Option>New Mexico</Option>
-					<Option>New York</Option>
-					<Option>North Carolina</Option>
-					<Option>North Dakota</Option>
-					<Option>Ohio</Option>
-					<Option>Oklahoma</Option>
-					<Option>Oregon</Option>
-					<Option>Pennsylvania Rhode Island</Option>
-					<Option>South Carolina</Option>
-					<Option>South Dakota</Option>
-					<Option>Tennessee</Option>
-					<Option>Texas</Option>
-					<Option>Utah</Option>
-					<Option>Vermont</Option>
-					<Option>Virginia</Option>
-					<Option>Washington</Option>
-					<Option>West Virginia</Option>
-					<Option>Wisconsin</Option>
-					<Option>Wyoming</Option>
-				</SearchableMultiSelect>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<SearchableMultiSelect {...args}>
+			<SelectionLabel>Selected States</SelectionLabel>
+			<Option>Alabama</Option>
+			<Option>Alaska</Option>
+			<Option>Arizona</Option>
+			<Option>Arkansas</Option>
+			<Option>California</Option>
+			<Option>Colorado</Option>
+			<Option>Connecticut</Option>
+			<Option>Delaware</Option>
+			<Option>Florida</Option>
+			<Option>Georgia</Option>
+			<Option>Hawaii</Option>
+			<Option>Idaho</Option>
+			<Option>Illinois</Option>
+			<Option>Indiana</Option>
+			<Option>Iowa</Option>
+			<Option>Kansas</Option>
+			<Option>Kentucky</Option>
+			<Option>Louisiana</Option>
+			<Option>Maine</Option>
+			<Option>Maryland</Option>
+			<Option>Massachusetts</Option>
+			<Option>Michigan</Option>
+			<Option>Minnesota</Option>
+			<Option>Mississippi</Option>
+			<Option>Missouri</Option>
+			<Option>Montana Nebraska</Option>
+			<Option>Nevada</Option>
+			<Option>New Hampshire</Option>
+			<Option>New Jersey</Option>
+			<Option>New Mexico</Option>
+			<Option>New York</Option>
+			<Option>North Carolina</Option>
+			<Option>North Dakota</Option>
+			<Option>Ohio</Option>
+			<Option>Oklahoma</Option>
+			<Option>Oregon</Option>
+			<Option>Pennsylvania Rhode Island</Option>
+			<Option>South Carolina</Option>
+			<Option>South Dakota</Option>
+			<Option>Tennessee</Option>
+			<Option>Texas</Option>
+			<Option>Utah</Option>
+			<Option>Vermont</Option>
+			<Option>Virginia</Option>
+			<Option>Washington</Option>
+			<Option>West Virginia</Option>
+			<Option>Wisconsin</Option>
+			<Option>Wyoming</Option>
+		</SearchableMultiSelect>
+	);
 };
 
 /* Select All */
 export const SelectAll: Story<ISearchableMultiSelectProps> = (args) => {
 	const { Option } = SearchableMultiSelect;
 
-	const Component = createClass({
-		render() {
-			return (
-				<section style={{ marginBottom: '300px' }}>
-					<Resizer>
-						{(width) => {
-							const responsiveMode = width >= 768 ? 'large' : 'small';
+	return (
+		<section style={{ marginBottom: '300px' }}>
+			<Resizer>
+				{(width) => {
+					const responsiveMode = width >= 768 ? 'large' : 'small';
 
-							return (
-								<SearchableMultiSelect
-									{...args}
-									hasSelectAll
-									selectAllText='Custom Select All Text'
-									responsiveMode={responsiveMode}
-								>
-									<Option>Alabama</Option>
-									<Option>Alaska</Option>
-									<Option>Arizona</Option>
-									<Option>Arkansas</Option>
-									<Option>California</Option>
-									<Option>Colorado</Option>
-									<Option>Connecticut</Option>
-									<Option>Delaware</Option>
-									<Option>Florida</Option>
-									<Option>Georgia</Option>
-									<Option>Hawaii</Option>
-									<Option>Idaho</Option>
-									<Option>Illinois</Option>
-									<Option>Indiana</Option>
-									<Option>Iowa</Option>
-									<Option>Kansas</Option>
-									<Option>Kentucky</Option>
-									<Option>Louisiana</Option>
-									<Option>Maine</Option>
-									<Option>Maryland</Option>
-									<Option>Massachusetts</Option>
-									<Option>Michigan</Option>
-									<Option>Minnesota</Option>
-									<Option>Mississippi</Option>
-									<Option>Missouri</Option>
-									<Option>Montana Nebraska</Option>
-									<Option>Nevada</Option>
-									<Option>New Hampshire</Option>
-									<Option>New Jersey</Option>
-									<Option>New Mexico</Option>
-									<Option>New York</Option>
-									<Option>North Carolina</Option>
-									<Option>North Dakota</Option>
-									<Option>Ohio</Option>
-									<Option>Oklahoma</Option>
-									<Option>Oregon</Option>
-									<Option>Pennsylvania Rhode Island</Option>
-									<Option>South Carolina</Option>
-									<Option>South Dakota</Option>
-									<Option>Tennessee</Option>
-									<Option>Texas</Option>
-									<Option>Utah</Option>
-									<Option>Vermont</Option>
-									<Option>Virginia</Option>
-									<Option>Washington</Option>
-									<Option>West Virginia</Option>
-									<Option>Wisconsin</Option>
-									<Option>Wyoming</Option>
-								</SearchableMultiSelect>
-							);
-						}}
-					</Resizer>
-				</section>
-			);
-		},
-	});
-
-	return <Component />;
+					return (
+						<SearchableMultiSelect
+							{...args}
+							hasSelectAll
+							selectAllText='Custom Select All Text'
+							responsiveMode={responsiveMode}
+						>
+							<Option>Alabama</Option>
+							<Option>Alaska</Option>
+							<Option>Arizona</Option>
+							<Option>Arkansas</Option>
+							<Option>California</Option>
+							<Option>Colorado</Option>
+							<Option>Connecticut</Option>
+							<Option>Delaware</Option>
+							<Option>Florida</Option>
+							<Option>Georgia</Option>
+							<Option>Hawaii</Option>
+							<Option>Idaho</Option>
+							<Option>Illinois</Option>
+							<Option>Indiana</Option>
+							<Option>Iowa</Option>
+							<Option>Kansas</Option>
+							<Option>Kentucky</Option>
+							<Option>Louisiana</Option>
+							<Option>Maine</Option>
+							<Option>Maryland</Option>
+							<Option>Massachusetts</Option>
+							<Option>Michigan</Option>
+							<Option>Minnesota</Option>
+							<Option>Mississippi</Option>
+							<Option>Missouri</Option>
+							<Option>Montana Nebraska</Option>
+							<Option>Nevada</Option>
+							<Option>New Hampshire</Option>
+							<Option>New Jersey</Option>
+							<Option>New Mexico</Option>
+							<Option>New York</Option>
+							<Option>North Carolina</Option>
+							<Option>North Dakota</Option>
+							<Option>Ohio</Option>
+							<Option>Oklahoma</Option>
+							<Option>Oregon</Option>
+							<Option>Pennsylvania Rhode Island</Option>
+							<Option>South Carolina</Option>
+							<Option>South Dakota</Option>
+							<Option>Tennessee</Option>
+							<Option>Texas</Option>
+							<Option>Utah</Option>
+							<Option>Vermont</Option>
+							<Option>Virginia</Option>
+							<Option>Washington</Option>
+							<Option>West Virginia</Option>
+							<Option>Wisconsin</Option>
+							<Option>Wyoming</Option>
+						</SearchableMultiSelect>
+					);
+				}}
+			</Resizer>
+		</section>
+	);
 };
 
 /* Formatted Options */
@@ -597,47 +567,33 @@ export const FormattedOptions: Story<ISearchableMultiSelectProps> = (args) => {
 		return true;
 	};
 
-	class Component extends React.Component {
-		render() {
-			return (
-				<SearchableMultiSelect {...args} optionFilter={optionFilter}>
-					<SearchableMultiSelect.OptionGroup Selected=''>
-						<div style={{ marginLeft: 27 }}>
-							<OptionCols col1='ID' col2='NAME' />
-						</div>
+	return (
+		<SearchableMultiSelect {...args} optionFilter={optionFilter}>
+			<SearchableMultiSelect.OptionGroup Selected=''>
+				<div style={{ marginLeft: 27 }}>
+					<OptionCols col1='ID' col2='NAME' />
+				</div>
 
-						<SearchableMultiSelect.Option
-							filterText='Foo'
-							Selected='Foo (1234)'
-						>
-							{({ searchText }: { searchText: string }) => (
-								<OptionCols col1='1234' col2='Foo' textMatch={searchText} />
-							)}
-						</SearchableMultiSelect.Option>
+				<SearchableMultiSelect.Option filterText='Foo' Selected='Foo (1234)'>
+					{({ searchText }: { searchText: string }) => (
+						<OptionCols col1='1234' col2='Foo' textMatch={searchText} />
+					)}
+				</SearchableMultiSelect.Option>
 
-						<SearchableMultiSelect.Option
-							filterText='Bar'
-							Selected='Bar (2345)'
-						>
-							{({ searchText }: { searchText: string }) => (
-								<OptionCols col1='2345' col2='Bar' textMatch={searchText} />
-							)}
-						</SearchableMultiSelect.Option>
+				<SearchableMultiSelect.Option filterText='Bar' Selected='Bar (2345)'>
+					{({ searchText }: { searchText: string }) => (
+						<OptionCols col1='2345' col2='Bar' textMatch={searchText} />
+					)}
+				</SearchableMultiSelect.Option>
 
-						<SearchableMultiSelect.Option
-							filterText='Baz'
-							Selected='Baz (3456)'
-						>
-							{({ searchText }: { searchText: string }) => (
-								<OptionCols col1='3456' col2='Baz' textMatch={searchText} />
-							)}
-						</SearchableMultiSelect.Option>
-					</SearchableMultiSelect.OptionGroup>
-				</SearchableMultiSelect>
-			);
-		}
-	}
-	return <Component />;
+				<SearchableMultiSelect.Option filterText='Baz' Selected='Baz (3456)'>
+					{({ searchText }: { searchText: string }) => (
+						<OptionCols col1='3456' col2='Baz' textMatch={searchText} />
+					)}
+				</SearchableMultiSelect.Option>
+			</SearchableMultiSelect.OptionGroup>
+		</SearchableMultiSelect>
+	);
 };
 FormattedOptions.args = {
 	...Basic.args,
@@ -647,101 +603,77 @@ FormattedOptions.args = {
 export const Invalid: Story<ISearchableMultiSelectProps> = (args) => {
 	const { Option } = SearchableMultiSelect;
 
-	const Component = createClass({
-		getInitialState() {
-			return {
-				selectedLength: 0,
-			};
-		},
-		handleChange(option: string, event: any) {
-			let count = this.state.selectedLength;
-			if (typeof event.props.children === 'string') {
-				count--;
-			} else {
-				event.props.children.props.isSelected ? count-- : count++;
-			}
-			this.setState({
-				selectedLength: count,
-			});
-		},
-		handleRemoveAll(option: string, event: any) {
-			this.setState({
-				selectedLength: 0,
-			});
-		},
-		render() {
-			return (
-				<Resizer>
-					{(width) => {
-						const responsiveMode = width >= 400 ? 'large' : 'small';
+	const [selectedLength, setSelectedLength] = useState(0);
 
-						return (
-							<SearchableMultiSelect
-								{...args}
-								responsiveMode={responsiveMode}
-								onRemoveAll={this.handleRemoveAll}
-								onSelect={this.handleChange}
-								Error={
-									this.state.selectedLength > 1
-										? null
-										: 'Please select at least two options'
-								}
-							>
-								<Option>Alabama</Option>
-								<Option>Alaska</Option>
-								<Option>Arizona</Option>
-								<Option>Arkansas</Option>
-								<Option>California</Option>
-								<Option>Colorado</Option>
-								<Option>Connecticut</Option>
-								<Option>Delaware</Option>
-								<Option>Florida</Option>
-								<Option>Georgia</Option>
-								<Option>Hawaii</Option>
-								<Option>Idaho</Option>
-								<Option>Illinois</Option>
-								<Option>Indiana</Option>
-								<Option>Iowa</Option>
-								<Option>Kansas</Option>
-								<Option>Kentucky</Option>
-								<Option>Louisiana</Option>
-								<Option>Maine</Option>
-								<Option>Maryland</Option>
-								<Option>Massachusetts</Option>
-								<Option>Michigan</Option>
-								<Option>Minnesota</Option>
-								<Option>Mississippi</Option>
-								<Option>Missouri</Option>
-								<Option>Montana Nebraska</Option>
-								<Option>Nevada</Option>
-								<Option>New Hampshire</Option>
-								<Option>New Jersey</Option>
-								<Option>New Mexico</Option>
-								<Option>New York</Option>
-								<Option>North Carolina</Option>
-								<Option>North Dakota</Option>
-								<Option>Ohio</Option>
-								<Option>Oklahoma</Option>
-								<Option>Oregon</Option>
-								<Option>Pennsylvania Rhode Island</Option>
-								<Option>South Carolina</Option>
-								<Option>South Dakota</Option>
-								<Option>Tennessee</Option>
-								<Option>Texas</Option>
-								<Option>Utah</Option>
-								<Option>Vermont</Option>
-								<Option>Virginia</Option>
-								<Option>Washington</Option>
-								<Option>West Virginia</Option>
-								<Option>Wisconsin</Option>
-								<Option>Wyoming</Option>
-							</SearchableMultiSelect>
-						);
-					}}
-				</Resizer>
-			);
-		},
-	});
+	const handleChange = (option: string, event: any) => {
+		let count = selectedLength;
+		if (typeof event.props.children === 'string') {
+			count--;
+		} else {
+			event.props.children.props.isSelected ? count-- : count++;
+		}
+		setSelectedLength(count);
+	};
 
-	return <Component />;
+	const handleRemoveAll = (option: string, event: any) => {
+		setSelectedLength(0);
+	};
+
+	return (
+		<SearchableMultiSelect
+			{...(args as any)}
+			onRemoveAll={handleRemoveAll}
+			onSelect={handleChange}
+			Error={selectedLength > 1 ? null : 'Please select at least two options'}
+		>
+			<Option>Alabama</Option>
+			<Option>Alaska</Option>
+			<Option>Arizona</Option>
+			<Option>Arkansas</Option>
+			<Option>California</Option>
+			<Option>Colorado</Option>
+			<Option>Connecticut</Option>
+			<Option>Delaware</Option>
+			<Option>Florida</Option>
+			<Option>Georgia</Option>
+			<Option>Hawaii</Option>
+			<Option>Idaho</Option>
+			<Option>Illinois</Option>
+			<Option>Indiana</Option>
+			<Option>Iowa</Option>
+			<Option>Kansas</Option>
+			<Option>Kentucky</Option>
+			<Option>Louisiana</Option>
+			<Option>Maine</Option>
+			<Option>Maryland</Option>
+			<Option>Massachusetts</Option>
+			<Option>Michigan</Option>
+			<Option>Minnesota</Option>
+			<Option>Mississippi</Option>
+			<Option>Missouri</Option>
+			<Option>Montana Nebraska</Option>
+			<Option>Nevada</Option>
+			<Option>New Hampshire</Option>
+			<Option>New Jersey</Option>
+			<Option>New Mexico</Option>
+			<Option>New York</Option>
+			<Option>North Carolina</Option>
+			<Option>North Dakota</Option>
+			<Option>Ohio</Option>
+			<Option>Oklahoma</Option>
+			<Option>Oregon</Option>
+			<Option>Pennsylvania Rhode Island</Option>
+			<Option>South Carolina</Option>
+			<Option>South Dakota</Option>
+			<Option>Tennessee</Option>
+			<Option>Texas</Option>
+			<Option>Utah</Option>
+			<Option>Vermont</Option>
+			<Option>Virginia</Option>
+			<Option>Washington</Option>
+			<Option>West Virginia</Option>
+			<Option>Wisconsin</Option>
+			<Option>Wyoming</Option>
+		</SearchableMultiSelect>
+	);
 };

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -142,8 +142,8 @@ Option.propTypes = {
 Option.defaultProps = DropMenu.Option.defaultProps;
 
 /** SearchableMultiSelect */
-/** TODO: Remove this constant when the component is converted to a functional component */
-const nonPassThroughs = [
+/** TODO: Remove these prop constants when the component is converted to a functional component */
+const propTypes = [
 	'children',
 	'className',
 	'isDisabled',
@@ -168,9 +168,8 @@ const nonPassThroughs = [
 	'OptionGroup',
 	'SearchField',
 	'Label',
-	'initialState',
-	'callbackId',
 ];
+const nonPassThroughs = propTypes.concat(['initialState', 'callbackId']);
 
 export type Size = 'large' | 'medium' | 'small';
 
@@ -974,7 +973,6 @@ class SearchableMultiSelect extends React.Component<
 				errorChildProps.children &&
 				errorChildProps.children !== true ? (
 					<div
-						// {...omitProps(errorChildProps, undefined)}
 						{...omit(errorChildProps, ['initialState', 'callbackId'])}
 						className={cx('&-error-content')}
 					>

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
@@ -7,7 +7,6 @@ import { buildModernHybridComponent } from '../../util/state-management';
 import { partitionText, propsSearch } from '../../util/text-manipulation';
 import {
 	StandardProps,
-	omitProps,
 	getFirst,
 	findTypes,
 	rejectTypes,
@@ -780,7 +779,7 @@ class SearchableMultiSelect extends React.Component<
 
 		return (
 			<div
-				{...(_.omit(passThroughs, nonPassThroughs) as any)}
+				{...(omit(passThroughs, nonPassThroughs) as any)}
 				className={cx('&', className)}
 			>
 				<DropMenu
@@ -975,7 +974,8 @@ class SearchableMultiSelect extends React.Component<
 				errorChildProps.children &&
 				errorChildProps.children !== true ? (
 					<div
-						{...omitProps(errorChildProps, undefined)}
+						// {...omitProps(errorChildProps, undefined)}
+						{...omit(errorChildProps, ['initialState', 'callbackId'])}
 						className={cx('&-error-content')}
 					>
 						{errorChildProps.children}

--- a/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.tsx.snap
+++ b/src/components/SearchableMultiSelect/__snapshots__/SearchableMultiSelect.spec.tsx.snap
@@ -57,56 +57,52 @@ exports[`SearchableMultiSelect [common] example testing should match snapshot(s)
 
 exports[`SearchableMultiSelect [common] example testing should match snapshot(s) for Basic 1`] = `
 <div
-  class="lucid-Resizer"
+  class="lucid-SearchableMultiSelect"
+  default=""
 >
   <div
-    class="lucid-SearchableMultiSelect"
-    default=""
+    class="lucid-DropMenu lucid-DropMenu-base lucid-SearchableMultiSelect-DropMenu"
   >
-    <div
-      class="lucid-DropMenu lucid-DropMenu-base lucid-SearchableMultiSelect-DropMenu lucid-SearchableMultiSelect-DropMenu-is-small"
+    <span
+      class="lucid-ContextMenu"
     >
-      <span
-        class="lucid-ContextMenu"
+      <div
+        class="lucid-DropMenu-Control"
+        tabindex="0"
       >
         <div
-          class="lucid-DropMenu-Control"
-          tabindex="0"
+          class="lucid-SearchField lucid-SearchableMultiSelect-search"
         >
+          <input
+            autocomplete="off"
+            class="lucid-TextField lucid-TextField-is-single-line"
+            rows="5"
+            type="text"
+            value=""
+          />
           <div
-            class="lucid-SearchField lucid-SearchableMultiSelect-search lucid-SearchableMultiSelect-search-is-small"
+            class="lucid-SearchField-Icon-container"
           >
-            <input
-              autocomplete="off"
-              class="lucid-TextField lucid-TextField-is-single-line"
-              rows="5"
-              type="text"
-              value=""
-            />
-            <div
-              class="lucid-SearchField-Icon-container"
+            <svg
+              class="lucid-Icon lucid-Icon-color-primary lucid-SearchIcon lucid-SearchField-Icon"
+              height="12"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width="12"
             >
-              <svg
-                class="lucid-Icon lucid-Icon-color-primary lucid-SearchIcon lucid-SearchField-Icon"
-                height="12"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width="12"
-              >
-                <circle
-                  cx="6"
-                  cy="6"
-                  r="5.5"
-                />
-                <path
-                  d="M15.5 15.5L9.876 9.876"
-                />
-              </svg>
-            </div>
+              <circle
+                cx="6"
+                cy="6"
+                r="5.5"
+              />
+              <path
+                d="M15.5 15.5L9.876 9.876"
+              />
+            </svg>
           </div>
         </div>
-      </span>
-    </div>
+      </div>
+    </span>
   </div>
 </div>
 `;
@@ -595,61 +591,57 @@ exports[`SearchableMultiSelect [common] example testing should match snapshot(s)
 
 exports[`SearchableMultiSelect [common] example testing should match snapshot(s) for Invalid 1`] = `
 <div
-  class="lucid-Resizer"
+  class="lucid-SearchableMultiSelect"
+  default=""
 >
   <div
-    class="lucid-SearchableMultiSelect"
-    default=""
+    class="lucid-DropMenu lucid-DropMenu-base lucid-SearchableMultiSelect-DropMenu"
   >
-    <div
-      class="lucid-DropMenu lucid-DropMenu-base lucid-SearchableMultiSelect-DropMenu lucid-SearchableMultiSelect-DropMenu-is-small"
+    <span
+      class="lucid-ContextMenu"
     >
-      <span
-        class="lucid-ContextMenu"
+      <div
+        class="lucid-DropMenu-Control"
+        tabindex="0"
       >
         <div
-          class="lucid-DropMenu-Control"
-          tabindex="0"
+          class="lucid-SearchField lucid-SearchableMultiSelect-search lucid-SearchableMultiSelect-search-is-error"
         >
+          <input
+            autocomplete="off"
+            class="lucid-TextField lucid-TextField-is-single-line"
+            rows="5"
+            type="text"
+            value=""
+          />
           <div
-            class="lucid-SearchField lucid-SearchableMultiSelect-search lucid-SearchableMultiSelect-search-is-small lucid-SearchableMultiSelect-search-is-error"
+            class="lucid-SearchField-Icon-container"
           >
-            <input
-              autocomplete="off"
-              class="lucid-TextField lucid-TextField-is-single-line"
-              rows="5"
-              type="text"
-              value=""
-            />
-            <div
-              class="lucid-SearchField-Icon-container"
+            <svg
+              class="lucid-Icon lucid-Icon-color-primary lucid-SearchIcon lucid-SearchField-Icon"
+              height="12"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width="12"
             >
-              <svg
-                class="lucid-Icon lucid-Icon-color-primary lucid-SearchIcon lucid-SearchField-Icon"
-                height="12"
-                preserveAspectRatio="xMidYMid meet"
-                viewBox="0 0 16 16"
-                width="12"
-              >
-                <circle
-                  cx="6"
-                  cy="6"
-                  r="5.5"
-                />
-                <path
-                  d="M15.5 15.5L9.876 9.876"
-                />
-              </svg>
-            </div>
+              <circle
+                cx="6"
+                cy="6"
+                r="5.5"
+              />
+              <path
+                d="M15.5 15.5L9.876 9.876"
+              />
+            </svg>
           </div>
         </div>
-      </span>
-    </div>
-    <div
-      class="lucid-SearchableMultiSelect-error-content"
-    >
-      Please select at least two options
-    </div>
+      </div>
+    </span>
+  </div>
+  <div
+    class="lucid-SearchableMultiSelect-error-content"
+  >
+    Please select at least two options
   </div>
 </div>
 `;


### PR DESCRIPTION
## PR Checklist

Description of changes to SearchableMultiSelect:
* Update Stories to SB6 functional stories
* Add unit test for pass throughs
* Remove omitProps method
* Update snapshot

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-3057-SearchableMultiSelect-omitProps/?path=/docs/controls-searchablemultiselect--basic
<img width="1606" alt="Screen Shot 2022-05-17 at 5 25 59 PM" src="https://user-images.githubusercontent.com/19521671/168922349-a13f5a14-565d-48ef-b353-44192336e16c.png">

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
