### PR TITLE
Cxp 3056 icon select replace omit props

### DIFF
--- a/src/components/IconSelect/IconSelect.spec.tsx
+++ b/src/components/IconSelect/IconSelect.spec.tsx
@@ -1,3 +1,4 @@
+import _, { forEach, has, noop } from 'lodash';
 import React from 'react';
 import assert from 'assert';
 import { shallow, mount } from 'enzyme';
@@ -87,6 +88,59 @@ describe('IconSelect', () => {
 			wrapper.find('figure[data-id="one"]').simulate('click');
 
 			expect(onIconSelectMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('pass throughs', () => {
+		let wrapper: any;
+		const defaultProps = IconSelect.defaultProps;
+
+		beforeEach(() => {
+			const props = {
+				...defaultProps,
+				items,
+				kind: 'multiple' as any,
+				onSelect: noop,
+				isDisabled: true,
+				style: { marginRight: 10 },
+				initialState: { test: true },
+				callbackId: 1,
+				'data-testid': 10,
+			};
+			wrapper = shallow(<IconSelect {...props} />);
+		});
+
+		afterEach(() => {
+			if (wrapper) {
+				wrapper.unmount();
+			}
+		});
+
+		it('passes through select props to the root element.', () => {
+			const rootProps = wrapper.find('.lucid-IconSelect').props();
+
+			// 'className' is plucked from the pass through object
+			// but still appears becuase it is also directly placed on the root element as a prop
+			forEach(['className', 'style', 'children', 'data-testid'], (prop) => {
+				expect(has(rootProps, prop)).toBe(true);
+			});
+		});
+		it("omits the component props, and, in addition, 'initialState' and 'callbackId' from the root element", () => {
+			const rootProps = wrapper.find('.lucid-IconSelect').props();
+
+			forEach(
+				[
+					'items',
+					'kind',
+					'onSelect',
+					'isDisabled',
+					'initialState',
+					'callbackId',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
 		});
 	});
 });

--- a/src/components/IconSelect/IconSelect.stories.tsx
+++ b/src/components/IconSelect/IconSelect.stories.tsx
@@ -20,7 +20,7 @@ export default {
 	args: IconSelect.defaultProps,
 } as Meta;
 
-export const Basic: Story<IIconSelectProps> = (args) => {
+export const BasicIconSelect: Story<IIconSelectProps> = (args) => {
 	const [selectedIcon, setSelectedIcon] = useState<string>('item2');
 
 	const handleSelect = (id: string) => {
@@ -29,28 +29,26 @@ export const Basic: Story<IIconSelectProps> = (args) => {
 	};
 
 	return (
-		<section>
-			<IconSelect
-				{...args}
-				onSelect={handleSelect}
-				items={
-					[
-						{
-							id: 'item1',
-							icon: <ClockIcon />,
-							isSelected: selectedIcon === 'item1',
-							label: 'Foo Bar',
-						},
-						{
-							id: 'item2',
-							icon: <StopwatchIcon />,
-							isSelected: selectedIcon === 'item2',
-							label: 'Bax Tar',
-						},
-					] as any
-				}
-			/>
-		</section>
+		<IconSelect
+			{...args}
+			onSelect={handleSelect}
+			items={
+				[
+					{
+						id: 'item1',
+						icon: <ClockIcon />,
+						isSelected: selectedIcon === 'item1',
+						label: 'Foo Bar',
+					},
+					{
+						id: 'item2',
+						icon: <StopwatchIcon />,
+						isSelected: selectedIcon === 'item2',
+						label: 'Bax Tar',
+					},
+				] as any
+			}
+		/>
 	);
 };
 
@@ -64,29 +62,27 @@ export const Single: Story<IIconSelectProps> = (args) => {
 	};
 
 	return (
-		<section>
-			<IconSelect
-				{...args}
-				onSelect={handleSelect}
-				kind='single'
-				items={
-					[
-						{
-							id: 'item1',
-							icon: <ClockIcon />,
-							isSelected: selectedIcon === 'item1',
-							label: 'Foo Bar',
-						},
-						{
-							id: 'item2',
-							icon: <StopwatchIcon />,
-							isSelected: selectedIcon === 'item2',
-							label: 'Bax Tar',
-						},
-					] as any
-				}
-			/>
-		</section>
+		<IconSelect
+			{...args}
+			onSelect={handleSelect}
+			kind='single'
+			items={
+				[
+					{
+						id: 'item1',
+						icon: <ClockIcon />,
+						isSelected: selectedIcon === 'item1',
+						label: 'Foo Bar',
+					},
+					{
+						id: 'item2',
+						icon: <StopwatchIcon />,
+						isSelected: selectedIcon === 'item2',
+						label: 'Bax Tar',
+					},
+				] as any
+			}
+		/>
 	);
 };
 
@@ -109,29 +105,27 @@ export const SelectMultipleIcons: Story<IIconSelectProps> = (args) => {
 	};
 
 	return (
-		<section>
-			<IconSelect
-				{...args}
-				onSelect={handleSelect}
-				kind='multiple'
-				items={
-					[
-						{
-							id: 'item1',
-							icon: <ClockIcon />,
-							isSelected: isSelected('item1'),
-							label: 'Foo Bar',
-						},
-						{
-							id: 'item2',
-							icon: <StopwatchIcon />,
-							isSelected: isSelected('item2'),
-							label: 'Bax Tar',
-						},
-					] as any
-				}
-			/>
-		</section>
+		<IconSelect
+			{...args}
+			onSelect={handleSelect}
+			kind='multiple'
+			items={
+				[
+					{
+						id: 'item1',
+						icon: <ClockIcon />,
+						isSelected: isSelected('item1'),
+						label: 'Foo Bar',
+					},
+					{
+						id: 'item2',
+						icon: <StopwatchIcon />,
+						isSelected: isSelected('item2'),
+						label: 'Bax Tar',
+					},
+				] as any
+			}
+		/>
 	);
 };
 

--- a/src/components/IconSelect/IconSelect.tsx
+++ b/src/components/IconSelect/IconSelect.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -6,11 +6,7 @@ import Icon from '../Icon/Icon';
 import RadioButtonLabeled from '../RadioButtonLabeled/RadioButtonLabeled';
 import CheckboxLabeled from '../CheckboxLabeled/CheckboxLabeled';
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	StandardProps,
-	omitProps,
-	Overwrite,
-} from '../../util/component-types';
+import { StandardProps, Overwrite } from '../../util/component-types';
 
 const cx = lucidClassNames.bind('&-IconSelect');
 
@@ -147,10 +143,17 @@ export const IconSelect = (props: IIconSelectProps): React.ReactElement => {
 
 	return (
 		<span
-			{...omitProps(passThroughs, undefined, [
-				..._.keys(IconSelect.propTypes),
-				'items',
-			])}
+			{...omit(
+				passThroughs,
+				[
+					'className',
+					'children',
+					'items',
+					'kind',
+					'onSelect',
+					'isDisabled',
+				].concat(['initialState', 'callbackId'])
+			)}
 			className={cx('&', className)}
 		>
 			{_.map(items, (childItem, index): React.ReactElement => {

--- a/src/components/IconSelect/__snapshots__/IconSelect.spec.tsx.snap
+++ b/src/components/IconSelect/__snapshots__/IconSelect.spec.tsx.snap
@@ -1,130 +1,128 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IconSelect [common] example testing should match snapshot(s) for Basic 1`] = `
-<section>
-  <span
-    class="lucid-IconSelect"
+exports[`IconSelect [common] example testing should match snapshot(s) for BasicIconSelect 1`] = `
+<span
+  class="lucid-IconSelect"
+>
+  <figure
+    class="lucid-IconSelect-Item lucid-IconSelect-Item-multi"
+    data-id="item1"
   >
-    <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-multi"
-      data-id="item1"
+    <svg
+      class="lucid-Icon lucid-Icon-color-primary lucid-ClockIcon"
+      height="16"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox="0 0 16 16"
+      width="16"
     >
-      <svg
-        class="lucid-Icon lucid-Icon-color-primary lucid-ClockIcon"
-        height="16"
-        preserveAspectRatio="xMidYMid meet"
-        viewBox="0 0 16 16"
-        width="16"
-      >
-        <circle
-          cx="8"
-          cy="8"
-          r="7.5"
-        />
-        <path
-          d="M8 3.5v5l2.75 2.25"
-        />
-      </svg>
-      <figcaption
-        class="lucid-IconSelect-Item-figcaption"
-      >
-        <label
-          class="lucid-CheckboxLabeled lucid-IconSelect-Item-checkbox"
-        >
-          <div
-            class="lucid-Checkbox lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-          <div
-            class="lucid-CheckboxLabeled-label"
-          >
-            Foo Bar
-          </div>
-        </label>
-      </figcaption>
-    </figure>
-    <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-multi"
-      data-id="item2"
+      <circle
+        cx="8"
+        cy="8"
+        r="7.5"
+      />
+      <path
+        d="M8 3.5v5l2.75 2.25"
+      />
+    </svg>
+    <figcaption
+      class="lucid-IconSelect-Item-figcaption"
     >
-      <svg
-        class="lucid-Icon lucid-Icon-color-primary lucid-StopwatchIcon"
-        height="16"
-        preserveAspectRatio="xMidYMid meet"
-        viewBox="0 0 16 16"
-        width="16"
+      <label
+        class="lucid-CheckboxLabeled lucid-IconSelect-Item-checkbox"
       >
-        <path
-          d="M7.5.5h3M9 .5v1.98M.5 6h5m-5 3h3m-3 3h4"
-        />
-        <path
-          d="M5.5 14.471A6.455 6.455 0 0 0 9 15.5a6.5 6.5 0 1 0 0-13c-1.29 0-2.489.38-3.5 1.029"
-        />
-        <path
-          d="M9 9l2.5-2.5"
-        />
-      </svg>
-      <figcaption
-        class="lucid-IconSelect-Item-figcaption"
-      >
-        <label
-          class="lucid-CheckboxLabeled lucid-CheckboxLabeled-is-selected lucid-IconSelect-Item-checkbox"
+        <div
+          class="lucid-Checkbox lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
         >
-          <div
-            class="lucid-Checkbox lucid-Checkbox-is-selected lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
+          <input
+            class="lucid-Checkbox-native"
+            type="checkbox"
+          />
+          <span
+            class="lucid-Checkbox-visualization-glow"
+          />
+          <span
+            class="lucid-Checkbox-visualization-container"
+          />
+          <span
+            class="lucid-Checkbox-visualization-checkmark"
           >
-            <input
-              checked=""
-              class="lucid-Checkbox-native"
-              type="checkbox"
+            <span
+              class="lucid-Checkbox-visualization-checkmark-stem"
             />
             <span
-              class="lucid-Checkbox-visualization-glow"
+              class="lucid-Checkbox-visualization-checkmark-kick"
             />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-          <div
-            class="lucid-CheckboxLabeled-label"
+          </span>
+        </div>
+        <div
+          class="lucid-CheckboxLabeled-label"
+        >
+          Foo Bar
+        </div>
+      </label>
+    </figcaption>
+  </figure>
+  <figure
+    class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-multi"
+    data-id="item2"
+  >
+    <svg
+      class="lucid-Icon lucid-Icon-color-primary lucid-StopwatchIcon"
+      height="16"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M7.5.5h3M9 .5v1.98M.5 6h5m-5 3h3m-3 3h4"
+      />
+      <path
+        d="M5.5 14.471A6.455 6.455 0 0 0 9 15.5a6.5 6.5 0 1 0 0-13c-1.29 0-2.489.38-3.5 1.029"
+      />
+      <path
+        d="M9 9l2.5-2.5"
+      />
+    </svg>
+    <figcaption
+      class="lucid-IconSelect-Item-figcaption"
+    >
+      <label
+        class="lucid-CheckboxLabeled lucid-CheckboxLabeled-is-selected lucid-IconSelect-Item-checkbox"
+      >
+        <div
+          class="lucid-Checkbox lucid-Checkbox-is-selected lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
+        >
+          <input
+            checked=""
+            class="lucid-Checkbox-native"
+            type="checkbox"
+          />
+          <span
+            class="lucid-Checkbox-visualization-glow"
+          />
+          <span
+            class="lucid-Checkbox-visualization-container"
+          />
+          <span
+            class="lucid-Checkbox-visualization-checkmark"
           >
-            Bax Tar
-          </div>
-        </label>
-      </figcaption>
-    </figure>
-  </span>
-</section>
+            <span
+              class="lucid-Checkbox-visualization-checkmark-stem"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark-kick"
+            />
+          </span>
+        </div>
+        <div
+          class="lucid-CheckboxLabeled-label"
+        >
+          Bax Tar
+        </div>
+      </label>
+    </figcaption>
+  </figure>
+</span>
 `;
 
 exports[`IconSelect [common] example testing should match snapshot(s) for DisabledIconSelect 1`] = `
@@ -405,241 +403,237 @@ exports[`IconSelect [common] example testing should match snapshot(s) for Partia
 `;
 
 exports[`IconSelect [common] example testing should match snapshot(s) for SelectMultipleIcons 1`] = `
-<section>
-  <span
-    class="lucid-IconSelect"
+<span
+  class="lucid-IconSelect"
+>
+  <figure
+    class="lucid-IconSelect-Item lucid-IconSelect-Item-multi"
+    data-id="item1"
   >
-    <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-multi"
-      data-id="item1"
+    <svg
+      class="lucid-Icon lucid-Icon-color-primary lucid-ClockIcon"
+      height="16"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox="0 0 16 16"
+      width="16"
     >
-      <svg
-        class="lucid-Icon lucid-Icon-color-primary lucid-ClockIcon"
-        height="16"
-        preserveAspectRatio="xMidYMid meet"
-        viewBox="0 0 16 16"
-        width="16"
-      >
-        <circle
-          cx="8"
-          cy="8"
-          r="7.5"
-        />
-        <path
-          d="M8 3.5v5l2.75 2.25"
-        />
-      </svg>
-      <figcaption
-        class="lucid-IconSelect-Item-figcaption"
-      >
-        <label
-          class="lucid-CheckboxLabeled lucid-IconSelect-Item-checkbox"
-        >
-          <div
-            class="lucid-Checkbox lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
-          >
-            <input
-              class="lucid-Checkbox-native"
-              type="checkbox"
-            />
-            <span
-              class="lucid-Checkbox-visualization-glow"
-            />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-          <div
-            class="lucid-CheckboxLabeled-label"
-          >
-            Foo Bar
-          </div>
-        </label>
-      </figcaption>
-    </figure>
-    <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-multi"
-      data-id="item2"
+      <circle
+        cx="8"
+        cy="8"
+        r="7.5"
+      />
+      <path
+        d="M8 3.5v5l2.75 2.25"
+      />
+    </svg>
+    <figcaption
+      class="lucid-IconSelect-Item-figcaption"
     >
-      <svg
-        class="lucid-Icon lucid-Icon-color-primary lucid-StopwatchIcon"
-        height="16"
-        preserveAspectRatio="xMidYMid meet"
-        viewBox="0 0 16 16"
-        width="16"
+      <label
+        class="lucid-CheckboxLabeled lucid-IconSelect-Item-checkbox"
       >
-        <path
-          d="M7.5.5h3M9 .5v1.98M.5 6h5m-5 3h3m-3 3h4"
-        />
-        <path
-          d="M5.5 14.471A6.455 6.455 0 0 0 9 15.5a6.5 6.5 0 1 0 0-13c-1.29 0-2.489.38-3.5 1.029"
-        />
-        <path
-          d="M9 9l2.5-2.5"
-        />
-      </svg>
-      <figcaption
-        class="lucid-IconSelect-Item-figcaption"
-      >
-        <label
-          class="lucid-CheckboxLabeled lucid-CheckboxLabeled-is-selected lucid-IconSelect-Item-checkbox"
+        <div
+          class="lucid-Checkbox lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
         >
-          <div
-            class="lucid-Checkbox lucid-Checkbox-is-selected lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
+          <input
+            class="lucid-Checkbox-native"
+            type="checkbox"
+          />
+          <span
+            class="lucid-Checkbox-visualization-glow"
+          />
+          <span
+            class="lucid-Checkbox-visualization-container"
+          />
+          <span
+            class="lucid-Checkbox-visualization-checkmark"
           >
-            <input
-              checked=""
-              class="lucid-Checkbox-native"
-              type="checkbox"
+            <span
+              class="lucid-Checkbox-visualization-checkmark-stem"
             />
             <span
-              class="lucid-Checkbox-visualization-glow"
+              class="lucid-Checkbox-visualization-checkmark-kick"
             />
-            <span
-              class="lucid-Checkbox-visualization-container"
-            />
-            <span
-              class="lucid-Checkbox-visualization-checkmark"
-            >
-              <span
-                class="lucid-Checkbox-visualization-checkmark-stem"
-              />
-              <span
-                class="lucid-Checkbox-visualization-checkmark-kick"
-              />
-            </span>
-          </div>
-          <div
-            class="lucid-CheckboxLabeled-label"
+          </span>
+        </div>
+        <div
+          class="lucid-CheckboxLabeled-label"
+        >
+          Foo Bar
+        </div>
+      </label>
+    </figcaption>
+  </figure>
+  <figure
+    class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-multi"
+    data-id="item2"
+  >
+    <svg
+      class="lucid-Icon lucid-Icon-color-primary lucid-StopwatchIcon"
+      height="16"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M7.5.5h3M9 .5v1.98M.5 6h5m-5 3h3m-3 3h4"
+      />
+      <path
+        d="M5.5 14.471A6.455 6.455 0 0 0 9 15.5a6.5 6.5 0 1 0 0-13c-1.29 0-2.489.38-3.5 1.029"
+      />
+      <path
+        d="M9 9l2.5-2.5"
+      />
+    </svg>
+    <figcaption
+      class="lucid-IconSelect-Item-figcaption"
+    >
+      <label
+        class="lucid-CheckboxLabeled lucid-CheckboxLabeled-is-selected lucid-IconSelect-Item-checkbox"
+      >
+        <div
+          class="lucid-Checkbox lucid-Checkbox-is-selected lucid-CheckboxLabeled-Checkbox lucid-IconSelect-Item-checkbox"
+        >
+          <input
+            checked=""
+            class="lucid-Checkbox-native"
+            type="checkbox"
+          />
+          <span
+            class="lucid-Checkbox-visualization-glow"
+          />
+          <span
+            class="lucid-Checkbox-visualization-container"
+          />
+          <span
+            class="lucid-Checkbox-visualization-checkmark"
           >
-            Bax Tar
-          </div>
-        </label>
-      </figcaption>
-    </figure>
-  </span>
-</section>
+            <span
+              class="lucid-Checkbox-visualization-checkmark-stem"
+            />
+            <span
+              class="lucid-Checkbox-visualization-checkmark-kick"
+            />
+          </span>
+        </div>
+        <div
+          class="lucid-CheckboxLabeled-label"
+        >
+          Bax Tar
+        </div>
+      </label>
+    </figcaption>
+  </figure>
+</span>
 `;
 
 exports[`IconSelect [common] example testing should match snapshot(s) for Single 1`] = `
-<section>
-  <span
-    class="lucid-IconSelect"
+<span
+  class="lucid-IconSelect"
+>
+  <figure
+    class="lucid-IconSelect-Item lucid-IconSelect-Item-single"
+    data-id="item1"
   >
-    <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-single"
-      data-id="item1"
+    <svg
+      class="lucid-Icon lucid-Icon-color-primary lucid-ClockIcon"
+      height="16"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox="0 0 16 16"
+      width="16"
     >
-      <svg
-        class="lucid-Icon lucid-Icon-color-primary lucid-ClockIcon"
-        height="16"
-        preserveAspectRatio="xMidYMid meet"
-        viewBox="0 0 16 16"
-        width="16"
-      >
-        <circle
-          cx="8"
-          cy="8"
-          r="7.5"
-        />
-        <path
-          d="M8 3.5v5l2.75 2.25"
-        />
-      </svg>
-      <figcaption
-        class="lucid-IconSelect-Item-figcaption"
-      >
-        <label
-          class="lucid-RadioButtonLabeled lucid-IconSelect-Item-radio"
-        >
-          <span
-            class="lucid-RadioButton lucid-IconSelect-Item-radio"
-          >
-            <input
-              class="lucid-RadioButton-native"
-              type="radio"
-            />
-            <span
-              class="lucid-RadioButton-visualization-glow"
-            />
-            <span
-              class="lucid-RadioButton-visualization-container"
-            />
-            <span
-              class="lucid-RadioButton-visualization-dot"
-            />
-          </span>
-          <div
-            class="lucid-RadioButtonLabeled-label"
-          >
-            Foo Bar
-          </div>
-        </label>
-      </figcaption>
-    </figure>
-    <figure
-      class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-single"
-      data-id="item2"
+      <circle
+        cx="8"
+        cy="8"
+        r="7.5"
+      />
+      <path
+        d="M8 3.5v5l2.75 2.25"
+      />
+    </svg>
+    <figcaption
+      class="lucid-IconSelect-Item-figcaption"
     >
-      <svg
-        class="lucid-Icon lucid-Icon-color-primary lucid-StopwatchIcon"
-        height="16"
-        preserveAspectRatio="xMidYMid meet"
-        viewBox="0 0 16 16"
-        width="16"
+      <label
+        class="lucid-RadioButtonLabeled lucid-IconSelect-Item-radio"
       >
-        <path
-          d="M7.5.5h3M9 .5v1.98M.5 6h5m-5 3h3m-3 3h4"
-        />
-        <path
-          d="M5.5 14.471A6.455 6.455 0 0 0 9 15.5a6.5 6.5 0 1 0 0-13c-1.29 0-2.489.38-3.5 1.029"
-        />
-        <path
-          d="M9 9l2.5-2.5"
-        />
-      </svg>
-      <figcaption
-        class="lucid-IconSelect-Item-figcaption"
-      >
-        <label
-          class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected lucid-IconSelect-Item-radio"
+        <span
+          class="lucid-RadioButton lucid-IconSelect-Item-radio"
         >
+          <input
+            class="lucid-RadioButton-native"
+            type="radio"
+          />
           <span
-            class="lucid-RadioButton lucid-RadioButton-is-selected lucid-IconSelect-Item-radio"
-          >
-            <input
-              checked=""
-              class="lucid-RadioButton-native"
-              type="radio"
-            />
-            <span
-              class="lucid-RadioButton-visualization-glow"
-            />
-            <span
-              class="lucid-RadioButton-visualization-container"
-            />
-            <span
-              class="lucid-RadioButton-visualization-dot"
-            />
-          </span>
-          <div
-            class="lucid-RadioButtonLabeled-label"
-          >
-            Bax Tar
-          </div>
-        </label>
-      </figcaption>
-    </figure>
-  </span>
-</section>
+            class="lucid-RadioButton-visualization-glow"
+          />
+          <span
+            class="lucid-RadioButton-visualization-container"
+          />
+          <span
+            class="lucid-RadioButton-visualization-dot"
+          />
+        </span>
+        <div
+          class="lucid-RadioButtonLabeled-label"
+        >
+          Foo Bar
+        </div>
+      </label>
+    </figcaption>
+  </figure>
+  <figure
+    class="lucid-IconSelect-Item lucid-IconSelect-Item-is-selected lucid-IconSelect-Item-single"
+    data-id="item2"
+  >
+    <svg
+      class="lucid-Icon lucid-Icon-color-primary lucid-StopwatchIcon"
+      height="16"
+      preserveAspectRatio="xMidYMid meet"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M7.5.5h3M9 .5v1.98M.5 6h5m-5 3h3m-3 3h4"
+      />
+      <path
+        d="M5.5 14.471A6.455 6.455 0 0 0 9 15.5a6.5 6.5 0 1 0 0-13c-1.29 0-2.489.38-3.5 1.029"
+      />
+      <path
+        d="M9 9l2.5-2.5"
+      />
+    </svg>
+    <figcaption
+      class="lucid-IconSelect-Item-figcaption"
+    >
+      <label
+        class="lucid-RadioButtonLabeled lucid-RadioButtonLabeled-is-selected lucid-IconSelect-Item-radio"
+      >
+        <span
+          class="lucid-RadioButton lucid-RadioButton-is-selected lucid-IconSelect-Item-radio"
+        >
+          <input
+            checked=""
+            class="lucid-RadioButton-native"
+            type="radio"
+          />
+          <span
+            class="lucid-RadioButton-visualization-glow"
+          />
+          <span
+            class="lucid-RadioButton-visualization-container"
+          />
+          <span
+            class="lucid-RadioButton-visualization-dot"
+          />
+        </span>
+        <div
+          class="lucid-RadioButtonLabeled-label"
+        >
+          Bax Tar
+        </div>
+      </label>
+    </figcaption>
+  </figure>
+</span>
 `;


### PR DESCRIPTION
## PR Checklist

Description of changes to IconSelect:
* Add unit test for pass through
* Tidy up SB story
* Replace omitProps with list of omitted props
* Update snapshot

Link(s) to Storybook on docspot:

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
<img width="1444" alt="Screen Shot 2022-05-18 at 12 24 56 PM" src="https://user-images.githubusercontent.com/19521671/169104530-b8909ade-4794-429f-a6f2-ad0ffb9bf41e.png">
