### PR TITLE
Cxp 3055 separator icon fix omit props

### DIFF
--- a/src/components/Icon/SeparatorIcon/SeparatorIcon.spec.tsx
+++ b/src/components/Icon/SeparatorIcon/SeparatorIcon.spec.tsx
@@ -1,8 +1,9 @@
-import { icons, common } from '../../../util/generic-tests';
+import { icons, common, passThroughs } from '../../../util/generic-tests';
 
 import SeparatorIcon from './SeparatorIcon';
 
 describe('SeparatorIcon', () => {
 	common(SeparatorIcon);
 	icons(SeparatorIcon);
+	passThroughs(SeparatorIcon);
 });

--- a/src/components/Icon/SeparatorIcon/SeparatorIcon.stories.tsx
+++ b/src/components/Icon/SeparatorIcon/SeparatorIcon.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import createClass from 'create-react-class';
-import SeparatorIcon from './SeparatorIcon';
+import { Story, Meta } from '@storybook/react';
+
+import SeparatorIcon, { ISeparatorIconProps } from './SeparatorIcon';
 
 export default {
 	title: 'Visual Design/SeparatorIcon',
@@ -12,15 +13,10 @@ export default {
 			},
 		},
 	},
-};
+	args: SeparatorIcon.defaultProps,
+} as Meta;
 
 /* Basic */
-export const Basic = () => {
-	const Component = createClass({
-		render() {
-			return <SeparatorIcon />;
-		},
-	});
-
-	return <Component />;
+export const BasicSeparatorIcon: Story<ISeparatorIconProps> = (args) => {
+	return <SeparatorIcon {...args} />;
 };

--- a/src/components/Icon/SeparatorIcon/SeparatorIcon.tsx
+++ b/src/components/Icon/SeparatorIcon/SeparatorIcon.tsx
@@ -1,8 +1,7 @@
-import _ from 'lodash';
+import _, { omit } from 'lodash';
 import React from 'react';
 import Icon, { IIconProps, propTypes as iconPropTypes } from '../Icon';
 import { lucidClassNames } from '../../../util/style-helpers';
-import { omitProps } from '../../../util/component-types';
 
 const cx = lucidClassNames.bind('&-SeparatorIcon');
 
@@ -14,13 +13,7 @@ export const SeparatorIcon = ({
 }: ISeparatorIconProps) => {
 	return (
 		<Icon
-			{...omitProps(
-				passThroughs,
-				undefined,
-				_.keys(SeparatorIcon.propTypes),
-				false
-			)}
-			{..._.pick(passThroughs, _.keys(iconPropTypes))}
+			{...omit(passThroughs, ['initialState'])}
 			className={cx('&', className)}
 		>
 			<path d='M5.2 0h1.5l4 8-4 8H5.2l4-8-4-8z' />

--- a/src/components/Icon/SeparatorIcon/__snapshots__/SeparatorIcon.spec.tsx.snap
+++ b/src/components/Icon/SeparatorIcon/__snapshots__/SeparatorIcon.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SeparatorIcon [common] example testing should match snapshot(s) for Basic 1`] = `
+exports[`SeparatorIcon [common] example testing should match snapshot(s) for BasicSeparatorIcon 1`] = `
 <svg
   class="lucid-Icon lucid-Icon-color-primary lucid-SeparatorIcon"
   height="16"

--- a/src/util/generic-tests.tsx
+++ b/src/util/generic-tests.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { mount, shallow, render } from 'enzyme';
 import assert from 'assert';
-import _, { each, omit, keys, includes } from 'lodash';
+import _, { each, omit, keys, includes, forEach } from 'lodash';
 import glob from 'glob';
 import { addons, mockChannel } from '@storybook/addons';
 import timekeeper from 'timekeeper';
@@ -249,6 +249,43 @@ export function icons(Component: any, config: IIconConfig = {} as any) {
 				wrapper.find('svg').hasClass(targetClassName),
 				`Missing '${targetClassName}' class`
 			);
+		});
+	});
+}
+
+export function passThroughs(Component: any, config: IIconConfig = {} as any) {
+	// The default expectation is for every Component to omit `initialState`,
+	// if it is passed through to the underlying element
+	const { includeInitialState = false } = config;
+
+	describe('pass throughs', () => {
+		it('should almost always omit the `initialState` key', () => {
+			const wrapper = shallow(<Component initialState={{ testState: true }} />);
+			const rootElementProps = keys(wrapper.first().props());
+
+			expect(includes(rootElementProps, 'initialState')).toBe(
+				includeInitialState
+			);
+		});
+		it('should pass through all props not defined in `propTypes` to the root element', () => {
+			const wrapper = shallow(
+				<Component
+					{...{
+						foo: 1,
+						bar: 2,
+						baz: 3,
+						qux: 4,
+						quux: 5,
+					}}
+				/>
+			);
+			const rootElementProps = keys(wrapper.first().props());
+
+			// It should pass `foo`, `bar`, `baz`, `qux`, and `quux`
+			// to the root element.
+			forEach(['foo', 'bar', 'baz', 'qux', 'quux'], (prop) => {
+				expect(includes(rootElementProps, prop)).toBe(true);
+			});
 		});
 	});
 }


### PR DESCRIPTION
## PR Checklist

Description of changes to SeparatorIcon:
* Add generic test for passThroughs
* Add unit test for passThroughs
* Convert story to functional story with type defs
* Replace omitProps and pick methods
* Update snapshot

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-3055-SeparatorIcon-fix-omitProps/?path=/docs/visual-design-separatoricon--basic-separator-icon
<img width="1467" alt="Screen Shot 2022-05-18 at 3 49 12 PM" src="https://user-images.githubusercontent.com/19521671/169153249-8e755ab6-d3b8-470c-9657-43c0a5c36292.png">

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
