### PR TITLE
Cxp 3054 draggable line chart fix prop types

### DIFF
--- a/src/components/Autocomplete/Autocomplete.spec.tsx
+++ b/src/components/Autocomplete/Autocomplete.spec.tsx
@@ -1,9 +1,10 @@
+import _ from 'lodash';
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import assert from 'assert';
 import sinon from 'sinon';
+
 import { findTypes } from '../../util/component-types';
-import _ from 'lodash';
 import { common } from '../../util/generic-tests';
 import { AutocompleteDumb as Autocomplete } from './Autocomplete';
 import { DropMenuDumb as DropMenu } from '../DropMenu/DropMenu';

--- a/src/components/DraggableLineChart/DraggableLineChart.spec.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.spec.tsx
@@ -1,6 +1,6 @@
 import _, { forEach, has, noop } from 'lodash';
-import React, { Component } from 'react';
-import { mount, shallow } from 'enzyme';
+import React from 'react';
+import { mount } from 'enzyme';
 import assert from 'assert';
 
 import { common } from '../../util/generic-tests';
@@ -10,7 +10,7 @@ import DraggableLineChart from './DraggableLineChart';
 describe('DraggableLineChart', () => {
 	common(DraggableLineChart);
 
-	let data = [
+	const data = [
 		{ x: new Date(), y: 1 },
 		{ x: new Date(), y: 2 },
 		{ x: new Date(), y: 3 },

--- a/src/components/DraggableLineChart/DraggableLineChart.spec.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.spec.tsx
@@ -1,10 +1,21 @@
-import React from 'react';
-import { mount } from 'enzyme';
+import _, { forEach, has, noop } from 'lodash';
+import React, { Component } from 'react';
+import { mount, shallow } from 'enzyme';
 import assert from 'assert';
+
+import { common } from '../../util/generic-tests';
 
 import DraggableLineChart from './DraggableLineChart';
 
 describe('DraggableLineChart', () => {
+	common(DraggableLineChart);
+
+	let data = [
+		{ x: new Date(), y: 1 },
+		{ x: new Date(), y: 2 },
+		{ x: new Date(), y: 3 },
+	] as any;
+
 	let wrapper: any;
 
 	afterEach(() => {
@@ -15,17 +26,7 @@ describe('DraggableLineChart', () => {
 
 	describe('render', () => {
 		it('should render an svg chart', () => {
-			wrapper = mount(
-				<DraggableLineChart
-					data={
-						[
-							{ x: new Date(), y: 1 },
-							{ x: new Date(), y: 2 },
-							{ x: new Date(), y: 3 },
-						] as any
-					}
-				/>
-			);
+			wrapper = mount(<DraggableLineChart data={data} />);
 
 			assert.equal(wrapper.find('svg').length, 1, 'did not render an svg');
 		});
@@ -43,6 +44,69 @@ describe('DraggableLineChart', () => {
 			wrapper.setProps({ data: data });
 
 			expect(wrapper.instance().d3LineChart.updateLineChart).toBeCalledTimes(1);
+		});
+	});
+	describe('pass throughs', () => {
+		const defaultProps = DraggableLineChart.defaultProps;
+		const props = {
+			...defaultProps,
+			data,
+			onDragEnd: noop,
+			onPreselect: noop,
+			xAxisTicksVertical: true,
+			dataIsCentered: true,
+			yAxisMin: 0,
+			preSelectText: 'test text',
+			yAxisFormatter: (value) => `string ${value}`,
+			className: 'wut',
+			style: { marginRight: 10 },
+			initialState: { test: true },
+			callbackId: 1,
+			'data-testid': 10,
+		};
+
+		it('passes through props not defined in `propTypes` to the root element.', () => {
+			wrapper = mount(<DraggableLineChart {...props} />);
+
+			const rootProps = wrapper.find('.lucid-DraggableLineChart').props();
+			expect(wrapper.first().prop(['className'])).toContain('wut');
+			expect(wrapper.first().prop(['style'])).toMatchObject({
+				marginRight: 10,
+			});
+			expect(wrapper.first().prop(['data-testid'])).toBe(10);
+
+			// 'className', 'width', 'height' and 'style' are plucked from the pass through object
+			// but still appears becuase each one is also directly added to the root element as a prop
+			forEach(
+				['className', 'data-testid', 'style', 'width', 'height'],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(true);
+				}
+			);
+		});
+		it('omits the props defined in `propTypes` (plus, in addition, `initialState`, and `callbackId`) from the root element', () => {
+			wrapper = mount(<DraggableLineChart {...props} />);
+
+			const rootProps = wrapper.find('.lucid-DraggableLineChart').props();
+			forEach(
+				[
+					'margin',
+					'data',
+					'onDragEnd',
+					'xAxisTicksVertical',
+					'dataIsCentered',
+					'yAxisMin',
+					'xAxisRenderProp',
+					'onPreselect',
+					'preSelectText',
+					'yAxisFormatter',
+					'initialState',
+					'callbackId',
+				],
+				(prop) => {
+					expect(has(rootProps, prop)).toBe(false);
+				}
+			);
 		});
 	});
 });

--- a/src/components/DraggableLineChart/DraggableLineChart.stories.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.stories.tsx
@@ -5,7 +5,9 @@ import { Meta, Story } from '@storybook/react';
 
 import { IXAxisRenderProp } from './d3-helpers';
 import { IData, ISelectedChartData } from './DraggableLineChartD3';
-import DraggableLineChart from './DraggableLineChart';
+import DraggableLineChart, {
+	IDraggableLineChartProps,
+} from './DraggableLineChart';
 import TextFieldValidated from '../TextFieldValidated/TextFieldValidated';
 
 export default {
@@ -18,9 +20,12 @@ export default {
 			},
 		},
 	},
+	args: DraggableLineChart.defaultProps,
 } as Meta;
 
-export const Basic: Story = () => {
+export const BasicDraggableLineChart: Story<IDraggableLineChartProps> = (
+	args
+) => {
 	const data = [
 		{ x: '12 AM', y: 0 },
 		{ x: '1 AM', y: 0 },
@@ -40,26 +45,23 @@ export const Basic: Story = () => {
 		paddingTop: '4rem',
 	};
 
-	const Component = createClass({
-		render() {
-			return (
-				<div style={style}>
-					<DraggableLineChart
-						onDragEnd={(x, y) => console.info({ x, y })}
-						data={data}
-						width={900}
-						xAxisTicksVertical={true}
-					/>
-				</div>
-			);
-		},
-	});
-
-	return <Component />;
+	return (
+		<div style={style}>
+			<DraggableLineChart
+				{...args}
+				onDragEnd={(x, y) => console.info({ x, y })}
+				data={data}
+				width={900}
+				xAxisTicksVertical={true}
+			/>
+		</div>
+	);
 };
 
 /* Example With External X Axis Render Prop */
-export const ExampleWithExternalXAxisRenderProp = () => {
+export const ExampleWithExternalXAxisRenderProp: Story<
+	IDraggableLineChartProps
+> = (args) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },
 		{ x: '1 AM', y: 1, ref: React.createRef() },
@@ -190,6 +192,7 @@ export const ExampleWithExternalXAxisRenderProp = () => {
 			return (
 				<div style={style}>
 					<DraggableLineChart
+						{...args}
 						data={customSpendDataPoints}
 						width={900}
 						dataIsCentered
@@ -203,11 +206,11 @@ export const ExampleWithExternalXAxisRenderProp = () => {
 
 	return <Component />;
 };
-ExampleWithExternalXAxisRenderProp.storyName =
-	'ExampleWithExternalXAxisRenderProp';
 
 /* Example With No Data With Preselect */
-export const ExampleWithNoDataWithPreselect = () => {
+export const ExampleWithNoDataWithPreselect: Story<IDraggableLineChartProps> = (
+	args
+) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },
 		{ x: '1 AM', y: 0, ref: React.createRef() },
@@ -364,10 +367,11 @@ export const ExampleWithNoDataWithPreselect = () => {
 
 	return <Component />;
 };
-ExampleWithNoDataWithPreselect.storyName = 'ExampleWithNoDataWithPreselect';
 
 /* Example With No Data Without Preselect */
-export const ExampleWithNoDataWithoutPreselect = () => {
+export const ExampleWithNoDataWithoutPreselect: Story<
+	IDraggableLineChartProps
+> = (args) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },
 		{ x: '1 AM', y: 0, ref: React.createRef() },
@@ -501,6 +505,7 @@ export const ExampleWithNoDataWithoutPreselect = () => {
 			return (
 				<div style={style}>
 					<DraggableLineChart
+						{...args}
 						data={customSpendDataPoints}
 						width={900}
 						dataIsCentered
@@ -515,11 +520,11 @@ export const ExampleWithNoDataWithoutPreselect = () => {
 
 	return <Component />;
 };
-ExampleWithNoDataWithoutPreselect.storyName =
-	'ExampleWithNoDataWithoutPreselect';
 
 /* Example With Y Axis Formatter */
-export const ExampleWithYAxisFormatter = () => {
+export const ExampleWithYAxisFormatter: Story<IDraggableLineChartProps> = (
+	args
+) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },
 		{ x: '1 AM', y: 1, ref: React.createRef() },
@@ -650,6 +655,7 @@ export const ExampleWithYAxisFormatter = () => {
 			return (
 				<div style={style}>
 					<DraggableLineChart
+						{...args}
 						data={customSpendDataPoints}
 						width={900}
 						dataIsCentered
@@ -664,4 +670,3 @@ export const ExampleWithYAxisFormatter = () => {
 
 	return <Component />;
 };
-ExampleWithYAxisFormatter.storyName = 'ExampleWithYAxisFormatter';

--- a/src/components/DraggableLineChart/DraggableLineChart.stories.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.stories.tsx
@@ -1,6 +1,6 @@
+import _ from 'lodash';
 import React, { useCallback } from 'react';
 import createClass from 'create-react-class';
-import _ from 'lodash';
 import { Meta, Story } from '@storybook/react';
 
 import { IXAxisRenderProp } from './d3-helpers';
@@ -24,7 +24,7 @@ export default {
 } as Meta;
 
 export const BasicDraggableLineChart: Story<IDraggableLineChartProps> = (
-	args
+	args: any
 ) => {
 	const data = [
 		{ x: '12 AM', y: 0 },
@@ -61,7 +61,7 @@ export const BasicDraggableLineChart: Story<IDraggableLineChartProps> = (
 /* Example With External X Axis Render Prop */
 export const ExampleWithExternalXAxisRenderProp: Story<
 	IDraggableLineChartProps
-> = (args) => {
+> = (args: any) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },
 		{ x: '1 AM', y: 1, ref: React.createRef() },
@@ -209,7 +209,7 @@ export const ExampleWithExternalXAxisRenderProp: Story<
 
 /* Example With No Data With Preselect */
 export const ExampleWithNoDataWithPreselect: Story<IDraggableLineChartProps> = (
-	args
+	args: any
 ) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },
@@ -352,6 +352,7 @@ export const ExampleWithNoDataWithPreselect: Story<IDraggableLineChartProps> = (
 			return (
 				<div style={style}>
 					<DraggableLineChart
+						{...args}
 						data={customSpendDataPoints}
 						width={900}
 						dataIsCentered
@@ -371,7 +372,7 @@ export const ExampleWithNoDataWithPreselect: Story<IDraggableLineChartProps> = (
 /* Example With No Data Without Preselect */
 export const ExampleWithNoDataWithoutPreselect: Story<
 	IDraggableLineChartProps
-> = (args) => {
+> = (args: any) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },
 		{ x: '1 AM', y: 0, ref: React.createRef() },
@@ -523,7 +524,7 @@ export const ExampleWithNoDataWithoutPreselect: Story<
 
 /* Example With Y Axis Formatter */
 export const ExampleWithYAxisFormatter: Story<IDraggableLineChartProps> = (
-	args
+	args: any
 ) => {
 	const initialCustomSpendDataPoints = [
 		{ x: '12 AM', y: 0, ref: React.createRef() },

--- a/src/components/DraggableLineChart/DraggableLineChart.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.tsx
@@ -1,3 +1,4 @@
+import _, { omit } from 'lodash';
 import * as d3Selection from 'd3-selection';
 import React from 'react';
 import { omitProps, Overwrite } from '../../util/component-types';
@@ -50,7 +51,8 @@ const nonPassThroughs = [
 	'xAxisRenderProp',
 	'onPreselect',
 	'preSelectText',
-];
+	'yAxisFormatter',
+].concat(['initialState', 'callbackId']);
 
 class DraggableLineChart extends React.Component<IDraggableLineChartProps, {}> {
 	ref: any;
@@ -113,13 +115,13 @@ class DraggableLineChart extends React.Component<IDraggableLineChartProps, {}> {
 	static defaultProps = draggableLineChartDefaultProps;
 
 	render(): React.ReactNode {
-		const { height, width, ...passThroughs } = this.props;
+		const { height, width, className, ...passThroughs } = this.props;
 
 		return (
 			<svg
-				{...omitProps(passThroughs, undefined, nonPassThroughs)}
+				{...(omit(passThroughs, nonPassThroughs) as any)}
 				ref={(ref: SVGSVGElement) => (this.ref = ref)}
-				className={cx('&')}
+				className={cx('&', className)}
 				width={width}
 				height={height}
 			/>

--- a/src/components/DraggableLineChart/__snapshots__/DraggableLineChart.spec.tsx.snap
+++ b/src/components/DraggableLineChart/__snapshots__/DraggableLineChart.spec.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DraggableLineChart [common] example testing should match snapshot(s) for BasicDraggableLineChart 1`] = `
+<div
+  style="padding-top:4rem"
+>
+  <svg
+    class="lucid-DraggableLineChart"
+    height="315"
+    width="900"
+  />
+</div>
+`;
+
+exports[`DraggableLineChart [common] example testing should match snapshot(s) for ExampleWithExternalXAxisRenderProp 1`] = `
+<div
+  style="padding-top:4rem"
+>
+  <svg
+    class="lucid-DraggableLineChart"
+    height="315"
+    width="900"
+  />
+</div>
+`;
+
+exports[`DraggableLineChart [common] example testing should match snapshot(s) for ExampleWithNoDataWithPreselect 1`] = `
+<div
+  style="padding-top:4rem"
+>
+  <svg
+    class="lucid-DraggableLineChart"
+    height="315"
+    width="900"
+  />
+</div>
+`;
+
+exports[`DraggableLineChart [common] example testing should match snapshot(s) for ExampleWithNoDataWithoutPreselect 1`] = `
+<div
+  style="padding-top:4rem"
+>
+  <svg
+    class="lucid-DraggableLineChart"
+    height="315"
+    width="900"
+  />
+</div>
+`;
+
+exports[`DraggableLineChart [common] example testing should match snapshot(s) for ExampleWithYAxisFormatter 1`] = `
+<div
+  style="padding-top:4rem"
+>
+  <svg
+    class="lucid-DraggableLineChart"
+    height="315"
+    width="900"
+  />
+</div>
+`;

--- a/src/components/DraggableLineChart/d3-helpers.ts
+++ b/src/components/DraggableLineChart/d3-helpers.ts
@@ -13,6 +13,7 @@ export type IXAxisRenderProp = ({
 	y: number;
 	ref?: any;
 }) => JSX.Element;
+
 export type ISelection = Selection<SVGElement | any, {} | any, null, undefined>;
 
 const getGroup = (selection: ISelection, className: string): ISelection => {


### PR DESCRIPTION
## PR Checklist

Description of changes:
* Add unit test for pass throughs
* Convert SB Story to SB6 with controls
* Explicitly omit props and add className prop
* Update snapshot
<img width="1317" alt="Screen Shot 2022-05-24 at 4 20 29 PM" src="https://user-images.githubusercontent.com/19521671/170134439-473fdfaa-b328-4bc3-885a-2ab049e13086.png">

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-3054-DraggableLineChart-fix-propTypes/?path=/docs/visualizations-draggablelinechart--basic-draggable-line-chart

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
