### PR TITLE
Cxp 3062 deprecate omitProps method

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -4,12 +4,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	findTypes,
-	filterTypes,
-	getFirst,
-	omitProps,
-} from '../../util/component-types';
+import { findTypes, filterTypes, getFirst } from '../../util/component-types';
 
 import Checkbox from '../Checkbox/Checkbox';
 import EmptyStateWrapper from '../EmptyStateWrapper/EmptyStateWrapper';

--- a/src/components/DateSelect/DateSelect.tsx
+++ b/src/components/DateSelect/DateSelect.tsx
@@ -6,7 +6,7 @@ import DayPicker from 'react-day-picker';
 
 import { buildModernHybridComponent } from '../../util/state-management';
 import { lucidClassNames } from '../../util/style-helpers';
-import { StandardProps, getFirst, omitProps } from '../../util/component-types';
+import { StandardProps, getFirst } from '../../util/component-types';
 import * as reducers from './DateSelect.reducers';
 import InfiniteSlidePanel from '../InfiniteSlidePanel/InfiniteSlidePanel';
 import { ISlidePanelProps } from '../SlidePanel/SlidePanel';

--- a/src/components/DraggableLineChart/DraggableLineChart.tsx
+++ b/src/components/DraggableLineChart/DraggableLineChart.tsx
@@ -1,7 +1,7 @@
 import _, { omit } from 'lodash';
 import * as d3Selection from 'd3-selection';
 import React from 'react';
-import { omitProps, Overwrite } from '../../util/component-types';
+import { Overwrite } from '../../util/component-types';
 import { lucidClassNames } from '../../util/style-helpers';
 import DraggableLineChartD3, {
 	IData,

--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -3,11 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	findTypes,
-	omitProps,
-	StandardProps,
-} from '../../util/component-types';
+import { findTypes, StandardProps } from '../../util/component-types';
 import { buildModernHybridComponent } from '../../util/state-management';
 import ChevronIcon from '../Icon/ChevronIcon/ChevronIcon';
 import Collapsible from '../Collapsible/Collapsible';

--- a/src/components/ExpanderPanel/ExpanderPanel.tsx
+++ b/src/components/ExpanderPanel/ExpanderPanel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import { getFirst, omitProps, StandardProps } from '../../util/component-types';
+import { getFirst, StandardProps } from '../../util/component-types';
 import { buildModernHybridComponent } from '../../util/state-management';
 import { IExpanderState } from '../Expander/Expander';
 import ChevronIcon from '../Icon/ChevronIcon/ChevronIcon';

--- a/src/components/InfiniteSlidePanel/InfiniteSlidePanel.tsx
+++ b/src/components/InfiniteSlidePanel/InfiniteSlidePanel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import { Overwrite, getFirst, omitProps } from '../../util/component-types';
+import { Overwrite, getFirst } from '../../util/component-types';
 import SlidePanel, {
 	ISlidePanelProps,
 	ISlidePanelSlideProps,

--- a/src/components/PieChart/PieChart.tsx
+++ b/src/components/PieChart/PieChart.tsx
@@ -3,11 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { lucidClassNames } from '../../util/style-helpers';
-import {
-	omitProps,
-	StandardProps,
-	Overwrite,
-} from '../../util/component-types';
+import { StandardProps, Overwrite } from '../../util/component-types';
 import * as d3Shape from 'd3-shape';
 import * as chartConstants from '../../constants/charts';
 import { buildModernHybridComponent } from '../../util/state-management';

--- a/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/src/components/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -10,6 +10,7 @@ import {
 	getFirst,
 	findTypes,
 	rejectTypes,
+	addSpecialOmittedProps,
 } from '../../util/component-types';
 import {
 	SearchFieldDumb as SearchField,
@@ -143,7 +144,7 @@ Option.defaultProps = DropMenu.Option.defaultProps;
 
 /** SearchableMultiSelect */
 /** TODO: Remove these prop constants when the component is converted to a functional component */
-const propTypes = [
+const props = [
 	'children',
 	'className',
 	'isDisabled',
@@ -169,7 +170,7 @@ const propTypes = [
 	'SearchField',
 	'Label',
 ];
-const nonPassThroughs = propTypes.concat(['initialState', 'callbackId']);
+const nonPassThroughs = addSpecialOmittedProps(props, true);
 
 export type Size = 'large' | 'medium' | 'small';
 

--- a/src/components/VerticalListMenu/VerticalListMenu.tsx
+++ b/src/components/VerticalListMenu/VerticalListMenu.tsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { lucidClassNames } from '../../util/style-helpers';
 import {
 	findTypes,
-	omitProps,
 	StandardProps,
 	Overwrite,
 } from '../../util/component-types';

--- a/src/util/component-types.spec.tsx
+++ b/src/util/component-types.spec.tsx
@@ -1,7 +1,6 @@
 import assert from 'assert';
-import _ from 'lodash';
+import _, { forEach } from 'lodash';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { shallow } from 'enzyme';
 
 import {
@@ -10,7 +9,7 @@ import {
 	rejectTypes,
 	createElements,
 	findTypes,
-	omitProps,
+	addSpecialOmittedProps,
 } from './component-types';
 
 function isReactComponentClass(componentClass: unknown) {
@@ -467,86 +466,23 @@ describe('component-types', () => {
 		});
 	});
 
-	describe('omitProps', () => {
-		const Button = createClass({
-			propTypes: {
-				className: PropTypes.any,
-				isActive: PropTypes.any,
-				isDisabled: PropTypes.any,
-				kind: PropTypes.any,
-				size: PropTypes.any,
-			},
+	describe('addSpecialOmittedProps', () => {
+		const props = ['children', 'className', 'isDisabled', 'isLoading'];
+
+		it('should add `callbackId` from props by default', () => {
+			const nonPassThroughs = addSpecialOmittedProps(props);
+
+			forEach(['initialState', 'callbackId'], (prop) => {
+				expect(nonPassThroughs.includes(prop)).toBe(true);
+			});
 		});
 
-		it('should omit props which are defined in propTypes', () => {
-			const props = omitProps(
-				{
-					className: 'test-button',
-					text: 'Click Me',
-					isActive: true,
-					isPrimary: true,
-					size: 'normal',
-				} as any,
-				Button
-			);
+		it('should not add `callbackId` when targetIsDOMElement is false', () => {
+			const nonPassThroughs = addSpecialOmittedProps(props, false);
 
-			assert.deepEqual(
-				props,
-				{
-					text: 'Click Me',
-					isPrimary: true,
-				},
-				'must omit props defined in propTypes'
-			);
-		});
-
-		it('should omit `callbackId` from props by default', () => {
-			const props = omitProps(
-				{
-					className: 'test-button',
-					text: 'Click Me',
-					isActive: true,
-					isPrimary: true,
-					size: 'normal',
-					callbackId: 'cant find me',
-				} as any,
-				Button
-			);
-
-			assert.deepEqual(
-				props,
-				{
-					text: 'Click Me',
-					isPrimary: true,
-				},
-				'must omit props defined in propTypes'
-			);
-		});
-
-		it('should not omit `callbackId` from props when specified', () => {
-			const props = omitProps(
-				{
-					className: 'test-button',
-					text: 'Click Me',
-					isActive: true,
-					isPrimary: true,
-					size: 'normal',
-					callbackId: 'can find me',
-				} as any,
-				Button,
-				[],
-				false
-			);
-
-			assert.deepEqual(
-				props,
-				{
-					text: 'Click Me',
-					isPrimary: true,
-					callbackId: 'can find me',
-				},
-				'must omit props defined in propTypes'
-			);
+			forEach(['callbackId'], (prop) => {
+				expect(nonPassThroughs.includes(prop)).toBe(false);
+			});
 		});
 	});
 });

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -293,6 +293,36 @@ export function getFirst<P>(
 	return _.first(findTypes<P>(props, types)) || defaultValue;
 }
 
+/**
+ *  Adds any speicial omitted props to an array
+ * @param {string[]} componentProps - an array of the component's props
+ * @param {boolean} targetIsDOMElement - true by default; specifies if the top-level element of the component is a plain DOM Element or a React Component Element
+ * @return {string[]} the array of component props plus the additional omitted keys
+ * */
+
+export function addSpecialOmittedProps<P>(
+	componentProps: string[] = [],
+	targetIsDOMElement: boolean = true
+): { [key: string]: any } {
+	// We only want to exclude the `callbackId` key when we're omitting props
+	// destined for a DOM element.
+	// We always want to add the `initialState` key
+	// to the list of excluded props.
+	const additionalOmittedKeys = targetIsDOMElement
+		? ['initialState', 'callbackId']
+		: ['initialState'];
+
+	return componentProps.concat(additionalOmittedKeys);
+}
+
+/**
+ * Deprecated May 25, 2022 by Noah Yasskin
+ * We removed this method because
+ * the import PropTypes from 'prop-types' stopped working as desired
+ * component.propTypes was not compiling correctly
+ * and props in the passThroughs object were leaking through
+ * because they were not being omitted.
+ */
 // Omit props defined in propTypes of the given type and any extra keys given
 // in third argument
 //
@@ -304,26 +334,26 @@ export function getFirst<P>(
 //
 // Note: The Partial<P> type is referring to the props passed into the omitProps,
 // not the props defined on the component.
-export function omitProps<P extends object>(
-	props: Partial<P>,
-	component: ICreateClassComponentClass<P> | undefined,
-	keys: string[] = [],
-	targetIsDOMElement = true
-): { [key: string]: any } {
-	// We only want to exclude the `callbackId` key when we're omitting props
-	// destined for a dom element.
-	// We always want to exclude the `initialState` key.
-	const additionalOmittedKeys = targetIsDOMElement
-		? ['initialState', 'callbackId']
-		: ['initialState'];
+// export function omitProps<P extends object>(
+// 	props: Partial<P>,
+// 	component: ICreateClassComponentClass<P> | undefined,
+// 	keys: string[] = [],
+// 	targetIsDOMElement: boolean = true
+// ): { [key: string]: any } {
+// 	// We only want to exclude the `callbackId` key when we're omitting props
+// 	// destined for a DOM element.
+// 	// We always want to exclude the `initialState` key.
+// 	const additionalOmittedKeys = targetIsDOMElement
+// 		? ['initialState', 'callbackId']
+// 		: ['initialState'];
 
-	// this is to support non-createClass components that we've converted to TypeScript
-	if (component === undefined) {
-		return _.omit(props, keys.concat(additionalOmittedKeys));
-	}
+// 	// this is to support non-createClass components that we've converted to TypeScript
+// 	if (component === undefined) {
+// 		return _.omit(props, keys.concat(additionalOmittedKeys));
+// 	}
 
-	return _.omit(
-		props,
-		_.keys(component.propTypes).concat(keys).concat(additionalOmittedKeys)
-	);
-}
+// 	return _.omit(
+// 		props,
+// 		_.keys(component.propTypes).concat(keys).concat(additionalOmittedKeys)
+// 	);
+// }


### PR DESCRIPTION
## PR Checklist

Description of changes:
* Remove omitProps method orphans
* addSpecialOmittedProps to SearchableMultiSelect
* Unit test for addSpecialOmittedProps
* Deprecate omitProps, add addSpecialOmittedProps
* Remove omitProps from DateSelect

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-3062-Deprecate-omitProps-method/

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
