### PR TITLE
Update the settings icon to reflect what we use in XDS.

### DIFF
--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -79,7 +79,7 @@ export const WithIconHeader: Story<IPanelProps> = (args) => {
 	return (
 		<Panel {...args}>
 			<Panel.Header>
-				<SettingsIcon style={{ marginRight: '16px' }} />
+				<SettingsIcon size={32} style={{ marginRight: '15px' }} />
 				<span>Header</span>
 			</Panel.Header>
 			Meditation literally chia, schlitz banh mi mlkshk vape ennui art party.

--- a/src/components/Panel/__snapshots__/Panel.spec.tsx.snap
+++ b/src/components/Panel/__snapshots__/Panel.spec.tsx.snap
@@ -595,11 +595,11 @@ exports[`Panel [common] example testing should match snapshot(s) for WithIconHea
   >
     <svg
       class="lucid-Icon lucid-Icon-color-primary lucid-SettingsIcon"
-      height="16"
+      height="32"
       preserveAspectRatio="xMidYMid meet"
-      style="margin-right:16px"
+      style="margin-right:15px"
       viewBox="0 0 16 16"
-      width="16"
+      width="32"
     >
       <path
         d="M2.254 13.052l1.733-.999A5.702 5.702 0 0 0 6.5 13.501V15.5h3v-1.999a5.708 5.708 0 0 0 2.513-1.451l1.733.999 1.5-2.599-1.733-.998c.25-.951.25-1.951 0-2.902l1.732-1.001-1.499-2.599-1.733 1A5.707 5.707 0 0 0 9.5 2.502V.5h-3v2.002a5.696 5.696 0 0 0-2.513 1.45l-1.726-1L.76 5.553l1.727.997a5.708 5.708 0 0 0 0 2.902L.755 10.453l1.499 2.599z"


### PR DESCRIPTION
It should be 32px and have a margin of 15px on the right.

Link(s) to Storybook on docspot: https://docspot.adnxs.net/projects/lucid/CXP-3064-update-panel-icon-size

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [x] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [x] Unit tests written (`common` at minimum)
- [x] PR has one of the `semver-` labels
