### PR TITLE
Uncomment the omitProps method so other libraries can use it

### DIFF
--- a/src/styles/master.less
+++ b/src/styles/master.less
@@ -21,10 +21,10 @@ body {
 	color: @color-neutral-9;
 
 	// repeating triangle Xandr pattern
-	// background: url('https://acdn.adnxs.com/cxp/1y/bg-pattern.226a6795ab64d5cdd0bdd4a853719227.svg'),
-	// 	@color-neutral-2;
-	// background-position: top right;
-	// background-repeat: repeat-y;
+	background: url('https://acdn.adnxs.com/cxp/1y/bg-pattern.226a6795ab64d5cdd0bdd4a853719227.svg'),
+		@color-neutral-2;
+	background-position: top right;
+	background-repeat: repeat-y;
 }
 
 h1,

--- a/src/util/component-types.ts
+++ b/src/util/component-types.ts
@@ -316,12 +316,12 @@ export function addSpecialOmittedProps<P>(
 }
 
 /**
- * Deprecated May 25, 2022 by Noah Yasskin
- * We removed this method because
+ * Deprecated from lucid-ui  May 25, 2022 by Noah Yasskin
+ * Do not use this method because
  * the import PropTypes from 'prop-types' stopped working as desired
- * component.propTypes was not compiling correctly
- * and props in the passThroughs object were leaking through
- * because they were not being omitted.
+ * component.propTypes does not compile correctly
+ * and props in the passThroughs object leak through
+ * because they are not being omitted.
  */
 // Omit props defined in propTypes of the given type and any extra keys given
 // in third argument
@@ -334,26 +334,26 @@ export function addSpecialOmittedProps<P>(
 //
 // Note: The Partial<P> type is referring to the props passed into the omitProps,
 // not the props defined on the component.
-// export function omitProps<P extends object>(
-// 	props: Partial<P>,
-// 	component: ICreateClassComponentClass<P> | undefined,
-// 	keys: string[] = [],
-// 	targetIsDOMElement: boolean = true
-// ): { [key: string]: any } {
-// 	// We only want to exclude the `callbackId` key when we're omitting props
-// 	// destined for a DOM element.
-// 	// We always want to exclude the `initialState` key.
-// 	const additionalOmittedKeys = targetIsDOMElement
-// 		? ['initialState', 'callbackId']
-// 		: ['initialState'];
+export function omitProps<P extends object>(
+	props: Partial<P>,
+	component: ICreateClassComponentClass<P> | undefined,
+	keys: string[] = [],
+	targetIsDOMElement: boolean = true
+): { [key: string]: any } {
+	// We only want to exclude the `callbackId` key when we're omitting props
+	// destined for a DOM element.
+	// We always want to exclude the `initialState` key.
+	const additionalOmittedKeys = targetIsDOMElement
+		? ['initialState', 'callbackId']
+		: ['initialState'];
 
-// 	// this is to support non-createClass components that we've converted to TypeScript
-// 	if (component === undefined) {
-// 		return _.omit(props, keys.concat(additionalOmittedKeys));
-// 	}
+	// this is to support non-createClass components that we've converted to TypeScript
+	if (component === undefined) {
+		return _.omit(props, keys.concat(additionalOmittedKeys));
+	}
 
-// 	return _.omit(
-// 		props,
-// 		_.keys(component.propTypes).concat(keys).concat(additionalOmittedKeys)
-// 	);
-// }
+	return _.omit(
+		props,
+		_.keys(component.propTypes).concat(keys).concat(additionalOmittedKeys)
+	);
+}


### PR DESCRIPTION
## PR Checklist

Description of changes:
Uncomment the omitProps so other libraries can use it.
Uncomment the xandr kite asset cdn so UIs can ut it.

Link(s) to Storybook on docspot:
https://docspot.adnxs.net/projects/lucid/CXP-3128-Update-lucid/?path=/docs/documentation-intro--page

- Manually tested across supported browsers

  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari

- [ ] Two cxp team engineer approvals
- [ ] One product design approval (as necessary)
- [ ] Unit tests written (`common` at minimum)
- [ ] PR has one of the `semver-` labels
